### PR TITLE
OozieScheduler: fix superParentId - now also returns the Coordinator id for subworkflows

### DIFF
--- a/test/com/linkedin/drelephant/schedulers/OozieSchedulerTest.java
+++ b/test/com/linkedin/drelephant/schedulers/OozieSchedulerTest.java
@@ -256,7 +256,7 @@ public class OozieSchedulerTest {
         SchedulerConfigurationData schedulerConfig = makeConfig("oozie", new HashMap<String, String>());
         OozieScheduler scheduler = new OozieScheduler("id", getOozieProperties(), schedulerConfig, oozieClient);
 
-        assertEquals(2, scheduler.getWorkflowDepth());
+        assertEquals(1, scheduler.getWorkflowDepth());
 
     }
 


### PR DESCRIPTION
in superParentId, while( ... !isCoordinatorJob(extractId(parentId))) actually stopped our loop before finding the Coordinator parent. So subworkflows only returned their superparentworkflow, but not the coordinator launching that one.

also fixed testDepthCalculation - our test workflow only has one parent so Depth should be 1.