### PR TITLE
Add default for boolean unboxing

### DIFF
--- a/app/controllers/MetricsController.java
+++ b/app/controllers/MetricsController.java
@@ -66,7 +66,7 @@ public class MetricsController extends Controller {
    */
   public static void init() {
     // Metrics registries will be initialized only if enabled
-    if(!Configuration.root().getBoolean("metrics")) {
+    if(!Configuration.root().getBoolean("metrics", false)) {
       LOGGER.debug("Metrics not enabled in the conf file.");
       return;
     }


### PR DESCRIPTION
Without a default value, if the Boolean object couldn't find a metrics setting (i.e. it's not defined in someone's `elephant.conf`) `null` is returned. Then, the jvm attemtpts to autounbox `null` in order to evaluate the boolean expression. Instead of causing the expression to evaluate to false as one would expect, this results in a `NullPointerException` being thrown which crashes the main processing thread (i.e. the web ui will continue to run but no new data will be ingested).

@krishnap