### PR TITLE
Add filtering on Job Definition Id in the Search view

### DIFF
--- a/app/views/page/searchPage.scala.html
+++ b/app/views/page/searchPage.scala.html
@@ -39,6 +39,10 @@
           <input type="text" class="form-control" id="form-flow-exec-id" name="flow-exec-id" placeholder="Flow Exec URL/ID">
         </div>
         <div class="form-group">
+          <label for="form-job-def-id">Job Definition ID</label>
+          <input type="text" class="form-control" id="form-job-def-id" name="job-def-id" placeholder="Job Definition ID">
+        </div>
+        <div class="form-group">
           <label for="form-username">User</label>
           <input type="text" class="form-control" id="form-username" name="username" placeholder="User">
         </div>

--- a/app/views/results/flowDefinitionIdDetails.scala.html
+++ b/app/views/results/flowDefinitionIdDetails.scala.html
@@ -14,27 +14,35 @@
 * the License.
 *@
 
-@(flowExecPair: IdUrlPair, results: java.util.Map[IdUrlPair, java.util.List[models.AppResult]])
+@(flowDefIdPair: IdUrlPair, results: java.util.Map[IdUrlPair, java.util.List[models.AppResult]])
 
 @*
-* Displays all the mr jobs belonging to a flow grouped by job exec url
+* Displays all the mr jobs triggered by a job definition id grouped by flow exec id
 *
-* @param flowExecPair The flow execution pair
-* @param results A map from job Exec URL to all the MR jobs.
+* @param flowDefIdPair The flow definition id pair
+* @param results A map from flow exec id to all the MR jobs triggered by the job definition id in flowDefIdPair.
 *@
 
 <div class="panel panel-default">
 
   <div class="panel-heading">
     <h3 class="panel-title">
-      Flow Execution URL: <a href=@flowExecPair.getUrl>@flowExecPair.getId</a>
+      @if(flowDefIdPair.getUrl.isEmpty){
+        Flow Id: @flowDefIdPair.getId
+      } else {
+        Flow Id: <a href=@flowDefIdPair.getUrl>@flowDefIdPair.getId</a>
+      }
     </h3>
   </div>
 
   <ul class="list-group">
-    @for( (jobExecPair, jobs) <- results) {
+    @for( (flowExecPair, jobs) <- results) {
       <div class="list-group-item">
-        Job Execution URL: <a href=@jobExecPair.getUrl>@jobExecPair.getId</a>
+        @if(flowExecPair.getUrl.isEmpty){
+          Flow Execution ID: @flowExecPair.getId
+        } else {
+          Flow Execution ID: <a href=@flowExecPair.getUrl>@flowExecPair.getId</a>
+        }
         <div class="list-group well-lg">
           @for(result <- jobs) {
             <a class="list-group-item list-group-item-@result.severity.getBootstrapColor"

--- a/public/js/searchform.js
+++ b/public/js/searchform.js
@@ -21,6 +21,7 @@ $(document).ready(function(){
 
   var jobId = $("#form-job-id");
   var flowExecId = $("#form-flow-exec-id");
+  var jobDefId = $("#form-job-def-id");
   var user = $("#form-username");
   var queueName = $("#form-queue-name");
   var jobtypeEnable = $("#form-job-type-enable");
@@ -45,6 +46,7 @@ $(document).ready(function(){
 
   var updateForm = function(){
     if(jobId.val()) {
+      jobDefId.prop('disabled', true);
       flowExecId.prop('disabled', true);
       user.prop('disabled', true);
       queueName.prop('disabled', true);
@@ -58,6 +60,20 @@ $(document).ready(function(){
       finishTimeEndDate.prop('disabled', true);
     } else if(flowExecId.val()) {
       jobId.prop('disabled', true);
+      jobDefId.prop('disabled', true);
+      user.prop('disabled', true);
+      queueName.prop('disabled', true);
+      severity.prop('disabled', true);
+      analysis.prop('disabled', true);
+      jobtype.prop('disabled', true);
+      jobtypeEnable.prop('disabled', true);
+      severityEnable.prop('disabled', true);
+      datetimeEnable.prop('disabled', true);
+      finishTimeBeginDate.prop('disabled', true);
+      finishTimeEndDate.prop('disabled', true);
+    } else if (jobDefId.val()) {
+      jobId.prop('disabled', true);
+      flowExecId.prop('disabled', true);
       user.prop('disabled', true);
       queueName.prop('disabled', true);
       severity.prop('disabled', true);
@@ -71,6 +87,7 @@ $(document).ready(function(){
     }
     else{
       jobId.prop('disabled', false);
+      jobDefId.prop('disabled', false);
       flowExecId.prop('disabled', false);
       jobtypeEnable.prop('disabled', false);
       severityEnable.prop('disabled', false);
@@ -103,6 +120,7 @@ $(document).ready(function(){
   }
   jobId.on("propertychange keyup input paste", updateForm);
   flowExecId.on("propertychange keyup input paste", updateForm);
+  jobDefId.on("propertychange keyup input paste", updateForm);
   jobtypeEnable.change(updateForm);
   severityEnable.change(updateForm);
   datetimeEnable.change(updateForm);


### PR DESCRIPTION
This change provides a new way of filtering when doing a search in the Search tab. It is now possible to use the Job Definition ID to get all execution of map reduce jobs that are related to this job definition id.

The results will be grouped by the flow execution id in which the job was executed. When searching with the job definition ID, it will thus be something like this : 


    Flow Id: flow_in_which_the_job_is_defined
       Flow Execution ID: flow_exec_1
           mr_job_triggered_by_the_job_definition_id_1
           mr_job_triggered_by_the_job_definition_id_2
           ...
       Flow Execution ID: flow_exec_2
           mr_job_triggered_by_the_job_definition_id_1
           mr_job_triggered_by_the_job_definition_id_2
           ...
       ...