### PR TITLE
LIHADOOP-19609: Make Spark Event Log Directory configurable

### DIFF
--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -20,4 +20,4 @@ db_password=""
 
 # Additional Configuration
 # Check https://www.playframework.com/documentation/2.2.x/ProductionConfiguration
-#jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
+jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true"

--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -20,4 +20,4 @@ db_password=""
 
 # Additional Configuration
 # Check https://www.playframework.com/documentation/2.2.x/ProductionConfiguration
-jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
+#jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,6 +67,7 @@ object Dependencies {
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "compileonly",
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Test,
     "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion % "compileonly",
+    "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion % Test,
     "org.codehaus.jackson" % "jackson-mapper-asl" % jacksonMapperAslVersion,
     "org.jsoup" % "jsoup" % jsoupVersion,
     "org.mockito" % "mockito-core" % "1.10.19"

--- a/test/com/linkedin/drelephant/configurations/fetcher/FetcherConfigurationTest.java
+++ b/test/com/linkedin/drelephant/configurations/fetcher/FetcherConfigurationTest.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
+
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,9 +42,9 @@ public class FetcherConfigurationTest {
 
   private static final String spark = "SPARK";
   private static final String logDirField = "event_log_dir";
-  private static final String logDirValue = "/system/spark-history";
+  private static final String logDirValue = "/custom/configured";
   private static final String logSizeField = "event_log_size_limit_in_mb";
-  private static final String logSizeValue = "100";
+  private static final String logSizeValue = "50";
 
 
   @BeforeClass
@@ -113,7 +115,7 @@ public class FetcherConfigurationTest {
   public void testParseFetcherConf4() {
     expectedEx.expect(RuntimeException.class);
     expectedEx.expectMessage("No tag or invalid tag 'applicationtype' in fetcher 1"
-        + " classname com.linkedin.drelephant.mapreduce.MapReduceFetcherHadoop2");
+            + " classname com.linkedin.drelephant.mapreduce.MapReduceFetcherHadoop2");
     FetcherConfiguration fetcherConf = new FetcherConfiguration(document4.getDocumentElement());
   }
 
@@ -129,5 +131,6 @@ public class FetcherConfigurationTest {
     assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getParamMap().get(logSizeField), logSizeValue);
     assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getParamMap().get(logDirField), logDirValue);
   }
+
 }
 

--- a/test/com/linkedin/drelephant/configurations/fetcher/FetcherConfigurationTest.java
+++ b/test/com/linkedin/drelephant/configurations/fetcher/FetcherConfigurationTest.java
@@ -36,6 +36,14 @@ public class FetcherConfigurationTest {
   private static Document document2 = null;
   private static Document document3 = null;
   private static Document document4 = null;
+  private static Document document5 = null;
+
+  private static final String spark = "SPARK";
+  private static final String logDirField = "event_log_dir";
+  private static final String logDirValue = "/system/spark-history";
+  private static final String logSizeField = "event_log_size_limit_in_mb";
+  private static final String logSizeValue = "100";
+
 
   @BeforeClass
   public static void runBeforeClass() {
@@ -54,6 +62,9 @@ public class FetcherConfigurationTest {
       document4 = builder.parse(
           FetcherConfigurationTest.class.getClassLoader().getResourceAsStream(
               "configurations/fetcher/FetcherConfTest4.xml"));
+      document5 = builder.parse(
+              FetcherConfigurationTest.class.getClassLoader().getResourceAsStream(
+                      "configurations/fetcher/FetcherConfTest5.xml"));
     } catch (ParserConfigurationException e) {
       throw new RuntimeException("XML Parser could not be created.", e);
     } catch (SAXException e) {
@@ -104,6 +115,19 @@ public class FetcherConfigurationTest {
     expectedEx.expectMessage("No tag or invalid tag 'applicationtype' in fetcher 1"
         + " classname com.linkedin.drelephant.mapreduce.MapReduceFetcherHadoop2");
     FetcherConfiguration fetcherConf = new FetcherConfiguration(document4.getDocumentElement());
+  }
+
+  /**
+   *  Test Spark fetcher params, Event log size and log directory
+   */
+  @Test
+  public void testParseFetcherConf5() {
+    FetcherConfiguration fetcherConf = new FetcherConfiguration(document5.getDocumentElement());
+    assertEquals(fetcherConf.getFetchersConfigurationData().size(), 1);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getAppType().getName(), spark);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getParamMap().size(), 3);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getParamMap().get(logSizeField), logSizeValue);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getParamMap().get(logDirField), logDirValue);
   }
 }
 

