### PR TITLE
Fix fallback to default `SPARK_LOG_EXT` value

### DIFF
--- a/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
+++ b/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
@@ -237,7 +237,7 @@ class SparkFSFetcher(fetcherConfData: FetcherConfigurationData) extends Elephant
               null
             }
           } else {
-            val sparkLogExt = fetcherConfData.getParamMap.getOrDefault(SPARK_LOG_EXT, defSparkLogExt)
+            val sparkLogExt = Option(fetcherConfData.getParamMap.get(SPARK_LOG_EXT)).getOrElse(defSparkLogExt)
             val logFilePath = new Path(logPath + sparkLogExt)
             if (!shouldThrottle(logFilePath)) {
               EventLoggingListener.openEventLog(logFilePath, fs)


### PR DESCRIPTION
Recent change (https://github.com/linkedin/dr-elephant/pull/79) broke the build:

```
[error] /tmp/dr-elephant/app/org/apache/spark/deploy/history/SparkFSFetcher.scala:240: value getOrDefault is not a member of java.util.Map[String,String]
[error]             val sparkLogExt = fetcherConfData.getParamMap.getOrDefault(SPARK_LOG_EXT, defSparkLogExt)
[error]                                                           ^
```

@paulbramsen have you tried compiling it after this minor change (https://github.com/linkedin/dr-elephant/pull/79#discussion_r67580363)?

@akshayrai @plypaul @krishnap