### PR TITLE
Fix sync issue in info extractor

### DIFF
--- a/app/com/linkedin/drelephant/util/InfoExtractor.java
+++ b/app/com/linkedin/drelephant/util/InfoExtractor.java
@@ -55,7 +55,7 @@ public class InfoExtractor {
    * Load all the schedulers configured in SchedulerConf.xml
    */
 
-  private static void loadSchedulers() {
+  private synchronized static void loadSchedulers() {
     Document document = Utils.loadXMLDoc(SCHEDULER_CONF);
     _schedulerConfData = new SchedulerConfiguration(document.getDocumentElement()).getSchedulerConfigurationData();
     for (SchedulerConfigurationData data : _schedulerConfData) {

--- a/app/com/linkedin/drelephant/util/InfoExtractor.java
+++ b/app/com/linkedin/drelephant/util/InfoExtractor.java
@@ -49,16 +49,15 @@ public class InfoExtractor {
 
   private static final String SCHEDULER_CONF = "SchedulerConf.xml";
 
-  private static List<SchedulerConfigurationData> _schedulerConfData;
+  private static final List<SchedulerConfigurationData> _configuredSchedulers;
 
   /**
    * Load all the schedulers configured in SchedulerConf.xml
    */
-
-  private synchronized static void loadSchedulers() {
+  static {
     Document document = Utils.loadXMLDoc(SCHEDULER_CONF);
-    _schedulerConfData = new SchedulerConfiguration(document.getDocumentElement()).getSchedulerConfigurationData();
-    for (SchedulerConfigurationData data : _schedulerConfData) {
+    _configuredSchedulers = new SchedulerConfiguration(document.getDocumentElement()).getSchedulerConfigurationData();
+    for (SchedulerConfigurationData data : _configuredSchedulers) {
       logger.info(String.format("Load Scheduler %s with class : %s", data.getSchedulerName(), data.getClassName()));
     }
   }
@@ -71,11 +70,8 @@ public class InfoExtractor {
    * @return the corresponding Scheduler which scheduled the job.
    */
   public static Scheduler getSchedulerInstance(String appId, Properties properties) {
-    if (_schedulerConfData == null) {
-      loadSchedulers();
-    }
     if (properties != null) {
-      for (SchedulerConfigurationData data : _schedulerConfData) {
+      for (SchedulerConfigurationData data : _configuredSchedulers) {
         try {
           Class<?> schedulerClass = Play.current().classloader().loadClass(data.getClassName());
           Object instance = schedulerClass.getConstructor(String.class, Properties.class, SchedulerConfigurationData.class).newInstance(appId, properties, data);


### PR DESCRIPTION
I noticed some weird log output and realized that `InfoExtractor` was duplicating some of its loading work because of not being properly synchronized. This fixes that issue.

I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.

@krishnap