### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ jdk:
   - oraclejdk7
   - openjdk6
 
+# only build PRs and master (not all branch pushes)
+branches:
+  only:
+    - master
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: scala
+sudo: false
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk7
+  - openjdk6
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Dr. Elephant
 
+
+[![Build Status](https://api.travis-ci.org/linkedin/dr-elephant.svg)](https://travis-ci.org/linkedin/dr-elephant/)
+
 <a href=""><img src="images/wiki/dr-elephant-logo-150x150.png" align="left" hspace="10" vspace="6"></a>
 
 **Dr. Elephant** is a performance monitoring and tuning tool for Hadoop and Spark. It automatically gathers all the metrics, runs analysis on them, and presents them in a simple way for easy consumption. Its goal is to improve developer productivity and increase cluster efficiency by making it easier to tune the jobs. It analyzes the Hadoop and Spark jobs using a set of pluggable, configurable, rule-based heuristics that provide insights on how a job performed, and then uses the results to make suggestions about how to tune the job to make it perform more efficiently.


### PR DESCRIPTION
This should fix the problem of supporting multiple Java versions. Any others I should add?

Checkout https://github.com/paulbramsen/dr-elephant/pull/1 and click "Show all checks" for an example of what things will look like.

Note: a Github admin will need to visit https://travis-ci.org/linkedin/dr-elephant/ and click activate project.