### PR TITLE
Make dashboard text more accurate

### DIFF
--- a/app/views/page/homePage.scala.html
+++ b/app/views/page/homePage.scala.html
@@ -31,7 +31,7 @@
   <p>I've looked through <b>@("%,d".format(numJobsAnalyzedLastDay))</b> jobs that have finished in the last 24 hours.<br>
     Of those, about <b>@("%,d".format(numJobsSevere))</b> could use some tuning<br>
     and <b>@("%,d".format(numJobsCritical))</b> need some serious attention.<br>
-    I've looked through <b>@("%,d".format(numJobsAnalyzedAllTime))</b> jobs in all time.
+    I have <b>@("%,d".format(numJobsAnalyzedAllTime))</b> processed jobs in my database.
   </p>
 </div>
 @results

--- a/app/views/page/homePage.scala.html
+++ b/app/views/page/homePage.scala.html
@@ -28,7 +28,7 @@
 @main("Dr. Elephant", "dashboard") {
 <div class="jumbotron">
   <h2>Hello there, I've been busy!</h2>
-  <p>I've looked through <b>@("%,d".format(numJobsAnalyzedLastDay))</b> jobs that finished in the last 24 hours.<br>
+  <p>I've looked at <b>@("%,d".format(numJobsAnalyzedLastDay))</b> jobs that finished in the last 24 hours.<br>
     Of those, about <b>@("%,d".format(numJobsSevere))</b> could use some tuning (severe)<br>
     and <b>@("%,d".format(numJobsCritical))</b> need some serious attention (critical).<br>
     I have <b>@("%,d".format(numJobsAnalyzedAllTime))</b> processed jobs in my database.

--- a/app/views/page/homePage.scala.html
+++ b/app/views/page/homePage.scala.html
@@ -14,7 +14,7 @@
 * the License.
 *@
 
-@(numJobsAnalyzed: Int, numJobsSevere: Int, numJobsCritical: Int)(results: Html)
+@(numJobsAnalyzedLastDay: Int, numJobsAnalyzedAllTime: Int, numJobsSevere: Int, numJobsCritical: Int)(results: Html)
 
 @*
 * The layout of the homepage of Dr. Elephant or the dashboard
@@ -26,12 +26,13 @@
 *@
 
 @main("Dr. Elephant", "dashboard") {
-  <div class="jumbotron">
-    <h2>Hello there, I've been busy!</h2>
-    <p>I looked through <b>@numJobsAnalyzed</b> jobs today.<br>
-      About <b>@numJobsSevere</b> of them could use some tuning.<br>
-      About <b>@numJobsCritical</b> of them need some serious attention!
-    </p>
-  </div>
-  @results
+<div class="jumbotron">
+  <h2>Hello there, I've been busy!</h2>
+  <p>I've looked through <b>@("%,d".format(numJobsAnalyzedLastDay))</b> jobs that have finished in the last 24 hours.<br>
+    Of those, about <b>@("%,d".format(numJobsSevere))</b> could use some tuning<br>
+    and <b>@("%,d".format(numJobsCritical))</b> need some serious attention.<br>
+    I've looked through <b>@("%,d".format(numJobsAnalyzedAllTime))</b> jobs in all time.
+  </p>
+</div>
+@results
 }

--- a/app/views/page/homePage.scala.html
+++ b/app/views/page/homePage.scala.html
@@ -28,9 +28,9 @@
 @main("Dr. Elephant", "dashboard") {
 <div class="jumbotron">
   <h2>Hello there, I've been busy!</h2>
-  <p>I've looked through <b>@("%,d".format(numJobsAnalyzedLastDay))</b> jobs that have finished in the last 24 hours.<br>
-    Of those, about <b>@("%,d".format(numJobsSevere))</b> could use some tuning<br>
-    and <b>@("%,d".format(numJobsCritical))</b> need some serious attention.<br>
+  <p>I've looked through <b>@("%,d".format(numJobsAnalyzedLastDay))</b> jobs that finished in the last 24 hours.<br>
+    Of those, about <b>@("%,d".format(numJobsSevere))</b> could use some tuning (severe)<br>
+    and <b>@("%,d".format(numJobsCritical))</b> need some serious attention (critical).<br>
     I have <b>@("%,d".format(numJobsAnalyzedAllTime))</b> processed jobs in my database.
   </p>
 </div>

--- a/test/controllers/ApplicationTest.java
+++ b/test/controllers/ApplicationTest.java
@@ -41,7 +41,7 @@ public class ApplicationTest {
     Content html = homePage.render(5, 1717, 2, 3, searchResults.render("Latest analysis", null));
     assertEquals("text/html", html.contentType());
     assertTrue(html.body().contains("Hello there, I've been busy!"));
-    assertTrue(html.body().contains("I've looked through <b>5</b> jobs that finished in the last 24 hours."));
+    assertTrue(html.body().contains("I've looked at <b>5</b> jobs that finished in the last 24 hours."));
     assertTrue(html.body().contains("Of those, about <b>2</b> could use some tuning (severe)<"));
     assertTrue(html.body().contains("and <b>3</b> need some serious attention (critical)."));
     assertTrue(html.body().contains("I have <b>1,717</b> processed jobs in my database."));

--- a/test/controllers/ApplicationTest.java
+++ b/test/controllers/ApplicationTest.java
@@ -44,7 +44,7 @@ public class ApplicationTest {
     assertTrue(html.body().contains("I've looked through <b>5</b> jobs that have finished in the last 24 hours."));
     assertTrue(html.body().contains("Of those, about <b>2</b> could use some tuning"));
     assertTrue(html.body().contains("and <b>3</b> need some serious attention."));
-    assertTrue(html.body().contains("I've looked through <b>1,717</b> jobs in all time."));
+    assertTrue(html.body().contains("I have <b>1,717</b> processed jobs in my database."));
   }
 
   @Test

--- a/test/controllers/ApplicationTest.java
+++ b/test/controllers/ApplicationTest.java
@@ -41,9 +41,9 @@ public class ApplicationTest {
     Content html = homePage.render(5, 1717, 2, 3, searchResults.render("Latest analysis", null));
     assertEquals("text/html", html.contentType());
     assertTrue(html.body().contains("Hello there, I've been busy!"));
-    assertTrue(html.body().contains("I've looked through <b>5</b> jobs that have finished in the last 24 hours."));
-    assertTrue(html.body().contains("Of those, about <b>2</b> could use some tuning"));
-    assertTrue(html.body().contains("and <b>3</b> need some serious attention."));
+    assertTrue(html.body().contains("I've looked through <b>5</b> jobs that finished in the last 24 hours."));
+    assertTrue(html.body().contains("Of those, about <b>2</b> could use some tuning (severe)<"));
+    assertTrue(html.body().contains("and <b>3</b> need some serious attention (critical)."));
     assertTrue(html.body().contains("I have <b>1,717</b> processed jobs in my database."));
   }
 

--- a/test/controllers/ApplicationTest.java
+++ b/test/controllers/ApplicationTest.java
@@ -38,12 +38,13 @@ public class ApplicationTest {
 
   @Test
   public void testRenderHomePage() {
-    Content html = homePage.render(5, 2, 3, searchResults.render("Latest analysis", null));
+    Content html = homePage.render(5, 1717, 2, 3, searchResults.render("Latest analysis", null));
     assertEquals("text/html", html.contentType());
     assertTrue(html.body().contains("Hello there, I've been busy!"));
-    assertTrue(html.body().contains("I looked through <b>5</b> jobs today."));
-    assertTrue(html.body().contains("About <b>2</b> of them could use some tuning."));
-    assertTrue(html.body().contains("About <b>3</b> of them need some serious attention!"));
+    assertTrue(html.body().contains("I've looked through <b>5</b> jobs that have finished in the last 24 hours."));
+    assertTrue(html.body().contains("Of those, about <b>2</b> could use some tuning"));
+    assertTrue(html.body().contains("and <b>3</b> need some serious attention."));
+    assertTrue(html.body().contains("I've looked through <b>1,717</b> jobs in all time."));
   }
 
   @Test


### PR DESCRIPTION
The way that stuff on the dashboard was phrased was fairly ambiguous (e.g. what does today really mean and what does "need some tuning" mean) so we cleaned it up. Also added commas to the numbers for improved readability.

@krishnap @saguziel
