### PR TITLE
Fix text box for ids composed of several words

### DIFF
--- a/app/views/page/flowHistoryPage.scala.html
+++ b/app/views/page/flowHistoryPage.scala.html
@@ -26,7 +26,7 @@
     <form class="box" id="flow-history-form" role="form" method="get" action="@routes.Application.flowHistory()">
       <div class="form-group">
         <label for="form-flow-def-idurl" >Flow Definition URL/ID</label>
-        <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value=@flowDefId>
+        <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value="@flowDefId">
       </div>
       <label for="graphType">Filter</label>
       <table>

--- a/app/views/page/jobHistoryPage.scala.html
+++ b/app/views/page/jobHistoryPage.scala.html
@@ -26,7 +26,7 @@
     <form id="job-history-form" role="form" method="get" action="@routes.Application.jobHistory()">
       <div class="form-group">
         <label for="form-job-def-id">Job Definition URL/ID</label>
-        <input type="text" class="form-control" id="form-job-def-id" name="job-def-id" placeholder="Job Def URL/ID" value=@jobDefId>
+        <input type="text" class="form-control" id="form-job-def-id" name="job-def-id" placeholder="Job Def URL/ID" value="@jobDefId">
       </div>
       <label for="graphType">Filter</label>
       <table>

--- a/app/views/page/oldFlowHistoryPage.scala.html
+++ b/app/views/page/oldFlowHistoryPage.scala.html
@@ -24,7 +24,7 @@
       <form id="flow-history-form" role="form" method="get" action="@routes.Application.oldFlowHistory()">
         <div class="form-group">
           <label for="form-flow-def-idurl">Flow Definition URL/ID</label>
-          <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value=@flowDefId>
+          <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value="@flowDefId">
         </div>
         <label for="graphType">Filter</label>
         <select class="form-control" name="select-graph-type" id="graphType">

--- a/app/views/page/oldJobHistoryPage.scala.html
+++ b/app/views/page/oldJobHistoryPage.scala.html
@@ -24,7 +24,7 @@
       <form id="job-history-form" role="form" method="get" action="@routes.Application.oldJobHistory()">
         <div class="form-group">
           <label for="form-job-def-id">Job Definition URL/ID</label>
-          <input type="text" class="form-control" id="form-job-def-id" name="job-def-id" placeholder="Job Def URL/ID" value=@jobDefId>
+          <input type="text" class="form-control" id="form-job-def-id" name="job-def-id" placeholder="Job Def URL/ID" value="@jobDefId">
         </div>
         <label for="graphType">Filter</label>
         <select class="form-control" name="select-graph-type" id="graphType">


### PR DESCRIPTION
This aims at fixing the Job History and Flow History views, when searching with _Flow Definition URL/ID_ that are composed of more than one word. Currently, if you search with, for example, a flow definition id such as **core-datamart (prod)**, the search is correctly done, but the string in the text box is sliced, and becomes **core-datamart**. This is an issue, as if you now change the filter for example, switching it from Resources to Time, the search will fail.