### PR TITLE
LIHADOOP-21568: Add Dropwizard metrics to Dr. Elephant

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -67,6 +67,9 @@ This product includes/uses Mockito (http://mockito.org)
 Copyright (c) 2007 Mockito contributors
 License: The MIT License (https://github.com/mockito/mockito/blob/master/LICENSE)
 
+This product includes/uses Metrics (http://metrics.dropwizard.io/)
+Copyright 2010-2014, Coda Hale, Yammer Inc.. Created using Sphinx 1.4.1.
+License: Apache 2.0 (https://github.com/dropwizard/metrics/blob/master/LICENSE)
 ------------------------------------------------------------------------------
 Attribution for JavaScript Libraries
 ------------------------------------------------------------------------------

--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -28,3 +28,12 @@ enable_analytics=false
 # Additional Configuration
 # Check https://www.playframework.com/documentation/2.2.x/ProductionConfiguration
 jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
+
+# Property enables dropwizard metrics for the application.
+# More info on Dropwizard metrics at http://metrics.dropwizard.io
+# By default metrics are turned which provides several useful stats for
+# the application. The following endpoints can be queried once the application is up.
+#   /ping
+#   /healthcheck
+#   /metrics
+metrics=true

--- a/app/com/linkedin/drelephant/ElephantRunner.java
+++ b/app/com/linkedin/drelephant/ElephantRunner.java
@@ -23,6 +23,7 @@ import com.linkedin.drelephant.analysis.HadoopSystemContext;
 import com.linkedin.drelephant.analysis.AnalyticJobGeneratorHadoop2;
 
 import com.linkedin.drelephant.security.HadoopSecurity;
+import controllers.MetricsController;
 import java.io.IOException;
 import java.security.PrivilegedAction;
 import java.util.List;
@@ -106,6 +107,10 @@ public class ElephantRunner implements Runnable {
           ElephantContext.init();
 
           _jobQueue = new LinkedBlockingQueue<AnalyticJob>();
+
+          // Initialize the metrics registries.
+          MetricsController.init();
+
           logger.info("executor num is " + _executorNum);
           if (_executorNum > 0) {
             _service = Executors.newFixedThreadPool(_executorNum);
@@ -140,7 +145,10 @@ public class ElephantRunner implements Runnable {
             }
 
             _jobQueue.addAll(todos);
-            logger.info("Job queue size is " + _jobQueue.size());
+
+            int queueSize = _jobQueue.size();
+            MetricsController.setQueueSize(queueSize);
+            logger.info("Job queue size is " + queueSize);
 
             //Wait for a while before next fetch
             waitInterval(_fetchInterval);
@@ -187,6 +195,7 @@ public class ElephantRunner implements Runnable {
             _analyticJobGenerator.addIntoRetries(analyticJob);
           } else {
             if (analyticJob != null) {
+              MetricsController.markSkippedJob();
               logger.error("Drop the analytic job. Reason: reached the max retries for application id = ["
                       + analyticJob.getAppId() + "].");
             }

--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -18,6 +18,7 @@ package com.linkedin.drelephant.analysis;
 
 import com.linkedin.drelephant.ElephantContext;
 import com.linkedin.drelephant.math.Statistics;
+import controllers.MetricsController;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -159,6 +160,9 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
   @Override
   public void addIntoRetries(AnalyticJob promise) {
     _retryQueue.add(promise);
+    int retryQueueSize = _retryQueue.size();
+    MetricsController.setRetryQueueSize(retryQueueSize);
+    logger.info("Retry queue size is " + retryQueueSize);
   }
 
   /**

--- a/app/com/linkedin/drelephant/metrics/CustomGarbageCollectorMetricSet.java
+++ b/app/com/linkedin/drelephant/metrics/CustomGarbageCollectorMetricSet.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+
+/**
+ * This class adds couple of custom guages apart from the ones
+ * implemented in <code>com.codahale.metrics.jvm.GarbageCollectorMetricSet</code>.
+ *
+ * <br><br>
+ * The following custom guages are added.
+ * <ul>jvmUptime - The time since the JVM was started.</ul>
+ * <ul>gc2UptimeRatio - The ratio of GC collection times to JVM uptime. Collection
+ * times for both young gen and perm gen are counted.</ul>
+ */
+public class CustomGarbageCollectorMetricSet implements MetricSet {
+  private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+
+  private final List<GarbageCollectorMXBean> garbageCollectors;
+
+  /**
+   * Creates a new set of gauges for all discoverable garbage collectors.
+   */
+  public CustomGarbageCollectorMetricSet() {
+    this(ManagementFactory.getGarbageCollectorMXBeans());
+  }
+
+  /**
+   * Creates a new set of gauges for the given collection of garbage collectors.
+   *
+   * @param garbageCollectors    the garbage collectors
+   */
+  public CustomGarbageCollectorMetricSet(Collection<GarbageCollectorMXBean> garbageCollectors) {
+    this.garbageCollectors = new ArrayList<GarbageCollectorMXBean>(garbageCollectors);
+  }
+
+  /**
+   * @return Returns a map of defined gauges.
+   */
+  @Override
+  public Map<String, Metric> getMetrics() {
+    final Map<String, Metric> gauges = new HashMap<String, Metric>();
+
+    long cumulativeGCTime = 0L;
+
+    for (final GarbageCollectorMXBean gc : garbageCollectors) {
+      final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-");
+
+      gauges.put(name(name, "count"), new Gauge<Long>() {
+        @Override
+        public Long getValue() {
+          return gc.getCollectionCount();
+        }
+      });
+
+      gauges.put(name(name, "time"), new Gauge<Long>() {
+        @Override
+        public Long getValue() {
+          return gc.getCollectionTime();
+        }
+      });
+
+      cumulativeGCTime += gc.getCollectionTime();
+    }
+
+    final long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
+    final Double gc2UptimeRatio = (double)cumulativeGCTime / uptime;
+
+    gauges.put("jvmUptime", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return uptime;
+      }
+    });
+
+    gauges.put("gc2UptimeRatio", new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return gc2UptimeRatio;
+      }
+    });
+
+    return Collections.unmodifiableMap(gauges);
+  }
+}

--- a/app/controllers/MetricsController.java
+++ b/app/controllers/MetricsController.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package controllers;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.health.jvm.ThreadDeadlockHealthCheck;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.linkedin.drelephant.analysis.AnalyticJob;
+import com.linkedin.drelephant.metrics.CustomGarbageCollectorMetricSet;
+import org.apache.log4j.Logger;
+import play.Configuration;
+import play.libs.Json;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+
+/**
+ * This class enables the use of <a href="http://metrics.dropwizard.io">Dropwizard</a>
+ * metrics for the application.
+ *
+ * <br><br>
+ * The following endpoints are exposed.
+ * <ul>/ping - Reports application status if up</ul>
+ * <ul>/healthcheck - Returns status in Json format from all the implemented healthchecks</ul>
+ * <ul>/metrics - Returns all the metrics in Json format</ul>
+ */
+public class MetricsController extends Controller {
+  private static final Logger LOGGER = Logger.getLogger(MetricsController.class);
+
+  private static MetricRegistry metricRegistry = null;
+  private static HealthCheckRegistry healthCheckRegistry = null;
+
+  private static final String METRICS_NOT_ENABLED = "Metrics not enabled";
+  private static final String HEALTHCHECK_NOT_ENABLED = "Healthcheck not enabled";
+  private static final String UNINITIALIZED_MESSAGE =
+      "Metrics should be initialized before use.";
+
+  private static int _queueSize = -1;
+  private static int _retryQueueSize = -1;
+  private static Meter skippedJobs;
+
+  /**
+   * Initializer method for the metrics registry. Call this method before registering
+   * new metrics with the registry.
+   */
+  public static void init() {
+    // Metrics registries will be initialized only if enabled
+    if(!Configuration.root().getBoolean("metrics")) {
+      LOGGER.debug("Metrics not enabled in the conf file.");
+      return;
+    }
+
+    // Metrics & healthcheck registries will be initialized only once
+    if(metricRegistry != null) {
+      LOGGER.debug("Metric registries already initialized.");
+      return;
+    }
+
+    metricRegistry = new MetricRegistry();
+
+    String className = AnalyticJob.class.getSimpleName();
+
+    metricRegistry.meter(name(className, "skippedJobs", "count"));
+
+    metricRegistry.register(name(className, "jobQueue", "size"), new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return _queueSize;
+      }
+    });
+
+    metricRegistry.register(name(className, "retryQueue", "size"), new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return _retryQueueSize;
+      }
+    });
+
+    metricRegistry.registerAll(new CustomGarbageCollectorMetricSet());
+    metricRegistry.registerAll(new MemoryUsageGaugeSet());
+
+    JmxReporter.forRegistry(metricRegistry).build().start();
+
+    healthCheckRegistry = new HealthCheckRegistry();
+
+    healthCheckRegistry.register("ThreadDeadlockHealthCheck",
+        new ThreadDeadlockHealthCheck());
+  }
+
+  /**
+   *
+   * @param name to be used while registering the timer.
+   * @return Returns <code> Timer.Context </code> if metrics is enabled
+   * and <code>null</code> otherwise.
+   */
+  public static Timer.Context startTimer(String name) {
+    if(metricRegistry != null) {
+      return metricRegistry.timer(name).time();
+    } else {
+      throw new NullPointerException(UNINITIALIZED_MESSAGE);
+    }
+  }
+
+  /**
+   *
+   * @return The <code>MetricRegistry</code> if initialized.
+   */
+  public static MetricRegistry getMetricRegistry() {
+    if (metricRegistry != null) {
+      return metricRegistry;
+    } else {
+      throw new NullPointerException(UNINITIALIZED_MESSAGE);
+    }
+  }
+
+  /**
+   * Set the current job queue size in the metric registry.
+   * @param size
+   */
+  public static void setQueueSize(int size) {
+    _queueSize = size;
+  }
+
+  /**
+   * Set the retry job queue size in the metric registry.
+   * @param retryQueueSize
+   */
+  public static void setRetryQueueSize(int retryQueueSize) {
+    _retryQueueSize = retryQueueSize;
+  }
+
+  /**
+   * A meter for marking skipped jobs.
+   * Jobs which doesn't have any data or which exceeds the set number of
+   * retries can be marked as skipped.
+   */
+  public static void markSkippedJob() {
+    skippedJobs.mark();
+  }
+
+  /**
+   * The endpoint /ping
+   * Ping will respond with the message 'alive' if the application is running.
+   *
+   * @return Will return 'alive' if Dr. Elephant is Up.
+   */
+  public static Result ping() {
+    return ok(Json.toJson("alive"));
+  }
+
+  /**
+   * The endpoint /metrics
+   * Endpoint can be queried if metrics is enabled.
+   *
+   * @return Will return all the metrics in Json format.
+   */
+  public static Result index() {
+    if (metricRegistry != null) {
+      return ok(Json.toJson(metricRegistry));
+    } else {
+      return ok(Json.toJson(METRICS_NOT_ENABLED));
+    }
+  }
+
+  /**
+   * The endpoint /healthcheck
+   * Endpoint can be queried if metrics is enabled.
+   *
+   * @return Will return all the healthcheck metrics in Json format.
+   */
+  public static Result healthcheck() {
+    if (healthCheckRegistry != null) {
+      return ok(Json.toJson(healthCheckRegistry.runHealthChecks()));
+    } else {
+      return ok(Json.toJson(HEALTHCHECK_NOT_ENABLED));
+    }
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -35,6 +35,10 @@ GET     /rest/compare               controllers.Application.restCompare()
 GET     /rest/flowgraphdata         controllers.Application.restFlowGraphData(id: String)
 GET     /rest/jobgraphdata          controllers.Application.restJobGraphData(id: String)
 
+# Metrics calls
+GET     /ping                       controllers.MetricsController.ping()
+GET     /metrics                    controllers.MetricsController.index()
+GET     /healthcheck                controllers.MetricsController.healthcheck()
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,6 +70,8 @@ object Dependencies {
     "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion % Test,
     "org.codehaus.jackson" % "jackson-mapper-asl" % jacksonMapperAslVersion,
     "org.jsoup" % "jsoup" % jsoupVersion,
+    "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
+    "io.dropwizard.metrics" % "metrics-healthchecks" % "3.1.2",
     "org.mockito" % "mockito-core" % "1.10.19",
     "org.jmockit" % "jmockit" % "1.23" % Test
   ) :+ sparkExclusion 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -116,6 +116,11 @@ if [ -n "${enable_analytics}" ]; then
   OPTS+=" -Denable.analytics=$enable_analytics"
 fi
 
+# Enable Dropwizard metrics if configured
+if [ -n "${metrics}" ]; then
+  OPTS+=" -Dmetrics=$metrics"
+fi
+
 # Navigate to project root
 cd $project_root
 


### PR DESCRIPTION
Added Dropwizard metrics to Dr. Elephant. This change enables metrics by default.

Following endpoints are exposed
	1) /ping
	2) /healthcheck
	3) /metrics

Following stats are available at present
  1. Application status - /ping
  2. Queue Size
  3. Skipped Jobs Count
  4. Retry Queue Size
  5. Thread Deadlocks - /healthcheck
  6. GC Count
  7. GC Time
  8. GC Count to JVM Uptime ratio
  9. Heap Memory Usage stats