### PR TITLE
 A more general and accurate implementation of MetricsAggregator for Spark 

### DIFF
--- a/app-conf/AggregatorConf.xml
+++ b/app-conf/AggregatorConf.xml
@@ -42,4 +42,13 @@
     </params>
     -->
   </aggregator>
+  <!--
+  <aggregator>
+    <applicationtype>spark</applicationtype>
+    <classname>com.linkedin.drelephant.spark.aggregator.YarnSparkMetricsAggregator</classname>
+    <params>
+      <executor_memory_default>1024</executor_memory_default>
+    </params>
+  </aggregator>
+  -->
 </aggregators>

--- a/app/com/linkedin/drelephant/spark/aggregator/YarnSparkMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/spark/aggregator/YarnSparkMetricsAggregator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.spark.aggregator;
+
+import com.linkedin.drelephant.analysis.HadoopAggregatedData;
+import com.linkedin.drelephant.analysis.HadoopApplicationData;
+import com.linkedin.drelephant.analysis.HadoopMetricsAggregator;
+import com.linkedin.drelephant.configurations.aggregator.AggregatorConfigurationData;
+import com.linkedin.drelephant.math.Statistics;
+import com.linkedin.drelephant.spark.data.SparkApplicationData;
+import com.linkedin.drelephant.spark.data.SparkExecutorData;
+import com.linkedin.drelephant.util.SparkUtils;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+
+/**
+ * A more general and accurate implementation of SparkMetricsAggregator which is compatible with Spark on YARN
+ * as well as executor dynamic allocation mode.
+ *
+ * What's new:
+ * 1) Memory: Use actual executor memory request considering `overhead` instead of only `spark.executor.memory`.
+ * 2) Time: Use running time of all existed executor, not duration(sum of task executing time) of
+ *      executors only including of those which are alive while ending of application.
+ *
+ */
+public class YarnSparkMetricsAggregator implements HadoopMetricsAggregator {
+
+  private static final Logger logger = LoggerFactory.getLogger(YarnSparkMetricsAggregator.class);
+
+  private AggregatorConfigurationData _aggregatorConfigurationData;
+  private double _storageMemWastageBuffer = 0.5;
+  private String executorMemoryDefault = "1g";
+
+  private static final String EXECUTOR_MEMORY_DEFAULT = "executor_memory_default";
+  //private static final String STORAGE_MEM_WASTAGE_BUFFER = "storage_mem_wastage_buffer";
+
+  private HadoopAggregatedData _hadoopAggregatedData = new HadoopAggregatedData();
+
+
+  public YarnSparkMetricsAggregator(AggregatorConfigurationData _aggregatorConfigurationData) {
+    this._aggregatorConfigurationData = _aggregatorConfigurationData;
+    String configValue = _aggregatorConfigurationData.getParamMap().get(EXECUTOR_MEMORY_DEFAULT);
+    if(configValue != null) {
+      executorMemoryDefault = configValue;
+    }
+  }
+
+  @Override
+  public void aggregate(HadoopApplicationData data) {
+    long resourceUsed = 0;
+    long resourceWasted = 0;
+    SparkApplicationData applicationData = (SparkApplicationData) data;
+
+    long perExecutorMem = SparkUtils.getExecutorReqMemoryMB(applicationData, executorMemoryDefault) * FileUtils.ONE_MB;
+
+    Iterator<String> executorIds = applicationData.getExecutorTrackingData().getExecutors().iterator();
+
+    while(executorIds.hasNext()) {
+      String executorId = executorIds.next();
+      SparkExecutorData.ExecutorInfo executorInfo = applicationData.getExecutorTrackingData().getExecutorInfo(executorId);
+      long executorDuration = executorInfo.getExecutorDuration();
+      // store the resourceUsed in MBSecs
+      resourceUsed += (executorDuration / Statistics.SECOND_IN_MS) * (perExecutorMem / FileUtils.ONE_MB);
+      // maxMem is the maximum available storage memory
+      // memUsed is how much storage memory is used.
+      // any difference is wasted after a buffer of 50% is wasted
+      long excessMemory = (long) (executorInfo.maxMem - (executorInfo.memUsed * (1.0 + _storageMemWastageBuffer)));
+      if( excessMemory > 0) {
+        resourceWasted += (executorDuration / Statistics.SECOND_IN_MS) * (excessMemory / FileUtils.ONE_MB);
+      }
+    }
+
+    _hadoopAggregatedData.setResourceUsed(resourceUsed);
+    _hadoopAggregatedData.setResourceWasted(resourceWasted);
+    // TODO: to find a way to calculate the delay
+    _hadoopAggregatedData.setTotalDelay(0L);
+  }
+
+  @Override
+  public HadoopAggregatedData getResult() {
+    return _hadoopAggregatedData;
+  }
+}

