### PR TITLE
Tries to get namenode host name from hadoop config, if it is missing spark config

### DIFF
--- a/test/com/linkedin/drelephant/spark/fetchers/SparkLogClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkLogClientTest.scala
@@ -53,6 +53,15 @@ class SparkLogClientTest extends AsyncFunSpec with Matchers with MockitoSugar {
       sparkLogClient.webhdfsEventLogUri should be(new URI("webhdfs://nn1.grid.example.com:50070/logs/spark"))
     }
 
+    it("uses a webhdfs URI constructed from spark.eventLog.dir, dfs.namenode.http-address, and fs.defaultFS if spark.eventLog.dir does not has hostname") {
+      val hadoopConfiguration = new Configuration()
+      hadoopConfiguration.set("dfs.namenode.http-address", "0.0.0.0:50070")
+      hadoopConfiguration.set("fs.defaultFS", "hdfs://nn1.grid.example.com:8020");
+      val sparkConf = new SparkConf().set("spark.eventLog.dir", "hdfs:///logs/spark")
+      val sparkLogClient = new SparkLogClient(hadoopConfiguration, sparkConf)
+      sparkLogClient.webhdfsEventLogUri should be(new URI("webhdfs://nn1.grid.example.com:50070/logs/spark"))
+    }
+
     it("returns the desired data from the Spark event logs") {
       import ExecutionContext.Implicits.global
 


### PR DESCRIPTION
This patch is trying to fix one of the problems raised in this [issue](https://github.com/linkedin/dr-elephant/issues/206), where `spark.eventLog.dir` config key does not contain namenode hostname. As reported in the issue, sometimes it's not possible to add hostname into that config.

In this patch, if `spark.eventLog.dir` does not contain the hostname, then fetcher gets the hostname from the value of config key, `fs.defaultFS`. I am not very sure if this the right way to do it. I referred this [documentation.](https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.4.2/bk_installing_manually_book/content/ch_setting_up_hadoop_configuration_chapter.html)

@rayortigas and @shankar37 