### PR TITLE
Fixes issue caused by http in history server config property

### DIFF
--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -51,7 +51,14 @@ class SparkRestClient(sparkConf: SparkConf) {
 
   private val historyServerUri: URI = sparkConf.getOption(HISTORY_SERVER_ADDRESS_KEY) match {
     case Some(historyServerAddress) =>
-      val baseUri = new URI(s"http://${historyServerAddress}")
+      val baseUri: URI =
+        // Latest versions of CDH include http in their history server address configuration.
+        // However, it is not recommended by Spark documentation(http://spark.apache.org/docs/latest/running-on-yarn.html)
+        if (historyServerAddress.contains(s"http://")) {
+          new URI(historyServerAddress)
+        } else {
+          new URI(s"http://${historyServerAddress}")
+        }
       require(baseUri.getPath == "")
       baseUri
     case None =>


### PR DESCRIPTION
This change fixes the [issue](https://github.com/linkedin/dr-elephant/issues/216), where Cloudera Manager adds http in their jobhistory webadress. And that causes the failure of SparkFetcher.

@paulbramsen @shankar37 

Please take a look.
Thank you. 