### PR TITLE
HttpPooling + gzip for requests to the Job History Server

### DIFF
--- a/app/com/linkedin/drelephant/ElephantRunner.java
+++ b/app/com/linkedin/drelephant/ElephantRunner.java
@@ -46,7 +46,7 @@ public class ElephantRunner implements Runnable {
   private static final Logger logger = Logger.getLogger(ElephantRunner.class);
 
   private static final long WAIT_INTERVAL = 60 * 1000;      // Interval between fetches and retries
-  private static final int EXECUTOR_NUM = 3;                // The number of executor threads to analyse the jobs
+  private static final int EXECUTOR_NUM = 96;                // The number of executor threads to analyse the jobs
 
   private AtomicBoolean _running = new AtomicBoolean(true);
   private long lastRun;

--- a/app/com/linkedin/drelephant/analysis/HttpConnectionPooling.java
+++ b/app/com/linkedin/drelephant/analysis/HttpConnectionPooling.java
@@ -1,0 +1,22 @@
+package com.linkedin.drelephant.analysis;
+
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+public class HttpConnectionPooling {
+    private static HttpConnectionPooling ourInstance = new HttpConnectionPooling();
+
+    public PoolingHttpClientConnectionManager getCm() {
+        return cm;
+    }
+
+    private PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+
+    public static HttpConnectionPooling getInstance() {
+        return ourInstance;
+    }
+
+    private HttpConnectionPooling() {
+        cm.setMaxTotal(96);
+        cm.setDefaultMaxPerRoute(96);
+    }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,8 +71,9 @@ object Dependencies {
     "org.codehaus.jackson" % "jackson-mapper-asl" % jacksonMapperAslVersion,
     "org.jsoup" % "jsoup" % jsoupVersion,
     "org.mockito" % "mockito-core" % "1.10.19",
-    "org.jmockit" % "jmockit" % "1.23" % Test
-  ) :+ sparkExclusion 
+    "org.jmockit" % "jmockit" % "1.23" % Test,
+    "org.apache.httpcomponents" % "httpclient" % "4.5.2"
+  ) :+ sparkExclusion
 
   var dependencies = Seq(javaJdbc, javaEbean, cache)
   dependencies ++= requiredDep


### PR DESCRIPTION
Addresses the [scaling issue](https://github.com/linkedin/dr-elephant/issues/73). 

This patch utilizes Apache's HTTP Client Lib to enable connection pooling for TCP requests that can then be shared between threads and utilized across Job History Server API requests to set an upper limit on the number of TCP connections open to the Job History Server at any one time. We also ensure that gzip is being used by utilizing http client api's that enable this by default.

With these changes, the queue of jobs being processed is reduced dramatically with only 96 worker threads as shown below:

![queue_size](https://cloud.githubusercontent.com/assets/1026696/15980222/ae499736-2f1e-11e6-87a9-48519a0eb17c.png)


After a few minutes the queue size normalizes to the number of jobs completed in the last [`WAIT_INTERVAL`](https://github.com/linkedin/dr-elephant/blob/master/app/com/linkedin/drelephant/ElephantRunner.java#L48).

One must still decide on the ratio of connections to threads. For many applications, the number of connections should be less than the number of worker threads. In the case of Dr.E, each thread really needs it's own connection as there are many requests being made in parallel. There are still speed benefits as the number of TCP connections can be capped, whereas before a separate connection was being created for each request ((4 + task num) * job count = many thousands).

The screenshot below shows how threads have to wait for a connection if not configured to have 1 connection per thread (the configuration was 48 worker threads with 24 connections).

![jvisvm](https://cloud.githubusercontent.com/assets/1026696/15980238/de3e78da-2f1e-11e6-8786-f7da33c47c70.png)

Moving to a 1:1 ratio for connections to threads moved the bottleneck to `.streamRead()` with virtually no time being spent in other functions. We believe this to be the optimal configuration. Using gzip ensures that the least amount of time possible is spent reading from the stream.

Gzip is enabled by using the [`HttpClientBuilder`](https://hc.apache.org/httpcomponents-client-4.3.x/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html). This ensures that the "accept-encoding" header is set to "gzip" and also processes the response body so that [`GZipInputStream`](https://docs.oracle.com/javase/7/docs/api/java/util/zip/GZIPInputStream.html) doesn't have to be used manually. There are other ways to get `HttpClient`'s in Apache's Http Client lib, if those are used the gzip header will have to be re-added and responses manually decompressed.

Limitations & Future Work:
- Add configuration option for the max number of connections.
  - This should likely just be tied to the number of threads, which could possibly be pulled out into a configuration option (as a separate PR)
- Any suggestions on ensuring compatibility with the Hadoop Authentication Mechanism? I think the first step is to add a test and then extend the class that handles pooling to ensure that the authentication process is also pooled.
  - The benefit of  getting the connection from the `AuthenticatedURL` that ships with the hadoop jars is that authentication is handled automatically. We'll need to add something similar to this patch. I'm currently looking into this, but feedback is much appreciated.