### PR TITLE
Fix job history page tab highlighting

### DIFF
--- a/app/views/page/jobHistoryPage.scala.html
+++ b/app/views/page/jobHistoryPage.scala.html
@@ -16,7 +16,7 @@
 
 @(results: Html)
 
-@main("Dr. Elephant - Job History", "jobHistory") {
+@main("Dr. Elephant - Job History", "jobhistory") {
 
   <!-- The Search panel-->
   @tags.column(12) {


### PR DESCRIPTION
The job history page tab doesn't highlight when you are on that page. This PR fixes the problem.

@krishnap