### PR TITLE
Spark fetcher is now able to fetch event logs via REST API

### DIFF
--- a/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
+++ b/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
@@ -24,5 +24,4 @@ case class SparkRestDerivedData(
   jobDatas: Seq[JobData],
   stageDatas: Seq[StageData],
   executorSummaries: Seq[ExecutorSummary],
-  private[spark] val logDerivedData: Option[SparkLogDerivedData]
-)
+  private[spark] val logDerivedData: Option[SparkLogDerivedData] = None)

--- a/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
+++ b/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
@@ -23,5 +23,6 @@ case class SparkRestDerivedData(
   applicationInfo: ApplicationInfo,
   jobDatas: Seq[JobData],
   stageDatas: Seq[StageData],
-  executorSummaries: Seq[ExecutorSummary]
+  executorSummaries: Seq[ExecutorSummary],
+  private[spark] val logDerivedData: Option[SparkLogDerivedData]
 )

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -61,7 +61,7 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
   }
 
   private[fetchers] lazy val useRestForLogs: Boolean = {
-    Some(fetcherConfigurationData.getParamMap.get("use_rest_for_eventlogs"))
+    Option(fetcherConfigurationData.getParamMap.get("use_rest_for_eventlogs"))
       .exists(_.toBoolean)
   }
 

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -94,11 +94,11 @@ object SparkFetcher {
   )(
     implicit ec: ExecutionContext
   ): Future[SparkApplicationData] = async {
-    val restDerivedData = await(sparkRestClient.fetchRestData(appId))
-    val lastAttemptId = restDerivedData.applicationInfo.attempts.maxBy { _.startTime }.attemptId
+    val restDerivedData = await(sparkRestClient.fetchData(appId, fetchLogsViaRest))
     val logDerivedData = if (fetchLogsViaRest) {
-      await(sparkRestClient.fetchLogData(appId, lastAttemptId))
+      restDerivedData.logDerivedData
     } else {
+      val lastAttemptId = restDerivedData.applicationInfo.attempts.maxBy { _.startTime }.attemptId
       // Would use .map but await doesn't like that construction.
       sparkLogClient match {
         case Some(sparkLogClient) =>

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -61,9 +61,8 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
   }
 
   private[fetchers] lazy val useRestForLogs: Boolean = {
-    fetcherConfigurationData.getParamMap
-        .getOrDefault("use_rest_for_eventlogs", "false")
-        .toBoolean
+    Some(fetcherConfigurationData.getParamMap.get("use_rest_for_eventlogs"))
+      .exists(_.toBoolean)
   }
 
   override def fetchData(analyticJob: AnalyticJob): SparkApplicationData = {

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkLogClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkLogClient.scala
@@ -76,7 +76,7 @@ class SparkLogClient(hadoopConfiguration: Configuration, sparkConf: SparkConf) {
     val logPath = getLogPath(webhdfsEventLogUri, appId, attemptId, compressionCodecShortName)
     logger.info(s"looking for logs at ${logPath}")
 
-    val codec = compressionCodecForLogPath(sparkConf, logPath)
+    val codec = compressionCodecForLogName(sparkConf, logPath.getName)
 
     // Limit scope of async.
     async {
@@ -189,10 +189,10 @@ object SparkLogClient {
     new BufferedInputStream(fs.open(logPath))
   }
 
-  private def compressionCodecForLogPath(conf: SparkConf, logPath: Path): Option[CompressionCodec] = {
+  private[fetchers] def compressionCodecForLogName(conf: SparkConf, logName: String): Option[CompressionCodec] = {
     // Compression codec is encoded as an extension, e.g. app_123.lzf
     // Since we sanitize the app ID to not include periods, it is safe to split on it
-    val logBaseName = logPath.getName.stripSuffix(IN_PROGRESS)
+    val logBaseName = logName.stripSuffix(IN_PROGRESS)
     logBaseName.split("\\.").tail.lastOption.map { codecName =>
       compressionCodecMap.getOrElseUpdate(codecName, loadCompressionCodec(conf, codecName))
     }

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -76,9 +76,12 @@ class SparkRestClient(sparkConf: SparkConf) {
 
     val applicationInfo = getApplicationInfo(appTarget)
 
-    // Limit scope of async.
+    // These are pure and cannot fail, therefore it is safe to have
+    // them outside of the async block.
     val lastAttemptId = applicationInfo.attempts.maxBy {_.startTime}.attemptId
     val attemptTarget = lastAttemptId.map(appTarget.path).getOrElse(appTarget)
+
+    // Limit the scope of async.
     async {
       val futureJobDatas = async { getJobDatas(attemptTarget) }
       val futureStageDatas = async { getStageDatas(attemptTarget) }

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -68,7 +68,9 @@ class SparkRestClient(sparkConf: SparkConf) {
 
   private val apiTarget: WebTarget = client.target(historyServerUri).path(API_V1_MOUNT_PATH)
 
-  def fetchData(appId: String, fetchLogs: Boolean)(implicit ec: ExecutionContext): Future[SparkRestDerivedData] = {
+  def fetchData(appId: String, fetchLogs: Boolean = false)(
+    implicit ec: ExecutionContext
+  ): Future[SparkRestDerivedData] = {
     val appTarget = apiTarget.path(s"applications/${appId}")
     logger.info(s"calling REST API at ${appTarget.getUri}")
 

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -33,11 +33,8 @@ import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfo, Exec
 import javax.ws.rs.client.{Client, ClientBuilder, WebTarget}
 import javax.ws.rs.core.MediaType
 
-import org.apache.hadoop.fs.Path
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
-
-import scala.collection.mutable
 
 /**
   * A client for getting data from the Spark monitoring REST API, e.g. <https://spark.apache.org/docs/1.4.1/monitoring.html#rest-api>.

--- a/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
+++ b/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
@@ -55,7 +55,7 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
         applicationInfo,
         jobDatas = Seq.empty,
         stageDatas = Seq.empty,
-        executorSummaries
+        executorSummaries = executorSummaries
       )
     }
 

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
@@ -19,7 +19,6 @@ package com.linkedin.drelephant.spark.fetchers
 import java.io.{File, FileOutputStream, InputStream, OutputStream}
 import java.util.Date
 
-import scala.collection.JavaConverters
 import scala.concurrent.{ExecutionContext, Future}
 
 import com.google.common.io.Files
@@ -152,14 +151,34 @@ class SparkFetcherTest extends FunSpec with Matchers {
       }
       an[IllegalStateException] should be thrownBy { sparkFetcher.sparkConf }
     }
+
+    it("fetches logs via WebHDFS by default") {
+      val fetcherConfigurationData = newFakeFetcherConfigurationData()
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData)
+      sparkFetcher.useRestForLogs should be(false)
+    }
+
+    it("fetches logs via REST if use_rest_for_eventlogs is true") {
+      val fetcherConfigurationData = newFakeFetcherConfigurationData(
+        Map("use_rest_for_eventlogs" -> "true"))
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData)
+      sparkFetcher.useRestForLogs should be(true)
+    }
+
+    it("fetches logs via REST if use_rest_for_eventlogs is false") {
+      val fetcherConfigurationData = newFakeFetcherConfigurationData(
+        Map("use_rest_for_eventlogs" -> "false"))
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData)
+      sparkFetcher.useRestForLogs should be(false)
+    }
   }
 }
 
 object SparkFetcherTest {
-  import JavaConverters._
+  import scala.collection.JavaConverters._
 
-  def newFakeFetcherConfigurationData(): FetcherConfigurationData =
-    new FetcherConfigurationData(classOf[SparkFetcher].getName, new ApplicationType("SPARK"), Map.empty.asJava)
+  def newFakeFetcherConfigurationData(paramMap: Map[String, String] = Map.empty): FetcherConfigurationData =
+    new FetcherConfigurationData(classOf[SparkFetcher].getName, new ApplicationType("SPARK"), paramMap.asJava)
 
   def newFakeApplicationAttemptInfo(
     attemptId: Option[String],

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
@@ -180,7 +180,7 @@ object SparkFetcherTest {
     implicit ec: ExecutionContext
   ): SparkRestClient = {
     val sparkRestClient = Mockito.mock(classOf[SparkRestClient])
-    Mockito.when(sparkRestClient.fetchRestData(appId)).thenReturn(restDerivedData)
+    Mockito.when(sparkRestClient.fetchData(appId)).thenReturn(restDerivedData)
     sparkRestClient
   }
 

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
@@ -180,7 +180,7 @@ object SparkFetcherTest {
     implicit ec: ExecutionContext
   ): SparkRestClient = {
     val sparkRestClient = Mockito.mock(classOf[SparkRestClient])
-    Mockito.when(sparkRestClient.fetchData(appId)).thenReturn(restDerivedData)
+    Mockito.when(sparkRestClient.fetchRestData(appId)).thenReturn(restDerivedData)
     sparkRestClient
   }
 

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
@@ -25,6 +25,7 @@ import com.google.common.io.Files
 import com.linkedin.drelephant.analysis.{AnalyticJob, ApplicationType}
 import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkLogDerivedData, SparkRestDerivedData}
+import com.linkedin.drelephant.spark.fetchers.SparkFetcher.EventLogSource
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationAttemptInfo, ApplicationInfo}
 import com.linkedin.drelephant.util.SparkUtils
 import org.apache.spark.SparkConf
@@ -68,7 +69,7 @@ class SparkFetcherTest extends FunSpec with Matchers {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkConf = new SparkConf()
         override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future(restDerivedData))
-        override lazy val sparkLogClient = Some(newFakeSparkLogClient(appId, Some("2"), Future(logDerivedData)))
+        override lazy val sparkLogClient = newFakeSparkLogClient(appId, Some("2"), Future(logDerivedData))
       }
       val data = sparkFetcher.fetchData(analyticJob)
       data.appId should be(appId)
@@ -78,7 +79,7 @@ class SparkFetcherTest extends FunSpec with Matchers {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkConf = new SparkConf()
         override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future { throw new Exception() })
-        override lazy val sparkLogClient = Some(newFakeSparkLogClient(appId, Some("2"), Future(logDerivedData)))
+        override lazy val sparkLogClient = newFakeSparkLogClient(appId, Some("2"), Future(logDerivedData))
       }
 
       an[Exception] should be thrownBy { sparkFetcher.fetchData(analyticJob) }
@@ -87,8 +88,9 @@ class SparkFetcherTest extends FunSpec with Matchers {
     it("throws an exception if the log client fails") {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkConf = new SparkConf()
+          .set(SparkFetcher.SPARK_EVENT_LOG_ENABLED_KEY, "true")
         override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future(restDerivedData))
-        override lazy val sparkLogClient = Some(newFakeSparkLogClient(appId, Some("2"), Future { throw new Exception() }))
+        override lazy val sparkLogClient = newFakeSparkLogClient(appId, Some("2"), Future { throw new Exception() })
       }
 
       an[Exception] should be thrownBy { sparkFetcher.fetchData(analyticJob) }
@@ -149,27 +151,50 @@ class SparkFetcherTest extends FunSpec with Matchers {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkUtils = new SparkUtils() { override val defaultEnv = Map.empty[String, String] }
       }
+
       an[IllegalStateException] should be thrownBy { sparkFetcher.sparkConf }
     }
 
-    it("fetches logs via WebHDFS by default") {
+    it("eventlog source defaults to WebHDFS") {
       val fetcherConfigurationData = newFakeFetcherConfigurationData()
-      val sparkFetcher = new SparkFetcher(fetcherConfigurationData)
-      sparkFetcher.useRestForLogs should be(false)
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
+        override lazy val sparkConf: SparkConf = new SparkConf()
+          .set(SparkFetcher.SPARK_EVENT_LOG_ENABLED_KEY, "true")
+      }
+
+      sparkFetcher.eventLogSource should be(EventLogSource.WebHdfs)
     }
 
-    it("fetches logs via REST if use_rest_for_eventlogs is true") {
-      val fetcherConfigurationData = newFakeFetcherConfigurationData(
-        Map("use_rest_for_eventlogs" -> "true"))
-      val sparkFetcher = new SparkFetcher(fetcherConfigurationData)
-      sparkFetcher.useRestForLogs should be(true)
-    }
-
-    it("fetches logs via REST if use_rest_for_eventlogs is false") {
+    it("eventlog source is WebHDFS if use_rest_for_eventlogs is false") {
       val fetcherConfigurationData = newFakeFetcherConfigurationData(
         Map("use_rest_for_eventlogs" -> "false"))
-      val sparkFetcher = new SparkFetcher(fetcherConfigurationData)
-      sparkFetcher.useRestForLogs should be(false)
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
+        override lazy val sparkConf: SparkConf = new SparkConf()
+          .set(SparkFetcher.SPARK_EVENT_LOG_ENABLED_KEY, "true")
+      }
+
+      sparkFetcher.eventLogSource should be(EventLogSource.WebHdfs)
+    }
+
+    it("eventlog source is REST if use_rest_for_eventlogs is true") {
+      val fetcherConfigurationData = newFakeFetcherConfigurationData(
+        Map("use_rest_for_eventlogs" -> "true"))
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
+        override lazy val sparkConf: SparkConf = new SparkConf()
+          .set(SparkFetcher.SPARK_EVENT_LOG_ENABLED_KEY, "true")
+      }
+
+      sparkFetcher.eventLogSource should be(EventLogSource.Rest)
+    }
+
+    it("eventlog fetching is disabled when spark.eventLog is false") {
+      val fetcherConfigurationData = newFakeFetcherConfigurationData()
+      val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
+        override lazy val sparkConf: SparkConf = new SparkConf()
+          .set(SparkFetcher.SPARK_EVENT_LOG_ENABLED_KEY, "false")
+      }
+
+      sparkFetcher.eventLogSource should be(EventLogSource.None)
     }
   }
 }

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -16,24 +16,27 @@
 
 package com.linkedin.drelephant.spark.fetchers
 
-import java.net.URI
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 import java.text.SimpleDateFormat
+import java.util.zip.{ZipEntry, ZipOutputStream}
 import java.util.{Calendar, Date, SimpleTimeZone}
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationAttemptInfo, ApplicationInfo, ExecutorSummary, JobData, StageData}
 import javax.ws.rs.{GET, Path, PathParam, Produces}
-import javax.ws.rs.client.WebTarget
-import javax.ws.rs.core.{Application, MediaType}
+import javax.ws.rs.core.{Application, MediaType, Response}
 import javax.ws.rs.ext.ContextResolver
+
+import com.google.common.io.Resources
+import com.ning.compress.lzf.LZFEncoder
 import org.apache.spark.SparkConf
 import org.glassfish.jersey.client.ClientConfig
 import org.glassfish.jersey.server.ResourceConfig
 import org.glassfish.jersey.test.{JerseyTest, TestProperties}
+import org.json4s.DefaultFormats
 import org.scalatest.{AsyncFunSpec, Matchers}
 import org.scalatest.compatible.Assertion
 
@@ -56,6 +59,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
               .register(classOf[FetchClusterModeDataFixtures.JobsResource])
               .register(classOf[FetchClusterModeDataFixtures.StagesResource])
               .register(classOf[FetchClusterModeDataFixtures.ExecutorsResource])
+              .register(classOf[FetchClusterModeDataFixtures.LogsResource])
           case config => config
         }
       }
@@ -70,12 +74,18 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
-        restDerivedData.jobDatas should not be(None)
-        restDerivedData.stageDatas should not be(None)
-        restDerivedData.executorSummaries should not be(None)
+        restDerivedData.jobDatas should not be (None)
+        restDerivedData.stageDatas should not be (None)
+        restDerivedData.executorSummaries should not be (None)
+        restDerivedData.logDerivedData should be(None)
+      } flatMap {
+        case assertion: Try[Assertion] => assertion
+        case _ =>
+          sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID, fetchLogs = true)
+            .map { _.logDerivedData should not be(None) }
       } andThen { case assertion: Try[Assertion] =>
-          fakeJerseyServer.tearDown()
-          assertion
+        fakeJerseyServer.tearDown()
+        assertion
       }
     }
 
@@ -200,6 +210,9 @@ object SparkRestClientTest {
 
       @Path("applications/{appId}/{attemptId}/executors")
       def getExecutors(): ExecutorsResource = new ExecutorsResource()
+
+      @Path("applications/{appId}/{attemptId}/logs")
+      def getLogs(): LogsResource = new LogsResource()
     }
 
     @Produces(Array(MediaType.APPLICATION_JSON))
@@ -239,6 +252,16 @@ object SparkRestClientTest {
       @GET
       def getExecutors(@PathParam("appId") appId: String, @PathParam("attemptId") attemptId: String): Seq[ExecutorSummary] =
         if (attemptId == "2") Seq.empty else throw new Exception()
+    }
+
+    @Produces(Array(MediaType.APPLICATION_OCTET_STREAM))
+    class LogsResource {
+      @GET
+      def getLogs(@PathParam("appId") appId: String, @PathParam("attemptId") attemptId: String): Response = {
+        if (attemptId == "2") {
+          Response.ok(newFakeLog(appId, attemptId)).build()
+        } else throw new Exception()
+      }
     }
   }
 
@@ -312,4 +335,19 @@ object SparkRestClientTest {
     sparkUser = "foo",
     completed = true
   )
+
+  private implicit val formats: DefaultFormats = DefaultFormats
+
+  def newFakeLog(appId: String, attempId: String): InputStream = {
+    val os = new ByteArrayOutputStream()
+    val zos = new ZipOutputStream(os)
+    zos.putNextEntry(new ZipEntry("$appId_$attemptId.lzf"))
+    val events = Resources.toByteArray(Resources.getResource("spark_event_logs/event_log_2"))
+    // LZFEncoder instead of Snappy, because of xerial/snappy-java#76.
+    zos.write(LZFEncoder.encode(events))
+    zos.closeEntry()
+    zos.close()
+
+    new ByteArrayInputStream(os.toByteArray)
+  }
 }

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -67,7 +67,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchRestData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
+      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)
@@ -101,7 +101,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchRestData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
+      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)
@@ -135,7 +135,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"http://${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchRestData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
+      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -67,7 +67,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
+      sparkRestClient.fetchRestData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)
@@ -101,7 +101,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
+      sparkRestClient.fetchRestData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)
@@ -135,7 +135,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"http://${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
+      sparkRestClient.fetchRestData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
         restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
         restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -81,8 +81,11 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       } flatMap {
         case assertion: Try[Assertion] => assertion
         case _ =>
+          val expectedLogDerivedData =
+            SparkLogClient.findDerivedData(new ByteArrayInputStream(EVENT_LOG_2))
+
           sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID, fetchLogs = true)
-            .map { _.logDerivedData should not be(None) }
+            .map { _.logDerivedData should be(Some(expectedLogDerivedData)) }
       } andThen { case assertion: Try[Assertion] =>
         fakeJerseyServer.tearDown()
         assertion
@@ -100,6 +103,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
               .register(classOf[FetchClientModeDataFixtures.JobsResource])
               .register(classOf[FetchClientModeDataFixtures.StagesResource])
               .register(classOf[FetchClientModeDataFixtures.ExecutorsResource])
+              .register(classOf[FetchClientModeDataFixtures.LogsResource])
           case config => config
         }
       }
@@ -117,6 +121,15 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
         restDerivedData.jobDatas should not be(None)
         restDerivedData.stageDatas should not be(None)
         restDerivedData.executorSummaries should not be(None)
+        restDerivedData.logDerivedData should be(None)
+      } flatMap {
+        case assertion: Try[Assertion] => assertion
+        case _ =>
+          val expectedLogDerivedData =
+            SparkLogClient.findDerivedData(new ByteArrayInputStream(EVENT_LOG_2))
+
+          sparkRestClient.fetchData(FetchClientModeDataFixtures.APP_ID, fetchLogs = true)
+            .map { _.logDerivedData should be(Some(expectedLogDerivedData)) }
       } andThen { case assertion: Try[Assertion] =>
         fakeJerseyServer.tearDown()
         assertion
@@ -259,7 +272,7 @@ object SparkRestClientTest {
       @GET
       def getLogs(@PathParam("appId") appId: String, @PathParam("attemptId") attemptId: String): Response = {
         if (attemptId == "2") {
-          Response.ok(newFakeLog(appId, attemptId)).build()
+          Response.ok(newFakeLog(appId, Some(attemptId))).build()
         } else throw new Exception()
       }
     }
@@ -282,6 +295,9 @@ object SparkRestClientTest {
 
       @Path("applications/{appId}/executors")
       def getExecutors(): ExecutorsResource = new ExecutorsResource()
+
+      @Path("applications/{appId}/logs")
+      def getLogs(): LogsResource = new LogsResource()
     }
 
     @Produces(Array(MediaType.APPLICATION_JSON))
@@ -322,6 +338,14 @@ object SparkRestClientTest {
       def getExecutors(@PathParam("appId") appId: String): Seq[ExecutorSummary] =
         Seq.empty
     }
+
+    @Produces(Array(MediaType.APPLICATION_OCTET_STREAM))
+    class LogsResource {
+      @GET
+      def getLogs(@PathParam("appId") appId: String): Response = {
+        Response.ok(newFakeLog(appId, None)).build()
+      }
+    }
   }
 
   def newFakeApplicationAttemptInfo(
@@ -336,15 +360,16 @@ object SparkRestClientTest {
     completed = true
   )
 
-  private implicit val formats: DefaultFormats = DefaultFormats
+  private val EVENT_LOG_2 = Resources.toByteArray(
+    Resources.getResource("spark_event_logs/event_log_2"))
 
-  def newFakeLog(appId: String, attempId: String): InputStream = {
+  def newFakeLog(appId: String, attemptId: Option[String]): InputStream = {
     val os = new ByteArrayOutputStream()
     val zos = new ZipOutputStream(os)
-    zos.putNextEntry(new ZipEntry("$appId_$attemptId.lzf"))
-    val events = Resources.toByteArray(Resources.getResource("spark_event_logs/event_log_2"))
+    val name = attemptId.map(id => s"${appId}_$id").getOrElse(appId) + ".lzf"
+    zos.putNextEntry(new ZipEntry(name))
     // LZFEncoder instead of Snappy, because of xerial/snappy-java#76.
-    zos.write(LZFEncoder.encode(events))
+    zos.write(LZFEncoder.encode(EVENT_LOG_2))
     zos.closeEntry()
     zos.close()
 

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
@@ -259,7 +259,7 @@ object ExecutorsHeuristicTest {
       new ApplicationInfo(appId, name = "app", Seq.empty),
       jobDatas = Seq.empty,
       stageDatas = Seq.empty,
-      executorSummaries
+      executorSummaries = executorSummaries
     )
 
     SparkApplicationData(appId, restDerivedData, logDerivedData = None)

--- a/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
@@ -178,7 +178,7 @@ object StagesHeuristicTest {
     val restDerivedData = SparkRestDerivedData(
       new ApplicationInfo(appId, name = "app", Seq.empty),
       jobDatas = Seq.empty,
-      stageDatas,
+      stageDatas = stageDatas,
       executorSummaries = Seq.empty
     )
 

--- a/test/com/linkedin/drelephant/util/InfoExtractorTest.java
+++ b/test/com/linkedin/drelephant/util/InfoExtractorTest.java
@@ -218,14 +218,14 @@ public class InfoExtractorTest {
     InfoExtractor.loadSchedulerInfo(result, data, scheduler);
 
     assertEquals(result.scheduler, "azkaban");
-    assertFalse(StringUtils.isEmpty(result.getJobExecId()));
-    assertFalse(StringUtils.isEmpty(result.getJobDefId()));
-    assertFalse(StringUtils.isEmpty(result.getFlowExecId()));
-    assertFalse(StringUtils.isEmpty(result.getFlowDefId()));
-    assertFalse(StringUtils.isEmpty(result.getJobExecUrl()));
-    assertFalse(StringUtils.isEmpty(result.getJobDefUrl()));
-    assertFalse(StringUtils.isEmpty(result.getFlowExecUrl()));
-    assertFalse(StringUtils.isEmpty(result.getFlowDefUrl()));
+//    assertFalse(StringUtils.isEmpty(result.getJobExecId()));
+//    assertFalse(StringUtils.isEmpty(result.getJobDefId()));
+//    assertFalse(StringUtils.isEmpty(result.getFlowExecId()));
+//    assertFalse(StringUtils.isEmpty(result.getFlowDefId()));
+//    assertFalse(StringUtils.isEmpty(result.getJobExecUrl()));
+//    assertFalse(StringUtils.isEmpty(result.getJobDefUrl()));
+//    assertFalse(StringUtils.isEmpty(result.getFlowExecUrl()));
+//    assertFalse(StringUtils.isEmpty(result.getFlowDefUrl()));
   }
 
   @Test

--- a/test/com/linkedin/drelephant/util/InfoExtractorTest.java
+++ b/test/com/linkedin/drelephant/util/InfoExtractorTest.java
@@ -218,14 +218,14 @@ public class InfoExtractorTest {
     InfoExtractor.loadSchedulerInfo(result, data, scheduler);
 
     assertEquals(result.scheduler, "azkaban");
-//    assertFalse(StringUtils.isEmpty(result.getJobExecId()));
-//    assertFalse(StringUtils.isEmpty(result.getJobDefId()));
-//    assertFalse(StringUtils.isEmpty(result.getFlowExecId()));
-//    assertFalse(StringUtils.isEmpty(result.getFlowDefId()));
-//    assertFalse(StringUtils.isEmpty(result.getJobExecUrl()));
-//    assertFalse(StringUtils.isEmpty(result.getJobDefUrl()));
-//    assertFalse(StringUtils.isEmpty(result.getFlowExecUrl()));
-//    assertFalse(StringUtils.isEmpty(result.getFlowDefUrl()));
+    assertFalse(StringUtils.isEmpty(result.getJobExecId()));
+    assertFalse(StringUtils.isEmpty(result.getJobDefId()));
+    assertFalse(StringUtils.isEmpty(result.getFlowExecId()));
+    assertFalse(StringUtils.isEmpty(result.getFlowDefId()));
+    assertFalse(StringUtils.isEmpty(result.getJobExecUrl()));
+    assertFalse(StringUtils.isEmpty(result.getJobDefUrl()));
+    assertFalse(StringUtils.isEmpty(result.getFlowExecUrl()));
+    assertFalse(StringUtils.isEmpty(result.getFlowDefUrl()));
   }
 
   @Test


### PR DESCRIPTION
This PR allows Dr. Elephant to fetch Spark logs without universal
read access to eventLog.dir on HDFS. SparkFetcher would use SparkRestClient
instead of SparkLogClient if configured as

```
<params>
  <use_rest_for_eventlogs>true</use_rest_for_eventlogs>
</params>
```

The default behaviour is to fetch the logs via SparkLogClient/WebHDFS.

Closes #199

---

What is missing?

- [ ] Documentation
- [x] Tests
