### PR TITLE
Fetch Spark 1.X/2.X jobs within the same Dr. Elephant instance

### DIFF
--- a/app/com/linkedin/drelephant/ElephantContext.java
+++ b/app/com/linkedin/drelephant/ElephantContext.java
@@ -16,7 +16,9 @@
 
 package com.linkedin.drelephant;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.linkedin.drelephant.analysis.ApplicationType;
 import com.linkedin.drelephant.analysis.ElephantFetcher;
@@ -38,6 +40,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +79,7 @@ public class ElephantContext {
   private final Map<String, ApplicationType> _nameToType = new HashMap<String, ApplicationType>();
   private final Map<ApplicationType, List<Heuristic>> _typeToHeuristics = new HashMap<ApplicationType, List<Heuristic>>();
   private final Map<ApplicationType, HadoopMetricsAggregator> _typeToAggregator = new HashMap<ApplicationType, HadoopMetricsAggregator>();
-  private final Map<ApplicationType, ElephantFetcher> _typeToFetcher = new HashMap<ApplicationType, ElephantFetcher>();
+  private final Multimap<ApplicationType, ElephantFetcher> _typeToFetcher = ArrayListMultimap.create();
   private final Map<String, Html> _heuristicToView = new HashMap<String, Html>();
   private Map<ApplicationType, List<JobType>> _appTypeToJobTypes = new HashMap<ApplicationType, List<JobType>>();
 
@@ -162,9 +165,7 @@ public class ElephantContext {
         }
 
         ApplicationType type = data.getAppType();
-        if (_typeToFetcher.get(type) == null) {
-          _typeToFetcher.put(type, (ElephantFetcher) instance);
-        }
+        _typeToFetcher.put(type, (ElephantFetcher) instance);
 
         logger.info("Load Fetcher : " + data.getClassName());
       } catch (ClassNotFoundException e) {
@@ -357,7 +358,7 @@ public class ElephantContext {
    * @param type The application type
    * @return The corresponding fetcher
    */
-  public ElephantFetcher getFetcherForApplicationType(ApplicationType type) {
+  public Collection<ElephantFetcher> getFetchersForApplicationType(ApplicationType type) {
     return _typeToFetcher.get(type);
   }
 

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -17,14 +17,14 @@
 package com.linkedin.drelephant.spark.fetchers
 
 import scala.async.Async
+import scala.collection.JavaConverters._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, SECONDS}
-import scala.util.Try
 import scala.util.control.NonFatal
 
 import com.linkedin.drelephant.analysis.{AnalyticJob, ElephantFetcher}
 import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData
-import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
+import com.linkedin.drelephant.spark.data.SparkApplicationData
 import com.linkedin.drelephant.util.SparkUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.log4j.Logger
@@ -46,10 +46,21 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
   private[fetchers] lazy val sparkUtils: SparkUtils = SparkUtils
 
   private[fetchers] lazy val sparkConf: SparkConf = {
+    // Allow to override SPARK_CONF_DIR and SPARK_HOME with values in
+    // the fetcher configuration.
+    val envOverride = fetcherConfigurationData.getParamMap.asScala
+      .map { case (key, value) => key.toUpperCase() -> value }
+      .toMap
+    val env = sparkUtils.defaultEnv ++ envOverride
+
     val sparkConf = new SparkConf()
-    sparkUtils.getDefaultPropertiesFile(sparkUtils.defaultEnv) match {
-      case Some(filename) => sparkConf.setAll(sparkUtils.getPropertiesFromFile(filename))
-      case None => throw new IllegalStateException("can't find Spark conf; please set SPARK_HOME or SPARK_CONF_DIR")
+    sparkUtils.getDefaultPropertiesFile(env) match {
+      case Some(filename) =>
+        logger.info(s"Loading Spark configuration from $filename")
+        sparkConf.setAll(sparkUtils.getPropertiesFromFile(filename))
+      case None => throw new IllegalStateException(
+        "can't find Spark conf; please set SPARK_HOME or SPARK_CONF_DIR " +
+        "or define them in lowercase in fetcher params")
     }
     sparkConf
   }


### PR DESCRIPTION
This PR is just a proof-of-concept aiming to start a discussion about the possible implementation of #226. It works (validated on our cluster), but the implementation is rather ad-hoc and ugly. 

I think that another direction is to add a new abstraction -- fetcher "supervisers" or "meta-fetchers" who would coordinate other fetchers and proxy their results during analysis. The only issue with this (besides possible over-engineering) is that `<params />` are designed to be flat, so there is no way to express hierarchical configuration.