### PR TITLE
Show result count in search

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -272,7 +272,7 @@ public class Application extends Controller {
     if (results.isEmpty() || currentPage > paginationStats.computePaginationBarEndIndex(results.size())) {
       return ok(searchPage.render(null, jobDetails.render(null)));
     } else {
-      return ok(searchPage.render(paginationStats, searchResults.render("Results",
+      return ok(searchPage.render(paginationStats, searchResults.render(String.format("%,d results", query.findRowCount()),
           results.subList((currentPage - paginationBarStartIndex) * pageLength,
               Math.min(results.size(), (currentPage - paginationBarStartIndex + 1) * pageLength)))));
     }

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -272,9 +272,10 @@ public class Application extends Controller {
     if (results.isEmpty() || currentPage > paginationStats.computePaginationBarEndIndex(results.size())) {
       return ok(searchPage.render(null, jobDetails.render(null)));
     } else {
-      return ok(searchPage.render(paginationStats, searchResults.render(String.format("%,d results", query.findRowCount()),
-          results.subList((currentPage - paginationBarStartIndex) * pageLength,
-              Math.min(results.size(), (currentPage - paginationBarStartIndex + 1) * pageLength)))));
+      List<AppResult> resultsToDisplay = results.subList((currentPage - paginationBarStartIndex) * pageLength,
+              Math.min(results.size(), (currentPage - paginationBarStartIndex + 1) * pageLength));
+      return ok(searchPage.render(paginationStats, searchResults.render(
+              String.format("Results: Showing %,d of %,d", resultsToDisplay.size(), query.findRowCount()), resultsToDisplay)));
     }
   }
 


### PR DESCRIPTION
We've found having search result counts on the search page to be quite useful.

I tested this on CDH 5.3 with MapReduce 2.5.0 and Spark 1.5.2.
@krishnap