### PR TITLE
Changes to load an agent jar along with Dr. Elephant.

### DIFF
--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -37,3 +37,19 @@ jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
 #   /healthcheck
 #   /metrics
 metrics=true
+
+#
+# Property enables an agent jar to be loaded along with the Dr. Elephant application.
+# The intention with this property is to have the agent publish metrics to other
+# applications, although it can do anything else. This property is disabled by default
+# and users wishing to make use of it should provide their own implementation of the agent.
+#
+# More information on writing a jvm agent can be found under the following.
+# https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
+#
+# Sample configuration of this property is shown below.
+# metrics_agent_jar="-javaagent:lib/your_agent.jar"
+#
+# Sample configuration of the agent with additional options.
+# metrics_agent_jar="-javaagent:lib/your_agent.jar=app-name=dr-elephant,app-host=foo"
+

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -125,6 +125,12 @@ if [ -n "${metrics}" ]; then
   OPTS+=" -Dmetrics=$metrics"
 fi
 
+# Enable metrics agent jar if configured. Agent publishes metrics to other apps.
+if [ -n "${metrics_agent_jar}" ]; then
+  OPTS+=" -J$metrics_agent_jar"
+fi
+
+
 # Navigate to project root
 cd $project_root
 


### PR DESCRIPTION
Changes to load an agent jar along with Dr. Elephant. Current use-case is to publish the metrics
to other applications. The property is disabled by default and users who wish to make use of this
specify their own agent jar.
