### PR TITLE
Add index on severity, finish_time to speed up welcome page display

### DIFF
--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -1,0 +1,12 @@
+# --- Indexing on severity,finish_time for count on welcome page
+# --- !Ups
+
+create index yarn_app_result_i9 on yarn_app_result (severity,finish_time);
+
+# --- !Downs
+
+drop index yarn_app_result_i9 on yarn_app_result;
+
+
+
+


### PR DESCRIPTION
Add an index on yarn_app_result table so the dashboard is display faster.

On our local deployment of dr-elephant with 2 millions of rows in this table(using mariadb) the below request was taking more than 30s:
`select count(*) from yarn_app_result t0 where t0.finish_time > 1496070064837  and t0.severity = 4`

With this index it now takes less than 1s.