--- a/test/org/apache/spark/deploy/history/SparkFsFetcherTest.java
+++ b/test/org/apache/spark/deploy/history/SparkFsFetcherTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.spark.deploy.history;
+
+import com.linkedin.drelephant.analysis.ElephantFetcher;
+import com.linkedin.drelephant.configurations.fetcher.FetcherConfiguration;
+import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SparkFsFetcherTest {
+
+  private static Document document1 = null;
+  private static Document document2 = null;
+  private static Document document3 = null;
+
+  private static final String spark = "SPARK";
+  private static final String defEventLogDir = "/system/spark-history";
+  private static final String confEventLogDir = "/custom/configured";
+  private static final double defEventLogSize = 100;
+  private static final double confEventLogSize = 50;
+
+  @BeforeClass
+  public static void runBeforeClass() {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      document1 = builder.parse(
+              SparkFsFetcherTest.class.getClassLoader().getResourceAsStream(
+                      "configurations/fetcher/FetcherConfTest5.xml"));
+      document2 = builder.parse(
+              SparkFsFetcherTest.class.getClassLoader().getResourceAsStream(
+                      "configurations/fetcher/FetcherConfTest6.xml"));
+      document3 = builder.parse(
+              SparkFsFetcherTest.class.getClassLoader().getResourceAsStream(
+                      "configurations/fetcher/FetcherConfTest7.xml"));
+    } catch (ParserConfigurationException e) {
+      throw new RuntimeException("XML Parser could not be created.", e);
+    } catch (SAXException e) {
+      throw new RuntimeException("Test files are not properly formed", e);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to read test files ", e);
+    }
+  }
+
+  /**
+   * Test for verifying the configured event log directory and log size
+   *
+   * <params>
+   *   <event_log_size_limit_in_mb>50</event_log_size_limit_in_mb>
+   *   <event_log_dir>/custom/configured</event_log_dir>
+   * </params>
+   */
+  @Test
+  public void testSparkFetcherConfig() {
+    FetcherConfiguration fetcherConf = new FetcherConfiguration(document1.getDocumentElement());
+    assertEquals(fetcherConf.getFetchersConfigurationData().size(), 1);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getAppType().getName(), spark);
+
+    Class<?> fetcherClass = null;
+    FetcherConfigurationData data = fetcherConf.getFetchersConfigurationData().get(0);
+    try {
+      fetcherClass = SparkFsFetcherTest.class.getClassLoader().loadClass(data.getClassName());
+      Object sparkFetcherInstance = fetcherClass.getConstructor(FetcherConfigurationData.class).newInstance(data);
+      if (!(sparkFetcherInstance instanceof ElephantFetcher)) {
+        throw new IllegalArgumentException(
+                "Class " + fetcherClass.getName() + " is not an implementation of " + ElephantFetcher.class.getName());
+      }
+
+      // Check if the configurations are picked up correctly
+      assertEquals(confEventLogSize, ((SparkFSFetcher) sparkFetcherInstance).getEventLogSize(), 0);
+      assertEquals(confEventLogDir, ((SparkFSFetcher) sparkFetcherInstance).getEventLogDir());
+
+    } catch (InstantiationException e) {
+      throw new RuntimeException("Could not instantiate class " + data.getClassName(), e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Could not find class " + data.getClassName(), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Could not access constructor for class" + data.getClassName(), e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException("Could not invoke class " + data.getClassName(), e);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Could not find constructor for class " + data.getClassName(), e);
+    }
+  }
+
+  /**
+   * Test for verifying unspecified log directory and log size configs
+   *
+   * <params>
+   * </params>
+   */
+  @Test
+  public void testSparkFetcherUnspecifiedConfig() {
+    FetcherConfiguration fetcherConf = new FetcherConfiguration(document3.getDocumentElement());
+    assertEquals(fetcherConf.getFetchersConfigurationData().size(), 1);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getAppType().getName(), spark);
+
+    Class<?> fetcherClass = null;
+    FetcherConfigurationData data = fetcherConf.getFetchersConfigurationData().get(0);
+    try {
+      fetcherClass = SparkFsFetcherTest.class.getClassLoader().loadClass(data.getClassName());
+      Object sparkFetcherInstance = fetcherClass.getConstructor(FetcherConfigurationData.class).newInstance(data);
+      if (!(sparkFetcherInstance instanceof ElephantFetcher)) {
+        throw new IllegalArgumentException(
+                "Class " + fetcherClass.getName() + " is not an implementation of " + ElephantFetcher.class.getName());
+      }
+
+      // Check if the default values are used
+      assertEquals(defEventLogSize, ((SparkFSFetcher) sparkFetcherInstance).getEventLogSize(), 0);
+      assertEquals(defEventLogDir, ((SparkFSFetcher) sparkFetcherInstance).getEventLogDir());
+
+    } catch (InstantiationException e) {
+      throw new RuntimeException("Could not instantiate class " + data.getClassName(), e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Could not find class " + data.getClassName(), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Could not access constructor for class" + data.getClassName(), e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException("Could not invoke class " + data.getClassName(), e);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Could not find constructor for class " + data.getClassName(), e);
+    }
+  }
+
+  /**
+   * Test for verifying empty log directory and log size configs
+   *
+   * <params>
+   *   <event_log_size_limit_in_mb></event_log_size_limit_in_mb>
+   *   <event_log_dir>/system/spark-history</event_log_dir>
+   * </params>
+   */
+  @Test
+  public void testSparkFetcherEmptyConfig() {
+    FetcherConfiguration fetcherConf = new FetcherConfiguration(document2.getDocumentElement());
+    assertEquals(fetcherConf.getFetchersConfigurationData().size(), 1);
+    assertEquals(fetcherConf.getFetchersConfigurationData().get(0).getAppType().getName(), spark);
+
+    Class<?> fetcherClass = null;
+    FetcherConfigurationData data = fetcherConf.getFetchersConfigurationData().get(0);
+    try {
+      fetcherClass = SparkFsFetcherTest.class.getClassLoader().loadClass(data.getClassName());
+      Object sparkFetcherInstance = fetcherClass.getConstructor(FetcherConfigurationData.class).newInstance(data);
+      if (!(sparkFetcherInstance instanceof ElephantFetcher)) {
+        throw new IllegalArgumentException(
+                "Class " + fetcherClass.getName() + " is not an implementation of " + ElephantFetcher.class.getName());
+      }
+
+      // Check if the default values are used
+      assertEquals(defEventLogSize, ((SparkFSFetcher) sparkFetcherInstance).getEventLogSize(), 0);
+      assertEquals(defEventLogDir, ((SparkFSFetcher) sparkFetcherInstance).getEventLogDir());
+
+    } catch (InstantiationException e) {
+      throw new RuntimeException("Could not instantiate class " + data.getClassName(), e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Could not find class " + data.getClassName(), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Could not access constructor for class" + data.getClassName(), e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException("Could not invoke class " + data.getClassName(), e);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Could not find constructor for class " + data.getClassName(), e);
+    }
+  }
+}

