### PR TITLE
Automatically delete old data

### DIFF
--- a/app-conf/GeneralConf.xml
+++ b/app-conf/GeneralConf.xml
@@ -37,9 +37,9 @@
     <value>true</value>
     <description>If this property is "false", search will only make exact matches</description>
   </property>
-  <property>
-    <name>drelephant.data.days.to.keep</name>
+  <!--<property>
+    <!name>drelephant.data.days.to.keep</name>
     <value>14</value>
     <description>If this property is defined and positive, data more than value days old will be thrown out</description>
-  </property>
+  </property>-->
 </configuration>

--- a/app-conf/GeneralConf.xml
+++ b/app-conf/GeneralConf.xml
@@ -37,4 +37,9 @@
     <value>true</value>
     <description>If this property is "false", search will only make exact matches</description>
   </property>
+  <property>
+    <name>drelephant.data.days.to.keep</name>
+    <value>14</value>
+    <description>If this property is defined and positive, data more than value days old will be thrown out</description>
+  </property>
 </configuration>

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -201,7 +201,7 @@ public class Application extends Controller {
     IdUrlPair schedulerInfoPair;
     // check for exact match
     schedulerInfoPair = bestSchedulerInfoMatchLikeValue(partialSchedulerInfoId, schedulerInfoIdField);
-    // check for suffix match if feature isn't disabled
+    // check for prefix match if feature isn't disabled
     if (schedulerInfoPair == null && ElephantContext.instance().getGeneralConf().getBoolean(SEARCH_MATCHES_PARTIAL_CONF, true)) {
       schedulerInfoPair = bestSchedulerInfoMatchLikeValue(String.format("%s%%", partialSchedulerInfoId), schedulerInfoIdField);
     }

--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -1,0 +1,14 @@
+# --- Cascade deletes to make dropping data easier (1 step instead of 3)
+# --- !Ups
+
+ALTER TABLE yarn_app_heuristic_result DROP FOREIGN KEY yarn_app_heuristic_result_f1;
+ALTER TABLE yarn_app_heuristic_result ADD CONSTRAINT yarn_app_heuristic_result_f1 FOREIGN KEY (yarn_app_result_id) REFERENCES yarn_app_result (id) ON DELETE CASCADE;
+ALTER TABLE yarn_app_heuristic_result_details DROP FOREIGN KEY  yarn_app_heuristic_result_details_f1;
+ALTER TABLE yarn_app_heuristic_result_details ADD CONSTRAINT yarn_app_heuristic_result_details_f1 FOREIGN KEY (yarn_app_heuristic_result_id) REFERENCES yarn_app_heuristic_result (id) ON DELETE CASCADE;
+
+# --- !Downs
+
+ALTER TABLE yarn_app_heuristic_result DROP FOREIGN KEY  yarn_app_heuristic_result_f1;
+ALTER TABLE yarn_app_heuristic_result ADD CONSTRAINT yarn_app_heuristic_result_f1 FOREIGN KEY (yarn_app_result_id) REFERENCES yarn_app_result (id);
+ALTER TABLE yarn_app_heuristic_result_details DROP FOREIGN KEY  yarn_app_heuristic_result_details_f1;
+ALTER TABLE yarn_app_heuristic_result_details ADD CONSTRAINT yarn_app_heuristic_result_details_f1 FOREIGN KEY (yarn_app_heuristic_result_id) REFERENCES yarn_app_heuristic_result (id);


### PR DESCRIPTION
This PR allows users to specify a cutoff date after which old data will be thrown out in order to keep things performant/avoid accumulating too much data. This feature is disabled by default.

I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.
@krishnap