--- a/app/com/linkedin/drelephant/spark/data/SparkApplicationData.java
+++ b/app/com/linkedin/drelephant/spark/data/SparkApplicationData.java
@@ -32,6 +32,8 @@ public interface SparkApplicationData extends HadoopApplicationData {
 
   public SparkExecutorData getExecutorData();
 
+  public SparkExecutorData getExecutorTrackingData();
+
   public SparkJobProgressData getJobProgressData();
 
   public SparkStorageData getStorageData();

--- a/app/com/linkedin/drelephant/spark/data/SparkExecutorData.java
+++ b/app/com/linkedin/drelephant/spark/data/SparkExecutorData.java
@@ -45,12 +45,24 @@ public class SparkExecutorData {
     public long shuffleRead = 0L;
     public long shuffleWrite = 0L;
 
+    public long startTime;
+    // Maybe set finishTime to 0 when an executor keep running until application finished.
+    // In this situation, we finally set finishTime to Application finish time.
+    public long finishTime;
+
+    public long getExecutorDuration() {
+      return finishTime <= 0 ? 0 : finishTime - startTime;
+    }
+
     public String toString() {
       return "{execId: " + execId + ", hostPort:" + hostPort + " , rddBlocks: " + rddBlocks + ", memUsed: " + memUsed
           + ", maxMem: " + maxMem + ", diskUsed: " + diskUsed + ", totalTasks" + totalTasks + ", tasksActive: "
           + activeTasks + ", tasksComplete: " + completedTasks + ", tasksFailed: " + failedTasks + ", duration: "
           + duration + ", inputBytes: " + inputBytes + ", outputBytes:" + outputBytes + ", shuffleRead: " + shuffleRead
-          + ", shuffleWrite: " + shuffleWrite + "}";
+          + ", shuffleWrite: " + shuffleWrite
+          + ", startTime: " + startTime
+          + ", finishTime: " + finishTime
+          + "}";
     }
   }
 

--- a/app/com/linkedin/drelephant/spark/listener/ExecutorsTrackingListener.scala
+++ b/app/com/linkedin/drelephant/spark/listener/ExecutorsTrackingListener.scala
@@ -1,0 +1,105 @@
+package com.linkedin.drelephant.spark.listener
+
+import scala.collection.mutable
+import scala.collection.mutable.HashMap
+
+import org.apache.spark.scheduler._
+import org.apache.spark.storage.{StorageStatus, StorageStatusListener}
+import org.apache.spark.{ExceptionFailure, Resubmitted}
+
+/**
+  * A modified version of ExecutorsListener that tracks all existed executors during the entire application runtime.
+  *
+  * In YARN executor-dynamic-allocation mode, some executor will be killed when idle, and the other executor will
+  * survive until end of the application.
+  * Also, ExecutorsListener within Spark has much modification from 1.4 to 1.6 and 2.0, so build customized listener.
+  * TODO:
+  */
+class ExecutorsTrackingListener(storageStatusListener: StorageStatusListener) extends SparkListener {
+  val executorToTasksActive = HashMap[String, Int]()
+  val executorToTasksComplete = HashMap[String, Int]()
+  val executorToTasksFailed = HashMap[String, Int]()
+  val executorToDuration = HashMap[String, Long]()
+  val executorToInputBytes = HashMap[String, Long]()
+  val executorToInputRecords = HashMap[String, Long]()
+  val executorToOutputBytes = HashMap[String, Long]()
+  val executorToOutputRecords = HashMap[String, Long]()
+  val executorToShuffleRead = HashMap[String, Long]()
+  val executorToShuffleWrite = HashMap[String, Long]()
+  val executorToLogUrls = HashMap[String, Map[String, String]]()
+  val executorIdToData = HashMap[String, ExecutorLifeData]()
+
+  def storageStatusList: Seq[StorageStatus] = storageStatusListener.storageStatusList
+
+  override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = synchronized {
+    val eid = executorAdded.executorId
+    executorToLogUrls(eid) = executorAdded.executorInfo.logUrlMap
+    executorIdToData(eid) = ExecutorLifeData(executorAdded.time)
+  }
+
+  override def onExecutorRemoved(
+      executorRemoved: SparkListenerExecutorRemoved): Unit = synchronized {
+    val eid = executorRemoved.executorId
+    val lifeData = executorIdToData(eid)
+    lifeData.finishTime = Some(executorRemoved.time)
+    lifeData.finishReason = Some(executorRemoved.reason)
+  }
+
+  override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = synchronized {
+    val eid = taskStart.taskInfo.executorId
+    executorToTasksActive(eid) = executorToTasksActive.getOrElse(eid, 0) + 1
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = synchronized {
+    val info = taskEnd.taskInfo
+    if (info != null) {
+      val eid = info.executorId
+      taskEnd.reason match {
+        case Resubmitted =>
+          // Note: For resubmitted tasks, we continue to use the metrics that belong to the
+          // first attempt of this task. This may not be 100% accurate because the first attempt
+          // could have failed half-way through. The correct fix would be to keep track of the
+          // metrics added by each attempt, but this is much more complicated.
+          return
+        case e: ExceptionFailure =>
+          executorToTasksFailed(eid) = executorToTasksFailed.getOrElse(eid, 0) + 1
+        case _ =>
+          executorToTasksComplete(eid) = executorToTasksComplete.getOrElse(eid, 0) + 1
+      }
+
+      executorToTasksActive(eid) = executorToTasksActive.getOrElse(eid, 1) - 1
+      executorToDuration(eid) = executorToDuration.getOrElse(eid, 0L) + info.duration
+
+      // Update shuffle read/write
+      val metrics = taskEnd.taskMetrics
+      if (metrics != null) {
+        metrics.inputMetrics.foreach { inputMetrics =>
+          executorToInputBytes(eid) =
+            executorToInputBytes.getOrElse(eid, 0L) + inputMetrics.bytesRead
+          executorToInputRecords(eid) =
+            executorToInputRecords.getOrElse(eid, 0L) + inputMetrics.recordsRead
+        }
+        metrics.outputMetrics.foreach { outputMetrics =>
+          executorToOutputBytes(eid) =
+            executorToOutputBytes.getOrElse(eid, 0L) + outputMetrics.bytesWritten
+          executorToOutputRecords(eid) =
+            executorToOutputRecords.getOrElse(eid, 0L) + outputMetrics.recordsWritten
+        }
+        metrics.shuffleReadMetrics.foreach { shuffleRead =>
+          executorToShuffleRead(eid) =
+            executorToShuffleRead.getOrElse(eid, 0L) + shuffleRead.remoteBytesRead
+        }
+        metrics.shuffleWriteMetrics.foreach { shuffleWrite =>
+          executorToShuffleWrite(eid) =
+            executorToShuffleWrite.getOrElse(eid, 0L) + shuffleWrite.shuffleBytesWritten
+        }
+      }
+    }
+  }
+
+}
+
+case class ExecutorLifeData(
+                             val startTime: Long,
+                             var finishTime: Option[Long] = None,
+                             var finishReason: Option[String] = None)

--- a/app/com/linkedin/drelephant/util/SparkUtils.scala
+++ b/app/com/linkedin/drelephant/util/SparkUtils.scala
@@ -1,0 +1,58 @@
+package com.linkedin.drelephant.util
+
+import com.linkedin.drelephant.spark.data.SparkApplicationData
+import org.apache.spark.network.util.JavaUtils
+
+/**
+  * Include some spark util methods.
+  */
+object SparkUtils {
+
+  val SPARK_EXECUTOR_CORES = "spark.executor.cores"
+
+  val SPARK_EXECUTOR_MEMORY = "spark.executor.memory"
+
+  val SPARK_MASTER = "spark.master"
+
+  val SPARK_MASTER_DEFAULT = "local[*]"
+
+  val MEMORY_OVERHEAD_FACTOR = "spark.yarn.executor.memoryOverhead.factor"
+
+  val MEMORY_OVERHEAD = "spark.yarn.executor.memoryOverhead"
+
+  /**
+    * Calculate Memory Request Resource which from configuration according to YARN mode or Standalone mode,
+    * instead of coming from `getRuntime().maxMemory`. <br/>
+    * In YARN mode, Memory Request Resource should be `spark.executor.memory` + `spark.yarn.executor.memoryOverhead`. <br/>
+    * In Standalone mode, Memory Request Resource should be `spark.executor.memory`
+    * @param data
+    * @param default default value
+    * @return Memory Request Resource(MB)
+    */
+  def getExecutorReqMemoryMB(data: SparkApplicationData, default: String) = {
+    val envData = data.getEnvironmentData
+
+    val executorMemory: Long = memoryStringToMb(envData.getSparkProperty(SPARK_EXECUTOR_MEMORY, default))
+
+    if (isYARNMode(envData.getSparkProperty(SPARK_MASTER, SPARK_MASTER_DEFAULT))) {
+      val memoryOverheadFactor = envData.getSparkProperty(MEMORY_OVERHEAD_FACTOR, "0.20").toDouble
+      val memoryOverhead: Int = envData.getSparkProperty(MEMORY_OVERHEAD,
+        math.max((memoryOverheadFactor * executorMemory).toInt, 384).toString).toInt
+      executorMemory + memoryOverhead
+    } else {
+      executorMemory
+    }
+  }
+
+  def isYARNMode(sparkMaster: String) = sparkMaster.startsWith("yarn")
+
+  /**
+    * Convert a Java memory parameter passed to -Xmx (such as 300m or 1g) to a number of mebibytes.
+    */
+  def memoryStringToMb(str: String): Int = {
+    // Convert to bytes, rather than directly to MB, because when no units are specified the unit
+    // is assumed to be bytes
+    (JavaUtils.byteStringAsBytes(str) / 1024 / 1024).toInt
+  }
+
+}

--- a/test/com/linkedin/drelephant/spark/MockSparkApplicationData.java
+++ b/test/com/linkedin/drelephant/spark/MockSparkApplicationData.java
@@ -67,6 +67,11 @@ public class MockSparkApplicationData implements SparkApplicationData {
   }
 
   @Override
+  public SparkExecutorData getExecutorTrackingData() {
+    return _sparkExecutorData;
+  }
+
+  @Override
   public SparkJobProgressData getJobProgressData() {
     return _sparkJobProgressData;
   }

--- a/test/com/linkedin/drelephant/spark/aggregator/TestYarnSparkAggregatedMetrics.java
+++ b/test/com/linkedin/drelephant/spark/aggregator/TestYarnSparkAggregatedMetrics.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.spark.aggregator;
+
+import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.configurations.aggregator.AggregatorConfigurationData;
+import com.linkedin.drelephant.spark.MockSparkApplicationData;
+import com.linkedin.drelephant.spark.data.SparkEnvironmentData;
+import com.linkedin.drelephant.spark.data.SparkExecutorData;
+import com.linkedin.drelephant.util.SparkUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.spark.SparkMetricsAggregator;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestYarnSparkAggregatedMetrics {
+  private static final String SPARK_EXECUTOR_MEMORY = "spark.executor.memory";
+
+  private static final long HOUR = 60 * 60 * 1000;
+
+  private SparkExecutorData.ExecutorInfo mockExecutorInfo(long startTime, long finishTime, long duration) {
+    SparkExecutorData.ExecutorInfo executorInfo = new SparkExecutorData.ExecutorInfo();
+    executorInfo.startTime = startTime;
+    executorInfo.finishTime = finishTime;
+    executorInfo.duration = duration;
+
+    return executorInfo;
+  }
+
+  @Test
+  public void TestNullExecutors() {
+    ApplicationType appType = new ApplicationType("SPARK");
+    AggregatorConfigurationData conf =
+        new AggregatorConfigurationData("org.apache.spark.SparkMetricsAggregator", appType, null);
+    YarnSparkMetricsAggregator metrics = new YarnSparkMetricsAggregator(conf);
+
+    MockSparkApplicationData appData = new MockSparkApplicationData();
+
+    metrics.aggregate(appData);
+
+    Assert.assertEquals(metrics.getResult().getResourceUsed() , 0L);
+    Assert.assertEquals(metrics.getResult().getResourceWasted() , 0L);
+    Assert.assertEquals(metrics.getResult().getTotalDelay() , 0L);
+  }
+
+  @Test
+  public void TestValidExecutorsWithNoEnvironmentData() {
+    ApplicationType appType = new ApplicationType("SPARK");
+    AggregatorConfigurationData conf =
+        new AggregatorConfigurationData("org.apache.spark.SparkMetricsAggregator", appType, null);
+    YarnSparkMetricsAggregator metrics = new YarnSparkMetricsAggregator(conf);
+
+    MockSparkApplicationData appData = new MockSparkApplicationData();
+    appData.getExecutorData().setExecutorInfo("1", mockExecutorInfo(0, 1 * HOUR, 1000));
+    appData.getExecutorData().setExecutorInfo("2", mockExecutorInfo(0, 2 * HOUR, 1000));
+
+    metrics.aggregate(appData);
+
+    Assert.assertEquals(1024 * 3 * 3600, metrics.getResult().getResourceUsed());
+    Assert.assertEquals(0, metrics.getResult().getResourceWasted());
+    Assert.assertEquals(0L, metrics.getResult().getTotalDelay());
+  }
+
+  @Test
+  public void TestValidExecutorsAndValidEnvironmentData() {
+    ApplicationType appType = new ApplicationType("SPARK");
+    AggregatorConfigurationData conf =
+        new AggregatorConfigurationData("org.apache.spark.SparkMetricsAggregator", appType, null);
+    YarnSparkMetricsAggregator metrics = new YarnSparkMetricsAggregator(conf);
+
+    long appFinishTime = 3 * HOUR;
+
+    MockSparkApplicationData appData = new MockSparkApplicationData();
+    appData.getExecutorData().setExecutorInfo("1", mockExecutorInfo(0, 2 * HOUR, 1000)); // runningTime: 2h
+    appData.getExecutorData().setExecutorInfo("2", mockExecutorInfo(0, appFinishTime, 1000)); // runningTime: 3h
+    appData.getExecutorData().setExecutorInfo("3", mockExecutorInfo(1 * HOUR, 2 * HOUR, 1000)); // runningTime: 1h
+    appData.getExecutorData().setExecutorInfo("4", mockExecutorInfo(2 * HOUR, appFinishTime, 1000)); // runningTime: 1h
+
+    // finally executor memory request on YARN is 1g + 2g
+    setExecutorReqEnv(appData.getEnvironmentData(), "10g", "2048", "0.2");
+
+    metrics.aggregate(appData);
+
+    // Total executor running time is 7h, so aggregated memory resource usage is 7h * 12g = 7 * 3600 * 12 * 1024 MB-seconds
+    Assert.assertEquals(7 * 3600 * 12 * 1024, metrics.getResult().getResourceUsed());
+    //Assert.assertEquals(20L, metrics.getResult().getResourceWasted());
+    //Assert.assertEquals(0L, metrics.getResult().getTotalDelay());
+  }
+
+  @Test
+  public void testGetYarnExecutorMemoryRequest() {
+    // memory request: 11g
+    MockSparkApplicationData appData = new MockSparkApplicationData();
+    setExecutorReqEnv(appData.getEnvironmentData(), "10g", "1024", "0.3");
+    Assert.assertEquals(11 * 1024, SparkUtils.getExecutorReqMemoryMB(appData, "1g"));
+
+    // memory request: 13g
+    appData = new MockSparkApplicationData();
+    setExecutorReqEnv(appData.getEnvironmentData(), "10g", null, "0.3");
+    Assert.assertEquals(13 * 1024, SparkUtils.getExecutorReqMemoryMB(appData, "1g"));
+
+    // memory request: 12g
+    appData = new MockSparkApplicationData();
+    setExecutorReqEnv(appData.getEnvironmentData(), "10g", null, null);
+    Assert.assertEquals(12 * 1024, SparkUtils.getExecutorReqMemoryMB(appData, "1g"));
+
+    // memory request: 10g + 384m
+    appData = new MockSparkApplicationData();
+    setExecutorReqEnv(appData.getEnvironmentData(), "10g", null, "0.01");
+    Assert.assertEquals(10 * 1024 + 384, SparkUtils.getExecutorReqMemoryMB(appData, "1g"));
+
+    // memory request: 5g + 1024m
+    appData = new MockSparkApplicationData();
+    setExecutorReqEnv(appData.getEnvironmentData(), null, null, null);
+    Assert.assertEquals(5 * 1024 + 1024, SparkUtils.getExecutorReqMemoryMB(appData, "5g"));
+  }
+
+  private void setExecutorReqEnv(SparkEnvironmentData envData, String execMemory, String execOverhead, String execOverheadFactor) {
+    envData.addSparkProperty(SparkUtils.SPARK_MASTER(), "yarn-client");
+    if (execMemory != null) {
+      envData.addSparkProperty(SparkUtils.SPARK_EXECUTOR_MEMORY(), execMemory);
+    }
+    if (execOverhead != null) {
+      envData.addSparkProperty(SparkUtils.MEMORY_OVERHEAD(), execOverhead);
+    }
+
+    if (execOverheadFactor != null) {
+      envData.addSparkProperty(SparkUtils.MEMORY_OVERHEAD_FACTOR(), execOverheadFactor);
+    }
+  }
+
+}

--- a/test/org/apache/spark/deploy/history/SparkDataCollectionTest.java
+++ b/test/org/apache/spark/deploy/history/SparkDataCollectionTest.java
@@ -46,7 +46,7 @@ public class SparkDataCollectionTest {
         replayBus.addListener(jobProgressListener);
 
         SparkDataCollection dataCollection = new SparkDataCollection(null, jobProgressListener,
-                null, null, null, null, null);
+                null, null, null, null, null, null);
 
         InputStream in = new BufferedInputStream(
                 SparkDataCollectionTest.class.getClassLoader().getResourceAsStream(event_log_dir + "event_log_1"));


### PR DESCRIPTION
 A more general and accurate implementation of MetricsAggregator for Spark which is compatible with Spark on YARN as well as executor dynamic allocation mode.

What's new:
 1.  Memory: Use actual executor memory request considering `memoryOverhead` instead of only `spark.executor.memory`.
 2. Time: Use running time of all existed executor, not duration(sum of task executing time) of executors only including of those which are alive while ending of application.

I test this feature for three real Spark applications on our YARN cluster and compare `Aggregate Memory Resource Allocation`(`Resource used` in dr-elephant) metric of applications in YARN(showed when spark application finished in AM page), dr-original and and dr-optimized Below is result of one application for example:
- YARN: 410620516 MB-seconds
- dr-original: 1394513510.4 MB-seconds
- dr-optimized: 405405696 MB-seconds

Consider YARN showed as the standard value,
- deviation of  dr-original：(410620516-1394513510.4)/410620516=239.61%
-  deviation of dr-optimized：(410620516-405405696)/410620516=1.27%

Average deviation of this feature is 1.88%, as  average deviation of  dr-original is 280.86%.

This is our first PR, so there has also some *TODO* work about code style, code reasonable, and etc, so please help us review and feel free to give us advise.

Future work we plan:
- Add cpu-time resource usage for CPU are also can be scheduled and CPU resource even is `bottleneck` resource in our company.
- Catch the real physical memory resource usage and optimize the `Resource wasted` metric. 

Thanks!