### PR TITLE
Add spark log ext conf param

### DIFF
--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -40,6 +40,7 @@
     <params>
       <event_log_size_limit_in_mb>100</event_log_size_limit_in_mb>
       <event_log_dir>/system/spark-history</event_log_dir>
+      <spark_log_ext>_1.snappy</spark_log_ext>
 
       #the values specified in namenode_addresses will be used for obtaining spark logs. The cluster configuration will be ignored.
       <namenode_addresses>address1,address2</namenode_addresses>

--- a/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
+++ b/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
@@ -237,10 +237,7 @@ class SparkFSFetcher(fetcherConfData: FetcherConfigurationData) extends Elephant
               null
             }
           } else {
-            var sparkLogExt = fetcherConfData.getParamMap.get(SPARK_LOG_EXT)
-            if (sparkLogExt == null) {
-              sparkLogExt = defSparkLogExt
-            }
+            val sparkLogExt = fetcherConfData.getParamMap.getOrDefault(SPARK_LOG_EXT, defSparkLogExt)
             val logFilePath = new Path(logPath + sparkLogExt)
             if (!shouldThrottle(logFilePath)) {
               EventLoggingListener.openEventLog(logFilePath, fs)

--- a/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
+++ b/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
@@ -348,6 +348,7 @@ private object SparkFSFetcher {
   val LOG_PREFIX = "EVENT_LOG_"
   val COMPRESSION_CODEC_PREFIX = EventLoggingListener.COMPRESSION_CODEC_KEY + "_"
 
+  // Param map property names that allow users to configer various aspects of the fetcher
   val NAMENODE_ADDRESSES = "namenode_addresses"
   val SPARK_LOG_EXT = "spark_log_ext"
 }

--- a/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
+++ b/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
@@ -237,7 +237,11 @@ class SparkFSFetcher(fetcherConfData: FetcherConfigurationData) extends Elephant
               null
             }
           } else {
-            val logFilePath = new Path(logPath + "_1.snappy")
+            var sparkLogExt = fetcherConfData.getParamMap.get(SPARK_LOG_EXT)
+            if (sparkLogExt == null) {
+              sparkLogExt = defSparkLogExt
+            }
+            val logFilePath = new Path(logPath + sparkLogExt)
             if (!shouldThrottle(logFilePath)) {
               EventLoggingListener.openEventLog(logFilePath, fs)
             } else {
@@ -338,6 +342,7 @@ private object SparkFSFetcher {
 
   var defEventLogDir = "/system/spark-history"
   var defEventLogSizeInMb = 100d; // 100MB
+  var defSparkLogExt = "_1.snappy"
 
   val LOG_SIZE_XML_FIELD = "event_log_size_limit_in_mb"
   val LOG_DIR_XML_FIELD = "event_log_dir"
@@ -347,4 +352,5 @@ private object SparkFSFetcher {
   val COMPRESSION_CODEC_PREFIX = EventLoggingListener.COMPRESSION_CODEC_KEY + "_"
 
   val NAMENODE_ADDRESSES = "namenode_addresses"
+  val SPARK_LOG_EXT = "spark_log_ext"
 }


### PR DESCRIPTION
Since not everyone's Spark logs end in _1.snappy, I think it makes sense to add the Spark log extension as a conf param.
I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.
@krishnap @plypaul @hongbozeng @liyintang @brandtg @timyitong