--- a/test/resources/configurations/fetcher/FetcherConfTest5.xml
+++ b/test/resources/configurations/fetcher/FetcherConfTest5.xml
@@ -15,32 +15,13 @@
   the License.
 -->
 
-<!-- Data fetchers configurations
-  A Fetcher implements ElephantFetcher interface and help fetch a certain application type data.
-
-  Example:
-  <fetcher>
-    # Choose the application type that this fetcher is for
-    <applicationtype>mapreduce</applicationtype>
-
-
-    # Specify the implementation class
-    <classname>com.linkedin.drelephant.mapreduce.MapReduceFetcherHadoop2</classname>
-  </fetcher>
--->
 <fetchers>
-  <fetcher>
-    <applicationtype>mapreduce</applicationtype>
-    <classname>com.linkedin.drelephant.mapreduce.MapReduceFetcherHadoop2</classname>
-  </fetcher>
   <fetcher>
     <applicationtype>spark</applicationtype>
     <classname>org.apache.spark.deploy.history.SparkFSFetcher</classname>
-    <!--
     <params>
       <event_log_size_limit_in_mb>100</event_log_size_limit_in_mb>
       <event_log_dir>/system/spark-history</event_log_dir>
     </params>
-    -->
   </fetcher>
 </fetchers>

--- a/test/resources/configurations/fetcher/FetcherConfTest6.xml
+++ b/test/resources/configurations/fetcher/FetcherConfTest6.xml
@@ -20,8 +20,8 @@
     <applicationtype>spark</applicationtype>
     <classname>org.apache.spark.deploy.history.SparkFSFetcher</classname>
     <params>
-      <event_log_size_limit_in_mb>50</event_log_size_limit_in_mb>
-      <event_log_dir>/custom/configured</event_log_dir>
+      <event_log_size_limit_in_mb></event_log_size_limit_in_mb>
+      <event_log_dir></event_log_dir>
     </params>
   </fetcher>
 </fetchers>

--- a/test/resources/configurations/fetcher/FetcherConfTest7.xml
+++ b/test/resources/configurations/fetcher/FetcherConfTest7.xml
@@ -20,8 +20,6 @@
     <applicationtype>spark</applicationtype>
     <classname>org.apache.spark.deploy.history.SparkFSFetcher</classname>
     <params>
-      <event_log_size_limit_in_mb>50</event_log_size_limit_in_mb>
-      <event_log_dir>/custom/configured</event_log_dir>
     </params>
   </fetcher>
 </fetchers>


### PR DESCRIPTION
* Make Spark Event log directory configurable
* Fix a bug: When Spark log size was configured (in MB), it was converted to bytes twice.