### PR TITLE
Adding code coverage to Dr. Elephant

### DIFF
--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -135,7 +135,7 @@ public final class Utils {
       } else {
         // Evaluate the limits
         parsedLimits = new double[thresholdLevels];
-        ScriptEngineManager mgr = new ScriptEngineManager();
+        ScriptEngineManager mgr = new ScriptEngineManager(null);
         ScriptEngine engine = mgr.getEngineByName("JavaScript");
         for (int i = 0; i < thresholdLevels; i++) {
           try {

--- a/jacoco.sbt
+++ b/jacoco.sbt
@@ -1,0 +1,28 @@
+//
+// Copyright 2016 LinkedIn Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+
+import de.johoop.jacoco4sbt.JacocoPlugin._
+import de.johoop.jacoco4sbt._
+
+jacoco.settings
+
+parallelExecution      in jacoco.Config := false
+
+jacoco.outputDirectory in jacoco.Config := file("target/jacoco")
+
+jacoco.reportFormats   in jacoco.Config := Seq(HTMLReport("utf-8"))
+
+jacoco.excludes        in jacoco.Config := Seq("views*", "*Routes*", "controllers*routes*", "controllers*Reverse*", "controllers*javascript*", "controller*ref*")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,6 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.2.2"))
+
+// Jacoco code coverage plugin
+addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")


### PR DESCRIPTION
…il.UtilsTest.testGetParam() is run

with code coverage. Turns out to be an sbt issue as noted here.
http://stackoverflow.com/questions/20168226/sbt-0-13-scriptengine-is-null-for-getenginebyname-javascript

Note:
1. All tests passed post this fix with and without code coverage
2. Application started without any issues