### PR TITLE
fix for null pointers in TaskList returned by MapReduceFSFetcherHadoop2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,6 +70,7 @@ object Dependencies {
     "mysql" % "mysql-connector-java" % mysqlConnectorVersion,
     "org.apache.hadoop" % "hadoop-auth" % hadoopVersion % "compileonly",
     "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "compileonly",
+    "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Test,
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "compileonly",
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Test,
     "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion % "compileonly",


### PR DESCRIPTION
For MapReduce jobs with succeeded status but containing failed tasks (by setting mapreduce.map.failures.maxpercent to non zero), MapReduceFSFetcherHadoop2 will construct a task list with null pointers. This PR fixes this bug and adds a unit test to distinguish it.