### PR TITLE
Spark dependency resolution based on version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,6 +40,21 @@ object Dependencies {
     sparkVersion = System.getProperties.getProperty(SPARK_VERSION)
   }
 
+  val sparkExclusion = if (sparkVersion >= "1.5.0") {
+    "org.apache.spark" % "spark-core_2.10" % sparkVersion excludeAll(
+      ExclusionRule(organization = "com.typesafe.akka"),
+      ExclusionRule(organization = "org.apache.avro"),
+      ExclusionRule(organization = "org.apache.hadoop"),
+      ExclusionRule(organization = "net.razorvine")
+    )
+  } else {
+    "org.apache.spark" % "spark-core_2.10" % sparkVersion excludeAll(
+      ExclusionRule(organization = "org.apache.avro"),
+      ExclusionRule(organization = "org.apache.hadoop"),
+      ExclusionRule(organization = "net.razorvine")
+    )
+  }
+
   // Dependency coordinates
   var requiredDep = Seq(
     "com.google.code.gson" % "gson" % gsonVersion,
@@ -50,16 +65,10 @@ object Dependencies {
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "compileonly",
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Test,
     "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion % "compileonly",
-    // TODO: Cleanup Spark dependencies
-    "org.apache.spark" % "spark-core_2.10" % sparkVersion excludeAll(
-            ExclusionRule(organization = "org.apache.avro"),
-            ExclusionRule(organization = "org.apache.hadoop"),
-            ExclusionRule(organization = "net.razorvine")
-            ),
     "org.codehaus.jackson" % "jackson-mapper-asl" % jacksonMapperAslVersion,
     "org.jsoup" % "jsoup" % jsoupVersion,
     "org.mockito" % "mockito-core" % "1.10.19"
-  )
+  ) :+ sparkExclusion 
 
   var dependencies = Seq(javaJdbc, javaEbean, cache)
   dependencies ++= requiredDep


### PR DESCRIPTION
This commit fixes #22 .

Spark 1.5.0 > has version `2.3.4-spark` for com.typesafe.akka packages (http://mvnrepository.com/artifact/org.apache.spark/spark-core_2.10/1.4.0). This is what the default config is.
If you have 1.5.0 < , version `2.3.11` (http://mvnrepository.com/artifact/org.apache.spark/spark-core_2.10/1.5.0) has a conflict with other akka dependencies required for dr. elephant. You need to exclude those packages. 