### PR TITLE
Try alternate resource manager if one is down

### DIFF
--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -73,8 +73,8 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
         List<String> ids = Arrays.asList(resourceManagers.split(","));
         _currentTime = System.currentTimeMillis();
         updateAuthToken();
-        try {
-          for (String id : ids) {
+        for (String id : ids) {
+          try {
             String resourceManager = configuration.get(RESOURCE_MANAGER_ADDRESS + "." + id);
             String resourceManagerURL = String.format(RM_NODE_STATE_URL, resourceManager);
             logger.info("Checking RM URL: " + resourceManagerURL);
@@ -84,17 +84,14 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
               logger.info(resourceManager + " is ACTIVE");
               _resourceManagerAddress = resourceManager;
               break;
-            }
-            else {
+            } else {
               logger.info(resourceManager + " is STANDBY");
             }
+          } catch (AuthenticationException e) {
+            logger.info("Error fetching resource manager " + id + " state " + e.getMessage());
+          } catch (IOException e) {
+            logger.info("Error fetching Json for resource manager "+ id + " status " + e.getMessage());
           }
-        }
-        catch (AuthenticationException e) {
-          logger.error("Error fetching resource manager state " + e.getMessage());
-        }
-        catch (IOException e) {
-          logger.error("Error fetching Json for resource manager status " + e.getMessage());
         }
       }
     } else {


### PR DESCRIPTION
Currently if there are multiple resource managers (i.e. HA mode) Dr. Elephant goes through each one and makes a request which it uses to determine which is currently active. The problem is, if any of these requests fail (which will happen if any node which is down is queried), the exception handling logic will cause the loop to break and stop the remaining nodes from having their status checked. This PR fixes that.
I'm from Airbnb. I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.
@krishnap @plypaul @hongbozeng @liyintang @brandtg