### PR TITLE
Add Airflow scheduler support to Dr. Elephant. Includes Tests.

### DIFF
--- a/app-conf/SchedulerConf.xml
+++ b/app-conf/SchedulerConf.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2016 LinkedIn Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!-- Scheduler configurations -->
+<schedulers>
+
+    <scheduler>
+        <name>airflow</name>
+        <classname>com.linkedin.drelephant.schedulers.AirflowScheduler</classname>
+        <params>
+            <airflowbaseurl>http://localhost:8000</airflowbaseurl>
+        </params>
+    </scheduler>
+
+    <scheduler>
+        <name>azkaban</name>
+        <classname>com.linkedin.drelephant.schedulers.AzkabanScheduler</classname>
+    </scheduler>
+
+</schedulers>

--- a/app/com/linkedin/drelephant/configurations/fetcher/FetcherConfiguration.java
+++ b/app/com/linkedin/drelephant/configurations/fetcher/FetcherConfiguration.java
@@ -17,6 +17,8 @@
 package com.linkedin.drelephant.configurations.fetcher;
 
 import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.util.Utils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,10 +65,10 @@ public class FetcherConfiguration {
       Node node = nodes.item(i);
       if (node.getNodeType() == Node.ELEMENT_NODE) {
         n++;
-        Element fetcherNode = (Element) node;
+        Element fetcherElem = (Element) node;
 
         String className;
-        Node classNameNode = fetcherNode.getElementsByTagName("classname").item(0);
+        Node classNameNode = fetcherElem.getElementsByTagName("classname").item(0);
         if (classNameNode == null) {
           throw new RuntimeException("No tag 'classname' in fetcher " + n);
         }
@@ -75,7 +77,7 @@ public class FetcherConfiguration {
           throw new RuntimeException("Empty tag 'classname' in fetcher " + n);
         }
 
-        Node appTypeNode = fetcherNode.getElementsByTagName("applicationtype").item(0);
+        Node appTypeNode = fetcherElem.getElementsByTagName("applicationtype").item(0);
         if (appTypeNode == null) {
           throw new RuntimeException(
               "No tag or invalid tag 'applicationtype' in fetcher " + n + " classname " + className);
@@ -89,17 +91,7 @@ public class FetcherConfiguration {
         ApplicationType appType = new ApplicationType(appTypeStr);
 
         // Check if parameters are defined for the heuristic
-        Map<String, String> paramsMap = new HashMap<String, String>();
-        Node paramsNode = fetcherNode.getElementsByTagName("params").item(0);
-        if (paramsNode != null) {
-          NodeList paramsList = paramsNode.getChildNodes();
-          for (int j = 0; j < paramsList.getLength(); j++) {
-            Node paramNode = paramsList.item(j);
-            if (paramNode != null && !paramsMap.containsKey(paramNode.getNodeName())) {
-              paramsMap.put(paramNode.getNodeName(), paramNode.getTextContent());
-            }
-          }
-        }
+        Map<String, String> paramsMap = Utils.getConfigurationParameters(fetcherElem);
 
         FetcherConfigurationData fetcherData = new FetcherConfigurationData(className, appType, paramsMap);
         _fetchersConfDataList.add(fetcherData);

--- a/app/com/linkedin/drelephant/configurations/heuristic/HeuristicConfiguration.java
+++ b/app/com/linkedin/drelephant/configurations/heuristic/HeuristicConfiguration.java
@@ -17,6 +17,8 @@
 package com.linkedin.drelephant.configurations.heuristic;
 
 import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.util.Utils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -53,10 +55,10 @@ public class HeuristicConfiguration {
       Node node = nodes.item(i);
       if (node.getNodeType() == Node.ELEMENT_NODE) {
         n++;
-        Element heuristicNode = (Element) node;
+        Element heuristicElem = (Element) node;
 
         String className;
-        Node classNameNode = heuristicNode.getElementsByTagName("classname").item(0);
+        Node classNameNode = heuristicElem.getElementsByTagName("classname").item(0);
         if (classNameNode == null) {
           throw new RuntimeException("No tag 'classname' in heuristic " + n);
         }
@@ -66,7 +68,7 @@ public class HeuristicConfiguration {
         }
 
         String heuristicName;
-        Node heuristicNameNode = heuristicNode.getElementsByTagName("heuristicname").item(0);
+        Node heuristicNameNode = heuristicElem.getElementsByTagName("heuristicname").item(0);
         if (heuristicNameNode == null) {
           throw new RuntimeException("No tag 'heuristicname' in heuristic " + n + " classname " + className);
         }
@@ -76,7 +78,7 @@ public class HeuristicConfiguration {
         }
 
         String viewName;
-        Node viewNameNode = heuristicNode.getElementsByTagName("viewname").item(0);
+        Node viewNameNode = heuristicElem.getElementsByTagName("viewname").item(0);
         if (viewNameNode == null) {
           throw new RuntimeException("No tag 'viewname' in heuristic " + n + " classname " + className);
         }
@@ -85,7 +87,7 @@ public class HeuristicConfiguration {
           throw new RuntimeException("Empty tag 'viewname' in heuristic " + n + " classname " + className);
         }
 
-        Node appTypeNode = heuristicNode.getElementsByTagName("applicationtype").item(0);
+        Node appTypeNode = heuristicElem.getElementsByTagName("applicationtype").item(0);
         if (appTypeNode == null) {
           throw new RuntimeException(
               "No tag or invalid tag 'applicationtype' in heuristic " + n + " classname " + className);
@@ -99,17 +101,7 @@ public class HeuristicConfiguration {
         ApplicationType appType = new ApplicationType(appTypeStr);
 
         // Check if parameters are defined for the heuristic
-        Map<String, String> paramsMap = new HashMap<String, String>();
-        Node paramsNode = heuristicNode.getElementsByTagName("params").item(0);
-        if (paramsNode != null) {
-          NodeList paramsList = paramsNode.getChildNodes();
-          for (int j = 0; j < paramsList.getLength(); j++) {
-            Node paramNode = paramsList.item(j);
-            if (paramNode != null && !paramsMap.containsKey(paramNode.getNodeName())) {
-              paramsMap.put(paramNode.getNodeName(), paramNode.getTextContent());
-            }
-          }
-        }
+        Map<String, String> paramsMap = Utils.getConfigurationParameters(heuristicElem);
 
         HeuristicConfigurationData heuristicData = new HeuristicConfigurationData(heuristicName, className, viewName,
             appType, paramsMap);

--- a/app/com/linkedin/drelephant/configurations/scheduler/SchedulerConfiguration.java
+++ b/app/com/linkedin/drelephant/configurations/scheduler/SchedulerConfiguration.java
@@ -1,0 +1,79 @@
+package com.linkedin.drelephant.configurations.scheduler;
+
+import org.apache.log4j.Logger;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class manages the scheduler configurations
+ */
+public class SchedulerConfiguration {
+  private List<SchedulerConfigurationData> _schedulerConfDataList;
+
+  public SchedulerConfiguration(Element configuration) {
+    parseSchedulerConfiguration(configuration);
+  }
+
+  public List<SchedulerConfigurationData> getSchedulerConfigurationData() {
+    return _schedulerConfDataList;
+  }
+
+  private void parseSchedulerConfiguration(Element configuration) {
+    _schedulerConfDataList = new ArrayList<SchedulerConfigurationData>();
+
+    NodeList nodes = configuration.getChildNodes();
+    int n = 0;
+    for (int i = 0; i < nodes.getLength(); i++) {
+      // Each scheduler node
+      Node node = nodes.item(i);
+      if (node.getNodeType() == Node.ELEMENT_NODE) {
+        n++;
+        Element schedulerNode = (Element) node;
+
+        String className;
+        Node classNameNode = schedulerNode.getElementsByTagName("classname").item(0);
+        if (classNameNode == null) {
+          throw new RuntimeException("No tag 'classname' in scheduler " + n);
+        }
+        className = classNameNode.getTextContent();
+        if (className.equals("")) {
+          throw new RuntimeException("Empty tag 'classname' in scheduler " + n);
+        }
+
+        String schedulerName;
+        Node schedulerNameNode = schedulerNode.getElementsByTagName("name").item(0);
+        if (schedulerNameNode == null) {
+          throw new RuntimeException("No tag 'name' in scheduler " + n + " classname " + className);
+        }
+        schedulerName = schedulerNameNode.getTextContent();
+        if (schedulerName.equals("")) {
+          throw new RuntimeException("Empty tag 'name' in scheduler " + n + " classname " + className);
+        }
+
+        // Check if parameters are defined for the scheduler
+        Map<String, String> paramsMap = new HashMap<String, String>();
+        Node paramsNode = schedulerNode.getElementsByTagName("params").item(0);
+        if (paramsNode != null) {
+          NodeList paramsList = paramsNode.getChildNodes();
+          for (int j = 0; j < paramsList.getLength(); j++) {
+            Node paramNode = paramsList.item(j);
+            if (paramNode != null && !paramsMap.containsKey(paramNode.getNodeName())) {
+              paramsMap.put(paramNode.getNodeName(), paramNode.getTextContent());
+            }
+          }
+        }
+
+        SchedulerConfigurationData schedulerData = new SchedulerConfigurationData(schedulerName, className, paramsMap);
+        _schedulerConfDataList.add(schedulerData);
+
+      }
+    }
+  }
+
+}

--- a/app/com/linkedin/drelephant/configurations/scheduler/SchedulerConfiguration.java
+++ b/app/com/linkedin/drelephant/configurations/scheduler/SchedulerConfiguration.java
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
 package com.linkedin.drelephant.configurations.scheduler;
 
-import org.apache.log4j.Logger;
+import com.linkedin.drelephant.util.Utils;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -34,10 +52,10 @@ public class SchedulerConfiguration {
       Node node = nodes.item(i);
       if (node.getNodeType() == Node.ELEMENT_NODE) {
         n++;
-        Element schedulerNode = (Element) node;
+        Element schedulerElem = (Element) node;
 
         String className;
-        Node classNameNode = schedulerNode.getElementsByTagName("classname").item(0);
+        Node classNameNode = schedulerElem.getElementsByTagName("classname").item(0);
         if (classNameNode == null) {
           throw new RuntimeException("No tag 'classname' in scheduler " + n);
         }
@@ -47,7 +65,7 @@ public class SchedulerConfiguration {
         }
 
         String schedulerName;
-        Node schedulerNameNode = schedulerNode.getElementsByTagName("name").item(0);
+        Node schedulerNameNode = schedulerElem.getElementsByTagName("name").item(0);
         if (schedulerNameNode == null) {
           throw new RuntimeException("No tag 'name' in scheduler " + n + " classname " + className);
         }
@@ -57,17 +75,7 @@ public class SchedulerConfiguration {
         }
 
         // Check if parameters are defined for the scheduler
-        Map<String, String> paramsMap = new HashMap<String, String>();
-        Node paramsNode = schedulerNode.getElementsByTagName("params").item(0);
-        if (paramsNode != null) {
-          NodeList paramsList = paramsNode.getChildNodes();
-          for (int j = 0; j < paramsList.getLength(); j++) {
-            Node paramNode = paramsList.item(j);
-            if (paramNode != null && !paramsMap.containsKey(paramNode.getNodeName())) {
-              paramsMap.put(paramNode.getNodeName(), paramNode.getTextContent());
-            }
-          }
-        }
+        Map<String, String> paramsMap = Utils.getConfigurationParameters(schedulerElem);
 
         SchedulerConfigurationData schedulerData = new SchedulerConfigurationData(schedulerName, className, paramsMap);
         _schedulerConfDataList.add(schedulerData);

--- a/app/com/linkedin/drelephant/configurations/scheduler/SchedulerConfigurationData.java
+++ b/app/com/linkedin/drelephant/configurations/scheduler/SchedulerConfigurationData.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.configurations.scheduler;
+
+import java.util.Map;
+
+
+/**
+ * The Heuristic Configuration Holder
+ */
+public class SchedulerConfigurationData {
+  private final String _schedulerName;
+  private final String _className;
+  private final Map<String, String> _paramMap;
+
+  public SchedulerConfigurationData(String schedulerName, String className, Map<String, String> paramMap) {
+    _schedulerName = schedulerName;
+    _className = className;
+    _paramMap = paramMap;
+  }
+
+  public String getSchedulerName() {
+    return _schedulerName;
+  }
+
+  public String getClassName() {
+    return _className;
+  }
+
+  public Map<String, String> getParamMap() {
+    return _paramMap;
+  }
+}

--- a/app/com/linkedin/drelephant/schedulers/AirflowScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/AirflowScheduler.java
@@ -49,7 +49,11 @@ public class AirflowScheduler implements Scheduler {
 
   public AirflowScheduler(String appId, Properties properties, SchedulerConfigurationData schedulerConfData) {
     _schedulerName = schedulerConfData.getSchedulerName();
-    _baseUrl = schedulerConfData.getParamMap().getOrDefault(AIRFLOW_BASE_URL_PARAM_NAME, AIRFLOW_BASE_URL_DEFAULT);
+    _baseUrl = schedulerConfData.getParamMap().get(AIRFLOW_BASE_URL_PARAM_NAME);
+    if (_baseUrl == null) {
+      _baseUrl = AIRFLOW_BASE_URL_DEFAULT;
+    }
+
     if (properties != null) {
       loadInfo(appId, properties);
     } else {
@@ -58,10 +62,14 @@ public class AirflowScheduler implements Scheduler {
   }
 
   private void loadInfo(String appId, Properties properties) {
-    // Update the 4 Ids
+    // examples:
+    // my_amazing_task_id
     _taskId = properties.getProperty(AIRFLOW_TASK_ID);
+    // 2016-06-27T01:30:00
     _taskInstanceExecutionDate = properties.getProperty(AIRFLOW_TASK_INSTANCE_EXECUTION_DATE);
-    _dagId = properties.getProperty(AIRFLOW_DAG_ID);
+    // my_amazing_dag_id
+    _dagId = properties.getProperty(AIRFLOW_DAG_ID); //
+    // 2016-06-27T00:00:00
     _dagRunExecutionDate = properties.getProperty(AIRFLOW_DAG_RUN_EXECUTION_DATE);
 
     _subdagDepth = 0; // TODO: Add sub-dag support

--- a/app/com/linkedin/drelephant/schedulers/AirflowScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/AirflowScheduler.java
@@ -92,7 +92,7 @@ public class AirflowScheduler implements Scheduler {
 
   @Override
   public String getJobExecId() {
-    return Utils.formatStringOrNull("%s/%s/%s", _dagId, _taskId, _taskInstanceExecutionDate);
+    return Utils.formatStringOrNull("%s/%s/%s/%s", _dagId, _dagRunExecutionDate, _taskId, _taskInstanceExecutionDate);
   }
 
   @Override

--- a/app/com/linkedin/drelephant/schedulers/AirflowScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/AirflowScheduler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.schedulers;
+
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+import com.linkedin.drelephant.util.Utils;
+
+import java.util.Properties;
+import org.apache.log4j.Logger;
+
+
+/**
+ * This class provides methods to load information specific to the Airflow scheduler.
+ */
+public class AirflowScheduler implements Scheduler {
+
+  private static final Logger logger = Logger.getLogger(AirflowScheduler.class);
+
+  public static final String AIRFLOW_TASK_ID = "airflow.ctx.task.task_id";
+  public static final String AIRFLOW_TASK_INSTANCE_EXECUTION_DATE = "airflow.ctx.task_instance.execution_date";
+  public static final String AIRFLOW_DAG_ID = "airflow.ctx.dag.dag_id";
+  public static final String AIRFLOW_DAG_RUN_EXECUTION_DATE = "airflow.ctx.dag_run.execution_date";
+
+  public static final String AIRFLOW_BASE_URL_PARAM_NAME = "airflowbaseurl";
+  private static final String AIRFLOW_BASE_URL_DEFAULT = "http://localhost:8000";
+
+  private String _schedulerName;
+  private String _taskId;
+  private String _taskInstanceExecutionDate;
+  private String _dagId;
+  private String _dagRunExecutionDate;
+  private int _subdagDepth;
+  private String _baseUrl;
+
+
+  public AirflowScheduler(String appId, Properties properties, SchedulerConfigurationData schedulerConfData) {
+    _schedulerName = schedulerConfData.getSchedulerName();
+    _baseUrl = schedulerConfData.getParamMap().getOrDefault(AIRFLOW_BASE_URL_PARAM_NAME, AIRFLOW_BASE_URL_DEFAULT);
+    if (properties != null) {
+      loadInfo(appId, properties);
+    } else {
+      // Use default value of data type
+    }
+  }
+
+  private void loadInfo(String appId, Properties properties) {
+    // Update the 4 Ids
+    _taskId = properties.getProperty(AIRFLOW_TASK_ID);
+    _taskInstanceExecutionDate = properties.getProperty(AIRFLOW_TASK_INSTANCE_EXECUTION_DATE);
+    _dagId = properties.getProperty(AIRFLOW_DAG_ID);
+    _dagRunExecutionDate = properties.getProperty(AIRFLOW_DAG_RUN_EXECUTION_DATE);
+
+    _subdagDepth = 0; // TODO: Add sub-dag support
+  }
+
+  @Override
+  public String getSchedulerName() {
+    return _schedulerName;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _taskId == null || _taskInstanceExecutionDate == null || _dagId == null || _dagRunExecutionDate == null;
+  }
+
+  @Override
+  public String getJobDefId() {
+    return Utils.formatStringOrNull("%s/%s", _dagId, _taskId);
+  }
+
+  @Override
+  public String getJobExecId() {
+    return Utils.formatStringOrNull("%s/%s/%s", _dagId, _taskId, _taskInstanceExecutionDate);
+  }
+
+  @Override
+  public String getFlowDefId() {
+    return Utils.formatStringOrNull("%s", _dagId);
+  }
+
+  @Override
+  public String getFlowExecId() {
+    return Utils.formatStringOrNull("%s/%s", _dagId, _dagRunExecutionDate);
+  }
+
+  @Override
+  public String getJobDefUrl() {
+    return Utils.formatStringOrNull("%s/admin/airflow/code?dag_id=%s&task_id=%s", _baseUrl, _dagId, _taskId);
+  }
+
+  @Override
+  public String getJobExecUrl() {
+    return Utils.formatStringOrNull("%s/admin/airflow/log?dag_id=%s&task_id=%s&execution_date=%s",
+            _baseUrl, _dagId, _taskId, _taskInstanceExecutionDate);
+
+  }
+
+  @Override
+  public String getFlowDefUrl() {
+    return Utils.formatStringOrNull("%s/admin/airflow/graph?dag_id=%s", _baseUrl, _dagId);
+  }
+
+  @Override
+  public String getFlowExecUrl() {
+    return Utils.formatStringOrNull("%s/admin/airflow/graph?dag_id=%s&execution_date=%s", _baseUrl, _dagId, _dagRunExecutionDate);
+  }
+
+  @Override
+  public int getWorkflowDepth() {
+    return _subdagDepth;
+  }
+
+  @Override
+  public String getJobName() { return _taskId; }
+}

--- a/app/com/linkedin/drelephant/schedulers/AzkabanScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/AzkabanScheduler.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.drelephant.schedulers;
 
-import com.linkedin.drelephant.util.Utils;
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
 import java.util.Properties;
 import org.apache.log4j.Logger;
 
@@ -28,13 +28,13 @@ public class AzkabanScheduler implements Scheduler {
 
   private static final Logger logger = Logger.getLogger(AzkabanScheduler.class);
 
-  public static final String SCHEDULER_NAME = "azkaban";
   public static final String AZKABAN_WORKFLOW_URL = "azkaban.link.workflow.url";
   public static final String AZKABAN_JOB_URL = "azkaban.link.job.url";
   public static final String AZKABAN_EXECUTION_URL = "azkaban.link.execution.url";
   public static final String AZKABAN_ATTEMPT_URL = "azkaban.link.attempt.url";
   public static final String AZKABAN_JOB_NAME = "azkaban.job.id";
 
+  private String schedulerName;
   private String jobDefId;
   private String jobExecId;
   private String flowDefId;
@@ -49,7 +49,8 @@ public class AzkabanScheduler implements Scheduler {
   private int workflowDepth;
 
 
-  public AzkabanScheduler(String appId, Properties properties) {
+  public AzkabanScheduler(String appId, Properties properties, SchedulerConfigurationData schedulerConfData) {
+    schedulerName = schedulerConfData.getSchedulerName();
     if (properties != null) {
       loadInfo(appId, properties);
     } else {
@@ -76,7 +77,12 @@ public class AzkabanScheduler implements Scheduler {
 
   @Override
   public String getSchedulerName() {
-    return SCHEDULER_NAME;
+    return schedulerName;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return jobDefId == null || jobExecId == null || flowDefId == null || flowExecId == null;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/schedulers/Scheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/Scheduler.java
@@ -30,6 +30,13 @@ public interface Scheduler {
   public String getSchedulerName();
 
   /**
+   * True if the the scheduler object was not able to parse the given properties
+   *
+   * @return true the scheduler is empty
+   */
+  public boolean isEmpty();
+
+  /**
    * Return the Job Definition Id of the job in the workflow
    *
    * @return the job definition id

--- a/app/com/linkedin/drelephant/util/InfoExtractor.java
+++ b/app/com/linkedin/drelephant/util/InfoExtractor.java
@@ -17,16 +17,24 @@
 package com.linkedin.drelephant.util;
 
 import com.linkedin.drelephant.analysis.HadoopApplicationData;
+import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData;
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfiguration;
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+import com.linkedin.drelephant.schedulers.AirflowScheduler;
 import com.linkedin.drelephant.schedulers.AzkabanScheduler;
 import com.linkedin.drelephant.schedulers.Scheduler;
 import com.linkedin.drelephant.spark.data.SparkApplicationData;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import java.util.Set;
 import org.apache.log4j.Logger;
+import org.w3c.dom.Document;
 
 import models.AppResult;
+import play.api.Play;
 
 import com.linkedin.drelephant.mapreduce.data.MapReduceApplicationData;
 
@@ -39,32 +47,23 @@ public class InfoExtractor {
   private static final Logger logger = Logger.getLogger(InfoExtractor.class);
   private static final String SPARK_EXTRA_JAVA_OPTIONS = "spark.driver.extraJavaOptions";
 
+  private static final String SCHEDULER_CONF = "SchedulerConf.xml";
+
+  private static List<SchedulerConfigurationData> _schedulerConfData;
+
+  public InfoExtractor() {
+    loadSchedulers();
+  }
+
   /**
-   * All the supported Schedulers.
-   * JobScheduler(x, y) where,
-   * x, is the unique property in the job conf that identifies the scheduler. This property must exist
-   *    in every job scheduled by the scheduler.
-   * y, is an instance of the Scheduler.
+   * Load all the schedulers configured in SchedulerConf.xml
    */
-  static enum JobScheduler {
-    AZKABAN(AzkabanScheduler.AZKABAN_JOB_URL);
 
-    String identifier;
-
-    JobScheduler(String identifier) {
-      this.identifier = identifier;
-    }
-
-    String getIdentifier() {
-      return this.identifier;
-    }
-
-    Scheduler getSchedulerInstance(String appId, Properties properties) {
-      if (this.equals(JobScheduler.AZKABAN)) {
-        return new AzkabanScheduler(appId, properties);
-      } else {
-        return null;
-      }
+  private static void loadSchedulers() {
+    Document document = Utils.loadXMLDoc(SCHEDULER_CONF);
+    _schedulerConfData = new SchedulerConfiguration(document.getDocumentElement()).getSchedulerConfigurationData();
+    for (SchedulerConfigurationData data : _schedulerConfData) {
+      logger.info(String.format("Load Scheduler %s with class : %s", data.getSchedulerName(), data.getClassName()));
     }
   }
 
@@ -76,10 +75,34 @@ public class InfoExtractor {
    * @return the corresponding Scheduler which scheduled the job.
    */
   public static Scheduler getSchedulerInstance(String appId, Properties properties) {
+    if (_schedulerConfData == null) {
+      loadSchedulers();
+    }
     if (properties != null) {
-      for (JobScheduler scheduler : JobScheduler.values()) {
-        if (properties.containsKey(scheduler.getIdentifier())) {
-          return scheduler.getSchedulerInstance(appId, properties);
+      for (SchedulerConfigurationData data : _schedulerConfData) {
+        try {
+          Class<?> schedulerClass = Play.current().classloader().loadClass(data.getClassName());
+          Object instance = schedulerClass.getConstructor(String.class, Properties.class, SchedulerConfigurationData.class).newInstance(appId, properties, data);
+          if (!(instance instanceof Scheduler)) {
+            throw new IllegalArgumentException(
+                    "Class " + schedulerClass.getName() + " is not an implementation of " + Scheduler.class.getName());
+          }
+          Scheduler scheduler = (Scheduler)instance;
+          if (!scheduler.isEmpty()) {
+            return scheduler;
+          }
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException("Could not find class " + data.getClassName(), e);
+        } catch (InstantiationException e) {
+          throw new RuntimeException("Could not instantiate class " + data.getClassName(), e);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException("Could not access constructor for class" + data.getClassName(), e);
+        } catch (RuntimeException e) {
+          throw new RuntimeException(data.getClassName() + " is not a valid Fetcher class.", e);
+        } catch (InvocationTargetException e) {
+          throw new RuntimeException("Could not invoke class " + data.getClassName(), e);
+        } catch (NoSuchMethodException e) {
+          throw new RuntimeException("Could not find constructor for class " + data.getClassName(), e);
         }
       }
     }

--- a/app/com/linkedin/drelephant/util/InfoExtractor.java
+++ b/app/com/linkedin/drelephant/util/InfoExtractor.java
@@ -51,10 +51,6 @@ public class InfoExtractor {
 
   private static List<SchedulerConfigurationData> _schedulerConfData;
 
-  public InfoExtractor() {
-    loadSchedulers();
-  }
-
   /**
    * Load all the schedulers configured in SchedulerConf.xml
    */

--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -30,6 +30,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import play.Play;
 
@@ -309,5 +312,26 @@ public final class Utils {
       }
     }
     return String.format(formatString, args);
+  }
+
+  /**
+   * Given a configuration element, extract the params map.
+   *
+   * @param confElem the configuration element
+   * @return the params map or an empty map if one can't be found
+   */
+  public static Map<String, String> getConfigurationParameters(Element confElem) {
+    Map<String, String> paramsMap = new HashMap<String, String>();
+    Node paramsNode = confElem.getElementsByTagName("params").item(0);
+    if (paramsNode != null) {
+      NodeList paramsList = paramsNode.getChildNodes();
+      for (int j = 0; j < paramsList.getLength(); j++) {
+        Node paramNode = paramsList.item(j);
+        if (paramNode != null && !paramsMap.containsKey(paramNode.getNodeName())) {
+          paramsMap.put(paramNode.getNodeName(), paramNode.getTextContent());
+        }
+      }
+    }
+    return paramsMap;
   }
 }

--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -294,4 +294,20 @@ public final class Utils {
       return defaultValue;
     }
   }
+
+  /**
+   * Return the formatted string unless one of the args is null in which case null is returned
+   *
+   * @param formatString the standard Java format string
+   * @param args objects to put in the format string
+   * @return formatted String or null
+   */
+  public static String formatStringOrNull(String formatString, Object... args) {
+    for (Object o : args) {
+      if (o == null) {
+        return null;
+      }
+    }
+    return String.format(formatString, args);
+  }
 }

--- a/test/com/linkedin/drelephant/configurations/scheduler/SchedulerConfigurationTest.java
+++ b/test/com/linkedin/drelephant/configurations/scheduler/SchedulerConfigurationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.configurations.scheduler;
+
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfiguration;
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class SchedulerConfigurationTest {
+
+  private static Document document1;
+  private static Document document2;
+  private static Document document3;
+
+  @BeforeClass
+  public static void runBeforeClass() {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      document1 = builder.parse(SchedulerConfigurationTest.class.getClassLoader()
+              .getResourceAsStream("configurations/scheduler/SchedulerConfTest1.xml"));
+      document2 = builder.parse(SchedulerConfigurationTest.class.getClassLoader()
+              .getResourceAsStream("configurations/scheduler/SchedulerConfTest2.xml"));
+      document3 = builder.parse(SchedulerConfigurationTest.class.getClassLoader()
+              .getResourceAsStream("configurations/scheduler/SchedulerConfTest3.xml"));
+    } catch (ParserConfigurationException e) {
+      throw new RuntimeException("XML Parser could not be created.", e);
+    } catch (SAXException e) {
+      throw new RuntimeException("Test files are not properly formed", e);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to read test files ", e);
+    }
+  }
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  /**
+   * Correctly configured scheduler
+   */
+  @Test
+  public void testParseSchedulerConf1() {
+    SchedulerConfiguration schedulerConf = new SchedulerConfiguration(document1.getDocumentElement());
+    List<SchedulerConfigurationData> schedulerConfData = schedulerConf.getSchedulerConfigurationData();
+    assertEquals(schedulerConfData.size(), 2);
+    for (SchedulerConfigurationData data : schedulerConfData) {
+      if (data.getSchedulerName().equals("airflow")) {
+        assertEquals("com.linkedin.drelephant.schedulers.AirflowScheduler", data.getClassName());
+        assertEquals("http://localhost:8000", data.getParamMap().get("airflowbaseurl"));
+      } else {
+        assertEquals("azkaban", data.getSchedulerName());
+        assertEquals("com.linkedin.drelephant.schedulers.AzkabanScheduler", data.getClassName());
+      }
+    }
+  }
+
+  /**
+   * No classname tag
+   */
+  @Test
+  public void testParseSchedulerConf2() {
+    expectedEx.expect(RuntimeException.class);
+    expectedEx.expectMessage("No tag 'classname' in scheduler 1");
+    new SchedulerConfiguration(document2.getDocumentElement());
+  }
+
+  /**
+   * No name tag
+   */
+  @Test
+  public void testParseSchedulerConf3() {
+    expectedEx.expect(RuntimeException.class);
+    expectedEx.expectMessage("No tag 'name' in scheduler 2 classname com.linkedin.drelephant.schedulers.AzkabanScheduler");
+    new SchedulerConfiguration(document3.getDocumentElement());
+  }
+
+}

--- a/test/com/linkedin/drelephant/schedulers/AirflowSchedulerTest.java
+++ b/test/com/linkedin/drelephant/schedulers/AirflowSchedulerTest.java
@@ -1,0 +1,114 @@
+package com.linkedin.drelephant.schedulers;
+
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Test;
+
+import static com.linkedin.drelephant.schedulers.AirflowScheduler.AIRFLOW_DAG_ID;
+import static com.linkedin.drelephant.schedulers.AirflowScheduler.AIRFLOW_DAG_RUN_EXECUTION_DATE;
+import static com.linkedin.drelephant.schedulers.AirflowScheduler.AIRFLOW_TASK_ID;
+import static com.linkedin.drelephant.schedulers.AirflowScheduler.AIRFLOW_TASK_INSTANCE_EXECUTION_DATE;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class AirflowSchedulerTest {
+
+  @Test
+  public void testAirflowLoadInfoWithCompleteConf() {
+
+    AirflowScheduler airScheduler = new AirflowScheduler("id", getAirflowProperties(), getSchedulerConfData());
+
+    assertEquals("http://localhost:1717/admin/airflow/graph?dag_id=dag_id", airScheduler.getFlowDefUrl());
+    assertEquals("dag_id", airScheduler.getFlowDefId());
+    assertEquals("http://localhost:1717/admin/airflow/graph?dag_id=dag_id&execution_date=dag_run_execution_date", airScheduler.getFlowExecUrl());
+    assertEquals("dag_id/dag_run_execution_date", airScheduler.getFlowExecId());
+
+    assertEquals("http://localhost:1717/admin/airflow/code?dag_id=dag_id&task_id=task_id", airScheduler.getJobDefUrl());
+    assertEquals("dag_id/task_id", airScheduler.getJobDefId());
+    assertEquals("http://localhost:1717/admin/airflow/log?dag_id=dag_id&task_id=task_id&execution_date=task_instance_execution_date", airScheduler.getJobExecUrl());
+    assertEquals("dag_id/task_id/task_instance_execution_date", airScheduler.getJobExecId());
+
+    assertEquals("task_id", airScheduler.getJobName());
+    assertEquals(0, airScheduler.getWorkflowDepth());
+    assertEquals("airflow", airScheduler.getSchedulerName());
+
+  }
+
+  @Test
+  public void testAirflowLoadInfoWithMissingProperty() {
+
+    AirflowScheduler airScheduler = new AirflowScheduler("id", getPropertiesAndRemove(AIRFLOW_TASK_ID), getSchedulerConfData());
+
+    assertEquals("http://localhost:1717/admin/airflow/graph?dag_id=dag_id", airScheduler.getFlowDefUrl());
+    assertEquals("dag_id", airScheduler.getFlowDefId());
+    assertEquals("http://localhost:1717/admin/airflow/graph?dag_id=dag_id&execution_date=dag_run_execution_date", airScheduler.getFlowExecUrl());
+    assertEquals("dag_id/dag_run_execution_date", airScheduler.getFlowExecId());
+
+    assertEquals(null, airScheduler.getJobDefUrl());
+    assertEquals(null, airScheduler.getJobDefId());
+    assertEquals(null, airScheduler.getJobExecUrl());
+    assertEquals(null, airScheduler.getJobExecId());
+
+    assertEquals(null, airScheduler.getJobName());
+    assertEquals(0, airScheduler.getWorkflowDepth());
+    assertEquals("airflow", airScheduler.getSchedulerName());
+  }
+
+  @Test
+  public void testAirflowLoadInfoWithNullProperty() {
+
+    AirflowScheduler airScheduler = new AirflowScheduler("id", null, getSchedulerConfData());
+
+    assertEquals(null, airScheduler.getFlowDefUrl());
+    assertEquals(null, airScheduler.getFlowDefId());
+    assertEquals(null, airScheduler.getFlowExecId());
+    assertEquals(null, airScheduler.getFlowExecUrl());
+
+    assertEquals(null, airScheduler.getJobDefId());
+    assertEquals(null, airScheduler.getJobDefUrl());
+    assertEquals(null, airScheduler.getJobExecId());
+    assertEquals(null, airScheduler.getJobExecUrl());
+
+    assertEquals(null, airScheduler.getJobName());
+    assertEquals(0, airScheduler.getWorkflowDepth());
+    assertEquals("airflow", airScheduler.getSchedulerName());
+  }
+
+  @Test
+  public void testAirflowLoadsNameFromConfData() {
+
+    AirflowScheduler airScheduler = new AirflowScheduler("id", null, getSchedulerConfData("othername"));
+    assertEquals("othername", airScheduler.getSchedulerName());
+
+  }
+
+  private static Properties getAirflowProperties() {
+    Properties properties = new Properties();
+    properties.put(AIRFLOW_DAG_ID, "dag_id");
+    properties.put(AIRFLOW_DAG_RUN_EXECUTION_DATE, "dag_run_execution_date");
+    properties.put(AIRFLOW_TASK_ID, "task_id");
+    properties.put(AIRFLOW_TASK_INSTANCE_EXECUTION_DATE, "task_instance_execution_date");
+
+    return properties;
+  }
+
+  private static Properties getPropertiesAndRemove(String key) {
+    Properties properties = getAirflowProperties();
+    properties.remove(key);
+    return properties;
+  }
+
+  private static SchedulerConfigurationData getSchedulerConfData() {
+    return getSchedulerConfData("airflow");
+  }
+
+  private static SchedulerConfigurationData getSchedulerConfData(String name) {
+    Map<String, String> paramMap = new HashMap<String, String>();
+    paramMap.put("airflowbaseurl", "http://localhost:1717");
+    return new SchedulerConfigurationData(name, null, paramMap);
+  }
+}

--- a/test/com/linkedin/drelephant/schedulers/AirflowSchedulerTest.java
+++ b/test/com/linkedin/drelephant/schedulers/AirflowSchedulerTest.java
@@ -30,7 +30,7 @@ public class AirflowSchedulerTest {
     assertEquals("http://localhost:1717/admin/airflow/code?dag_id=dag_id&task_id=task_id", airScheduler.getJobDefUrl());
     assertEquals("dag_id/task_id", airScheduler.getJobDefId());
     assertEquals("http://localhost:1717/admin/airflow/log?dag_id=dag_id&task_id=task_id&execution_date=task_instance_execution_date", airScheduler.getJobExecUrl());
-    assertEquals("dag_id/task_id/task_instance_execution_date", airScheduler.getJobExecId());
+    assertEquals("dag_id/dag_run_execution_date/task_id/task_instance_execution_date", airScheduler.getJobExecId());
 
     assertEquals("task_id", airScheduler.getJobName());
     assertEquals(0, airScheduler.getWorkflowDepth());

--- a/test/com/linkedin/drelephant/schedulers/AzkabanSchedulerTest.java
+++ b/test/com/linkedin/drelephant/schedulers/AzkabanSchedulerTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.drelephant.schedulers;
 
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+
 import java.util.Properties;
 import org.junit.Test;
 
@@ -16,7 +18,7 @@ public class AzkabanSchedulerTest {
   @Test
   public void testAzkabanLoadInfoWithCompleteConf() {
 
-    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", getAzkabanProperties());
+    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", getAzkabanProperties(), getSchedulerConfData());
 
     assertEquals("https://host:9000/manager?project=project-name&flow=flow-name", azkScheduler.getFlowDefUrl());
     assertEquals("https://host:9000/manager?project=project-name&flow=flow-name", azkScheduler.getFlowDefId());
@@ -36,7 +38,7 @@ public class AzkabanSchedulerTest {
   @Test
   public void testAzkabanLoadInfoWithMissingProperty() {
 
-    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", getPropertiesAndRemove(AZKABAN_JOB_URL));
+    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", getPropertiesAndRemove(AZKABAN_JOB_URL), getSchedulerConfData());
 
     assertEquals("https://host:9000/manager?project=project-name&flow=flow-name", azkScheduler.getFlowDefUrl());
     assertEquals("https://host:9000/manager?project=project-name&flow=flow-name", azkScheduler.getFlowDefId());
@@ -56,7 +58,7 @@ public class AzkabanSchedulerTest {
   @Test
   public void testAzkabanLoadInfoWithNullProperty() {
 
-    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", null);
+    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", null, getSchedulerConfData());
 
     assertEquals(null, azkScheduler.getFlowDefUrl());
     assertEquals(null, azkScheduler.getFlowDefId());
@@ -71,6 +73,14 @@ public class AzkabanSchedulerTest {
     assertEquals(null, azkScheduler.getJobName());
     assertEquals(0, azkScheduler.getWorkflowDepth());
     assertEquals("azkaban", azkScheduler.getSchedulerName());
+  }
+
+  @Test
+  public void testAzkabanLoadsNameFromConfData() {
+
+    AzkabanScheduler azkScheduler = new AzkabanScheduler("id", null, getSchedulerConfData("othername"));
+    assertEquals("othername", azkScheduler.getSchedulerName());
+
   }
 
   private static Properties getAzkabanProperties() {
@@ -88,5 +98,13 @@ public class AzkabanSchedulerTest {
     Properties properties = getAzkabanProperties();
     properties.remove(key);
     return properties;
+  }
+
+  private static SchedulerConfigurationData getSchedulerConfData() {
+    return getSchedulerConfData("azkaban");
+  }
+
+  private static SchedulerConfigurationData getSchedulerConfData(String name) {
+    return new SchedulerConfigurationData(name, null, null);
   }
 }

--- a/test/com/linkedin/drelephant/util/InfoExtractorTest.java
+++ b/test/com/linkedin/drelephant/util/InfoExtractorTest.java
@@ -79,7 +79,7 @@ public class InfoExtractorTest {
     assertEquals("airflow_dag_id", scheduler.getFlowDefId());
     assertEquals("airflow_dag_id/airflow_dag_run_execution_date", scheduler.getFlowExecId());
     assertEquals("airflow_dag_id/airflow_task_id", scheduler.getJobDefId());
-    assertEquals("airflow_dag_id/airflow_task_id/airflow_task_instance_execution_date", scheduler.getJobExecId());
+    assertEquals("airflow_dag_id/airflow_dag_run_execution_date/airflow_task_id/airflow_task_instance_execution_date", scheduler.getJobExecId());
     assertEquals("airflow_task_id", scheduler.getJobName());
     assertEquals("airflow", scheduler.getSchedulerName());
   }

--- a/test/com/linkedin/drelephant/util/InfoExtractorTest.java
+++ b/test/com/linkedin/drelephant/util/InfoExtractorTest.java
@@ -16,26 +16,72 @@
 
 package com.linkedin.drelephant.util;
 
+import com.linkedin.drelephant.schedulers.AirflowScheduler;
 import com.linkedin.drelephant.schedulers.AzkabanScheduler;
 import com.linkedin.drelephant.schedulers.Scheduler;
+
 import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import play.test.FakeApplication;
+import play.test.Helpers;
 
 import static org.junit.Assert.assertEquals;
 
 
 public class InfoExtractorTest {
 
+  private FakeApplication app;
+
+  @Before
+  public void startApp() throws Exception {
+    app = Helpers.fakeApplication(Helpers.inMemoryDatabase());
+    Helpers.start(app);
+  }
+
+  @After
+  public void stopApp() throws Exception {
+    Helpers.stop(app);
+  }
+
   @Test
   public void testGetSchedulerInstanceAzkaban() {
     Properties properties = new Properties();
-    properties.put(AzkabanScheduler.AZKABAN_JOB_URL,
-        "https://host:9000/manager?project=project-name&flow=flow-name&job=job-name");
+    properties.put(AzkabanScheduler.AZKABAN_WORKFLOW_URL, "azkaban_workflow_url");
+    properties.put(AzkabanScheduler.AZKABAN_JOB_URL, "azkaba_job_url");
+    properties.put(AzkabanScheduler.AZKABAN_EXECUTION_URL, "azkaban_execution_url");
+    properties.put(AzkabanScheduler.AZKABAN_ATTEMPT_URL, "azkaba_attempt_url");
+    properties.put(AzkabanScheduler.AZKABAN_JOB_NAME, "azkaba_job_name");
 
     Scheduler scheduler = InfoExtractor.getSchedulerInstance("id", properties);
     assertEquals(true, scheduler instanceof AzkabanScheduler);
-    assertEquals("https://host:9000/manager?project=project-name&flow=flow-name&job=job-name", scheduler.getJobDefId());
+    assertEquals("azkaban_workflow_url", scheduler.getFlowDefId());
+    assertEquals("azkaba_job_url", scheduler.getJobDefId());
+    assertEquals("azkaban_execution_url", scheduler.getFlowExecId());
+    assertEquals("azkaba_attempt_url", scheduler.getJobExecId());
+    assertEquals("azkaba_job_name", scheduler.getJobName());
     assertEquals("azkaban", scheduler.getSchedulerName());
+  }
+
+  @Test
+  public void testGetSchedulerInstanceAirflow() {
+    Properties properties = new Properties();
+    properties.put(AirflowScheduler.AIRFLOW_DAG_ID, "airflow_dag_id");
+    properties.put(AirflowScheduler.AIRFLOW_DAG_RUN_EXECUTION_DATE, "airflow_dag_run_execution_date");
+    properties.put(AirflowScheduler.AIRFLOW_TASK_ID, "airflow_task_id");
+    properties.put(AirflowScheduler.AIRFLOW_TASK_INSTANCE_EXECUTION_DATE, "airflow_task_instance_execution_date");
+
+    Scheduler scheduler = InfoExtractor.getSchedulerInstance("id", properties);
+    assertEquals(true, scheduler instanceof AirflowScheduler);
+    assertEquals("airflow_dag_id", scheduler.getFlowDefId());
+    assertEquals("airflow_dag_id/airflow_dag_run_execution_date", scheduler.getFlowExecId());
+    assertEquals("airflow_dag_id/airflow_task_id", scheduler.getJobDefId());
+    assertEquals("airflow_dag_id/airflow_task_id/airflow_task_instance_execution_date", scheduler.getJobExecId());
+    assertEquals("airflow_task_id", scheduler.getJobName());
+    assertEquals("airflow", scheduler.getSchedulerName());
   }
 
   @Test

--- a/test/com/linkedin/drelephant/util/UtilsTest.java
+++ b/test/com/linkedin/drelephant/util/UtilsTest.java
@@ -162,4 +162,10 @@ public class UtilsTest {
     assertEquals(defaultValue, Utils.getNonNegativeLong(conf, "foo6", defaultValue));
     assertEquals(defaultValue, Utils.getNonNegativeLong(conf, "foo7", defaultValue));
   }
+
+  @Test
+  public void testFormatStringOrNull() {
+    assertEquals("Hello world!", Utils.formatStringOrNull("%s %s!", "Hello", "world"));
+    assertEquals(null, Utils.formatStringOrNull("%s %s!", "Hello", null));
+  }
 }

--- a/test/resources/SchedulerConf.xml
+++ b/test/resources/SchedulerConf.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2016 LinkedIn Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!-- Scheduler configurations -->
+<!-- NOTE! THIS IS THE TESTING CONFIGURATION! -->
+<schedulers>
+
+    <scheduler>
+        <name>airflow</name>
+        <classname>com.linkedin.drelephant.schedulers.AirflowScheduler</classname>
+        <params>
+            <airflowbaseurl>http://localhost:8000</airflowbaseurl>
+        </params>
+    </scheduler>
+
+    <scheduler>
+        <name>azkaban</name>
+        <classname>com.linkedin.drelephant.schedulers.AzkabanScheduler</classname>
+    </scheduler>
+
+</schedulers>

--- a/test/resources/configurations/scheduler/SchedulerConfTest1.xml
+++ b/test/resources/configurations/scheduler/SchedulerConfTest1.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2016 LinkedIn Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<schedulers>
+
+    <scheduler>
+        <name>airflow</name>
+        <classname>com.linkedin.drelephant.schedulers.AirflowScheduler</classname>
+        <params>
+            <airflowbaseurl>http://localhost:8000</airflowbaseurl>
+        </params>
+    </scheduler>
+
+    <scheduler>
+        <name>azkaban</name>
+        <classname>com.linkedin.drelephant.schedulers.AzkabanScheduler</classname>
+    </scheduler>
+
+</schedulers>

--- a/test/resources/configurations/scheduler/SchedulerConfTest2.xml
+++ b/test/resources/configurations/scheduler/SchedulerConfTest2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2016 LinkedIn Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<schedulers>
+
+    <scheduler>
+        <name>airflow</name>
+        <params>
+            <airflowbaseurl>http://localhost:8000</airflowbaseurl>
+        </params>
+    </scheduler>
+
+    <scheduler>
+        <name>azkaban</name>
+        <classname>com.linkedin.drelephant.schedulers.AzkabanScheduler</classname>
+    </scheduler>
+
+</schedulers>

--- a/test/resources/configurations/scheduler/SchedulerConfTest3.xml
+++ b/test/resources/configurations/scheduler/SchedulerConfTest3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2016 LinkedIn Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<schedulers>
+
+    <scheduler>
+        <name>airflow</name>
+        <classname>com.linkedin.drelephant.schedulers.AirflowScheduler</classname>
+        <params>
+            <airflowbaseurl>http://localhost:8000</airflowbaseurl>
+        </params>
+    </scheduler>
+
+    <scheduler>
+        <classname>com.linkedin.drelephant.schedulers.AzkabanScheduler</classname>
+    </scheduler>
+
+</schedulers>


### PR DESCRIPTION
This commit gives Dr. Elephant the ability to ingest Airflow data in the same way it reads Azkaban data! It also makes adding additional schedulers in the future more inline with other stuff that is configurable in Dr. Elephant (i.e. there is a conf file). This PR also includes tests for the new Airflow capabilities.

I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.
@krishnap @plypaul @hongbozeng @liyintang @brandtg @timyitong

Note: This requires that your version of Airflow include the patch in this PR: https://github.com/apache/incubator-airflow/pull/1607. Currently only the Hive operator is supported but there is planned support for additional operators in the near future.