### PR TITLE
Removes play dependencies to read config file and read system properties.

### DIFF
--- a/app/com/linkedin/drelephant/security/HadoopSecurity.java
+++ b/app/com/linkedin/drelephant/security/HadoopSecurity.java
@@ -23,7 +23,6 @@ import org.apache.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.security.PrivilegedAction;
-import play.Play;
 
 
 /**
@@ -46,13 +45,13 @@ public class HadoopSecurity {
       logger.info("This cluster is Kerberos enabled.");
       boolean login = true;
 
-      _keytabUser = Play.application().configuration().getString("keytab.user");
+      _keytabUser = System.getProperty("keytab.user");
       if (_keytabUser == null) {
         logger.error("Keytab user not set. Please set keytab_user in the configuration file");
         login = false;
       }
 
-      _keytabLocation = Play.application().configuration().getString("keytab.location");
+      _keytabLocation = System.getProperty("keytab.location");
       if (_keytabLocation == null) {
         logger.error("Keytab location not set. Please set keytab_location in the configuration file");
         login = false;

--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -39,7 +39,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-import play.Play;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -77,7 +76,7 @@ public final class Utils {
   public static Document loadXMLDoc(String filePath) {
     InputStream instream = null;
     logger.info("Loading configuration file " + filePath);
-    instream = Play.application().resourceAsStream(filePath);
+    instream = ClassLoader.getSystemClassLoader().getResourceAsStream(filePath);
 
     if (instream == null) {
       logger.info("Configuation file not present in classpath. File:  " + filePath);
@@ -414,7 +413,7 @@ public final class Utils {
     }
     return paramsMap;
   }
-   
+
   /* Returns the total resources used by the job list
    * @param resultList The job lsit
    * @return The total resources used by the job list


### PR DESCRIPTION
In order to read the values of JVM properties, -Dkeytab.user and -Dkeytab.location, using System.getProperty(), instead of Play APIs.

Using ClassLoader.getSystemClassLoader().getResourceAsStream to read the config files, instead of Play APIs.

This change is a continuation of a previous change, https://github.com/linkedin/dr-elephant/pull/179

@akshayrai : Can you please review this.



