### PR TITLE
Add JAVA_OPTS env var export to start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -155,6 +155,9 @@ OPTS+=" $jvm_args -Djava.library.path=$JAVA_LIB_PATH"
 OPTS+=" -Dhttp.port=$port"
 OPTS+=" -Ddb.default.url=$db_loc -Ddb.default.user=$db_user -Ddb.default.password=$db_password"
 
+# set Java related options (e.g. -Xms1024m -Xmx1024m)
+export JAVA_OPTS="-XX:+HeapDumpOnOutOfMemoryError"
+
 # Start Dr. Elaphant
 echo "Starting Dr. Elephant ...."
 nohup ./bin/dr-elephant ${OPTS} > $project_root/dr.log 2>&1 &


### PR DESCRIPTION
It took me a while to figure out how to configure java options so thought I would share this. Also, I think it would be helpful to enable heap dump on OOM by default for future debugging.
