### PR TITLE
Adds a version of analyze method taking app data as input

### DIFF
--- a/app/com/linkedin/drelephant/analysis/AnalyticJob.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJob.java
@@ -232,9 +232,19 @@ public class AnalyticJob {
     ElephantFetcher fetcher = ElephantContext.instance().getFetcherForApplicationType(getAppType());
     HadoopApplicationData data = fetcher.fetchData(this);
 
+    return getAnalysis(data);
+  }
+
+  /**
+   * Analyzes given app data and returns AppResult that could be directly serialized into DB.
+   *
+   * @param data Hadoop application data to analyze.
+   * @throws Exception if the analysis process encountered a problem.
+   * @return the analysed AppResult
+   */
+  public AppResult getAnalysis(HadoopApplicationData data) throws Exception {
     JobType jobType = ElephantContext.instance().matchJobType(data);
     String jobTypeName = jobType == null ? UNKNOWN_JOB_TYPE : jobType.getName();
-
     // Run all heuristics over the fetched data
     List<HeuristicResult> analysisResults = new ArrayList<HeuristicResult>();
     if (data == null || data.isEmpty()) {


### PR DESCRIPTION
In the [proposed modularization refactoring design](https://docs.google.com/document/d/191PZZGxt0PMIj7j2Bj4pIPgi_Xuu7HRLYtRkhH9daSg/edit), we want to run analysis driver backend without the fetcher part. The AnalyticJob class current has getAnalysis method that fetches app data on its own. The analysis driver backend cannot use this method.

This change adds a version of the method that takes app data as input. With this, the analysis driver backend will prepopulate app data and call the new method.