### PR TITLE
Make default container mem configurable

### DIFF
--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -84,6 +84,7 @@
     <!--<params>
       <container_memory_severity>1, 1.5, 2, 2.5</container_memory_severity>
       <memory_ratio_severity>0.6, 0.5, 0.4, 0.3</memory_ratio_severity>
+      <container_memory_default_mb>2048</container_memory_default_mb>
     </params>-->
   </heuristic>
 
@@ -130,6 +131,7 @@
     <!--<params>
       <container_memory_severity>1, 1.5, 2, 2.5</container_memory_severity>
       <memory_ratio_severity>0.6, 0.5, 0.4, 0.3</memory_ratio_severity>
+      <container_memory_default_mb>2048</container_memory_default_mb>
     </params>-->
   </heuristic>
 

--- a/app/com/linkedin/drelephant/mapreduce/heuristics/GenericMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/mapreduce/heuristics/GenericMemoryHeuristic.java
@@ -39,7 +39,7 @@ import org.apache.log4j.Logger;
  */
 public abstract class GenericMemoryHeuristic implements Heuristic<MapReduceApplicationData> {
   private static final Logger logger = Logger.getLogger(GenericMemoryHeuristic.class);
-  private static final long CONTAINER_MEMORY_DEFAULT_BYTES_DEFAULT = 2048L * FileUtils.ONE_MB;
+  private static final long CONTAINER_MEMORY_DEFAULT_BYTES = 2048L * FileUtils.ONE_MB;
 
   // Severity Parameters
   private static final String MEM_RATIO_SEVERITY = "memory_ratio_severity";
@@ -64,7 +64,7 @@ public abstract class GenericMemoryHeuristic implements Heuristic<MapReduceAppli
     logger.info(heuristicName + " will use " + MEM_RATIO_SEVERITY + " with the following threshold settings: "
         + Arrays.toString(memRatioLimits));
 
-    long containerMemDefaultBytes = CONTAINER_MEMORY_DEFAULT_BYTES_DEFAULT;
+    long containerMemDefaultBytes = CONTAINER_MEMORY_DEFAULT_BYTES;
     if (paramMap.containsKey(CONTAINER_MEM_DEFAULT_MB)) {
       containerMemDefaultBytes = Long.valueOf(paramMap.get(CONTAINER_MEM_DEFAULT_MB)) * FileUtils.ONE_MB;
     }

--- a/app/com/linkedin/drelephant/mapreduce/heuristics/GenericMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/mapreduce/heuristics/GenericMemoryHeuristic.java
@@ -39,11 +39,12 @@ import org.apache.log4j.Logger;
  */
 public abstract class GenericMemoryHeuristic implements Heuristic<MapReduceApplicationData> {
   private static final Logger logger = Logger.getLogger(GenericMemoryHeuristic.class);
-  private static final long CONTAINER_MEMORY_DEFAULT_BYTES = 2048L * FileUtils.ONE_MB;
+  private static final long CONTAINER_MEMORY_DEFAULT_BYTES_DEFAULT = 2048L * FileUtils.ONE_MB;
 
   // Severity Parameters
   private static final String MEM_RATIO_SEVERITY = "memory_ratio_severity";
   private static final String CONTAINER_MEM_SEVERITY = "container_memory_severity";
+  private static final String CONTAINER_MEM_DEFAULT_MB = "container_memory_default_mb";
 
   // Default value of parameters
   private double[] memRatioLimits = {0.6d, 0.5d, 0.4d, 0.3d}; // Avg Physical Mem of Tasks / Container Mem
@@ -63,6 +64,13 @@ public abstract class GenericMemoryHeuristic implements Heuristic<MapReduceAppli
     logger.info(heuristicName + " will use " + MEM_RATIO_SEVERITY + " with the following threshold settings: "
         + Arrays.toString(memRatioLimits));
 
+    long containerMemDefaultBytes = CONTAINER_MEMORY_DEFAULT_BYTES_DEFAULT;
+    if (paramMap.containsKey(CONTAINER_MEM_DEFAULT_MB)) {
+      containerMemDefaultBytes = Long.valueOf(paramMap.get(CONTAINER_MEM_DEFAULT_MB)) * FileUtils.ONE_MB;
+    }
+    logger.info(heuristicName + " will use " + CONTAINER_MEM_DEFAULT_MB + " with the following setting: "
+            + containerMemDefaultBytes);
+
     double[] confMemoryLimits = Utils.getParam(paramMap.get(CONTAINER_MEM_SEVERITY), memoryLimits.length);
     if (confMemoryLimits != null) {
       memoryLimits = confMemoryLimits;
@@ -70,7 +78,7 @@ public abstract class GenericMemoryHeuristic implements Heuristic<MapReduceAppli
     logger.info(heuristicName + " will use " + CONTAINER_MEM_SEVERITY + " with the following threshold settings: "
         + Arrays.toString(memoryLimits));
     for (int i = 0; i < memoryLimits.length; i++) {
-      memoryLimits[i] = memoryLimits[i] * CONTAINER_MEMORY_DEFAULT_BYTES;
+      memoryLimits[i] = memoryLimits[i] * containerMemDefaultBytes;
     }
   }
 

--- a/app/com/linkedin/drelephant/mapreduce/heuristics/GenericMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/mapreduce/heuristics/GenericMemoryHeuristic.java
@@ -68,7 +68,7 @@ public abstract class GenericMemoryHeuristic implements Heuristic<MapReduceAppli
     if (paramMap.containsKey(CONTAINER_MEM_DEFAULT_MB)) {
       containerMemDefaultBytes = Long.valueOf(paramMap.get(CONTAINER_MEM_DEFAULT_MB)) * FileUtils.ONE_MB;
     }
-    logger.info(heuristicName + " will use " + CONTAINER_MEM_DEFAULT_MB + " with the following setting: "
+    logger.info(heuristicName + " will use " + CONTAINER_MEM_DEFAULT_MB + " with the following threshold setting: "
             + containerMemDefaultBytes);
 
     double[] confMemoryLimits = Utils.getParam(paramMap.get(CONTAINER_MEM_SEVERITY), memoryLimits.length);


### PR DESCRIPTION
Not everyone uses a 2GB default container size. This makes that property easily configurable in `HeuristicConf.xml`.

I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.
@krishnap