### PR TITLE
Peak Unified Memory Heuristic - (Depends on Custom SHS - Requires peakUnifiedMemory metric)

### DIFF
--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -195,6 +195,12 @@
   </heuristic>
   <heuristic>
     <applicationtype>spark</applicationtype>
+    <heuristicname>Peak Unified Memory</heuristicname>
+    <classname>com.linkedin.drelephant.spark.heuristics.UnifiedMemoryHeuristic</classname>
+    <viewname>views.html.help.spark.helpUnifiedMemoryHeuristic</viewname>
+  </heuristic>
+  <heuristic>
+    <applicationtype>spark</applicationtype>
     <heuristicname>JVM Used Memory</heuristicname>
     <classname>com.linkedin.drelephant.spark.heuristics.JvmUsedMemoryHeuristic</classname>
     <viewname>views.html.help.spark.helpJvmUsedMemoryHeuristic</viewname>

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
@@ -90,6 +90,7 @@ trait ExecutorSummary{
   def totalMemoryBytesSpilled: Long
   def executorLogs: Map[String, String]
   def peakJvmUsedMemory: Map[String, Long]
+  def peakUnifiedMemory: Map[String, Long]
 }
 
 trait JobData{
@@ -298,7 +299,8 @@ class ExecutorSummaryImpl(
   var totalGCTime: Long,
   var totalMemoryBytesSpilled: Long,
   var executorLogs: Map[String, String],
-  var peakJvmUsedMemory: Map[String, Long]) extends ExecutorSummary
+  var peakJvmUsedMemory: Map[String, Long],
+  var peakUnifiedMemory: Map[String, Long]) extends ExecutorSummary
 
 class JobDataImpl(
   var jobId: Int,

--- a/app/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristic.scala
@@ -20,6 +20,7 @@ import com.linkedin.drelephant.analysis._
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.SparkApplicationData
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.ExecutorSummary
+
 import scala.collection.JavaConverters
 
 

--- a/app/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristic.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.spark.heuristics
+
+import com.linkedin.drelephant.analysis._
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
+import com.linkedin.drelephant.spark.data.SparkApplicationData
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.ExecutorSummary
+import scala.collection.JavaConverters
+
+
+/**
+  * A heuristic based on peak unified memory for the spark executors
+  *
+  * This heuristic reports the fraction of memory used/ memory allocated for execution and if the fraction can be reduced. Also, it checks for the skew in peak unified memory and reports if the skew is too much.
+  */
+
+
+class UnifiedMemoryHeuristic(private val heuristicConfigurationData: HeuristicConfigurationData)
+  extends Heuristic[SparkApplicationData] {
+
+  import UnifiedMemoryHeuristic._
+  import JavaConverters._
+
+  override def getHeuristicConfData(): HeuristicConfigurationData = heuristicConfigurationData
+
+  override def apply(data: SparkApplicationData): HeuristicResult = {
+    val evaluator = new Evaluator(this, data)
+
+    var resultDetails = Seq(
+      new HeuristicResultDetails("Max peak unified memory", evaluator.maxUnifiedMemory.toString),
+      new HeuristicResultDetails("Mean peak unified memory", evaluator.meanUnifiedMemory.toString)
+    )
+
+    if (evaluator.severityPeak.getValue > Severity.LOW.getValue) {
+      resultDetails = resultDetails :+ new HeuristicResultDetails("Note", "The value of peak unified memory is very low, we recommend to increase the value of spark.memory.fraction")
+    }
+    if (evaluator.severitySkew.getValue > Severity.LOW.getValue) {
+      resultDetails = resultDetails :+ new HeuristicResultDetails("Note", "There is a imbalance in the amount of work (and data) for tasks, please see into this so that in can be more balanced")
+    }
+    val result = new HeuristicResult(
+      heuristicConfigurationData.getClassName,
+      heuristicConfigurationData.getHeuristicName,
+      evaluator.severity,
+      0,
+      resultDetails.asJava
+    )
+    result
+  }
+
+}
+
+object UnifiedMemoryHeuristic {
+
+  val JVM_USED_MEMORY = "jvmUsedMemory"
+
+  class Evaluator(memoryFractionHeuristic: UnifiedMemoryHeuristic, data: SparkApplicationData) {
+    lazy val appConfigurationProperties: Map[String, String] =
+      data.appConfigurationProperties
+
+    lazy val executorSummaries: Seq[ExecutorSummary] = data.executorSummaries
+
+    val maxMemory: Long = executorSummaries.head.maxMemory
+
+    val DEFAULT_PEAK_UNIFIED_MEMORY_THRESHOLDS =
+      SeverityThresholds(low = 0.7 * maxMemory, moderate = 0.6 * maxMemory, severe = 0.4 * maxMemory, critical = 0.2 * maxMemory, ascending = false)
+
+    val DEFAULT_UNIFIED_MEMORY_SKEW_THRESHOLDS =
+      SeverityThresholds(low = 1.5 * meanUnifiedMemory, moderate = 2 * meanUnifiedMemory, severe = 4 * meanUnifiedMemory, critical = 8 * meanUnifiedMemory, ascending = true)
+
+    def getPeakUnifiedMemoryExecutorSeverity(executorSummary: ExecutorSummary): Severity = {
+      var jvmPeakUnifiedMemory: Long = executorSummary.peakUnifiedMemory.getOrElse(JVM_USED_MEMORY, 0)
+      return DEFAULT_PEAK_UNIFIED_MEMORY_THRESHOLDS.severityOf(jvmPeakUnifiedMemory)
+    }
+
+    lazy val meanUnifiedMemory: Long = (executorSummaries.map {
+      _.peakUnifiedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
+    }.sum) / executorSummaries.size
+    lazy val maxUnifiedMemory: Long = (executorSummaries.map {
+      _.peakUnifiedMemory.get(JVM_USED_MEMORY)
+    }.max).getOrElse(0)
+    val severitySkew = DEFAULT_UNIFIED_MEMORY_SKEW_THRESHOLDS.severityOf(maxUnifiedMemory)
+
+    lazy val severityPeak: Severity = {
+      var severityPeakUnifiedMemoryVariable: Severity = Severity.NONE
+      for (executorSummary <- executorSummaries) {
+        var peakUnifiedMemoryExecutorSeverity: Severity = getPeakUnifiedMemoryExecutorSeverity(executorSummary)
+        if (peakUnifiedMemoryExecutorSeverity.getValue > severityPeakUnifiedMemoryVariable.getValue) {
+          severityPeakUnifiedMemoryVariable = peakUnifiedMemoryExecutorSeverity
+        }
+      }
+      severityPeakUnifiedMemoryVariable
+    }
+    lazy val severity: Severity = Severity.max(severityPeak, severitySkew)
+  }
+
+}

--- a/app/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristic.scala
@@ -20,6 +20,7 @@ import com.linkedin.drelephant.analysis._
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.SparkApplicationData
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.ExecutorSummary
+import com.linkedin.drelephant.util.MemoryFormatUtils
 
 import scala.collection.JavaConverters
 
@@ -41,8 +42,8 @@ class UnifiedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
     val evaluator = new Evaluator(this, data)
 
     var resultDetails = Seq(
-      new HeuristicResultDetails("Allocated memory for the unified region", evaluator.maxMemory.toString),
-      new HeuristicResultDetails("Mean peak unified memory", evaluator.meanUnifiedMemory.toString)
+      new HeuristicResultDetails("Allocated memory for the unified region", MemoryFormatUtils.bytesToString(evaluator.maxMemory)),
+      new HeuristicResultDetails("Mean peak unified memory", MemoryFormatUtils.bytesToString(evaluator.meanUnifiedMemory))
     )
 
     if (evaluator.severity.getValue > Severity.LOW.getValue) {

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -24,7 +24,6 @@ import scala.util.Try
 import com.linkedin.drelephant.spark.fetchers.statusapiv1._
 import org.apache.spark.JobExecutionStatus
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
-
 /**
   * Converters for legacy SparkApplicationData to current SparkApplicationData.
   *

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -46,7 +46,7 @@ object LegacyDataConverters {
       override def shuffleWriteRecords: Long = 0
       override def inputBytes: Long = 0
       override def details: String = ""
-      override def tasks: Option[collection.Map[Long, TaskData]] = None
+      override def tasks = None
       override def attemptId: Int = 0
       override def stageId: Int = 0
       override def memoryBytesSpilled: Long = 0
@@ -206,7 +206,8 @@ object LegacyDataConverters {
         executorInfo.totalGCTime,
         executorInfo.totalMemoryBytesSpilled,
         executorLogs = Map.empty,
-        peakJvmUsedMemory = Map.empty
+        peakJvmUsedMemory = Map.empty,
+        peakUnifiedMemory = Map.empty
       )
     }
 

--- a/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
@@ -13,6 +13,9 @@
 * License for the specific language governing permissions and limitations under
 * the License.
 *@
-<pre>Peak Unified Memory Heuristic : This heuristic whether more memory has been allocated for an executor than being utilised.
-  It also checks for the peak unified memory skew amongst all executors and reports if the skew is significantly more.</pre>
-<p>Other suggestions are provided in the result itself</p>
+<p> This is a heuristic for peak Unified Memory </p>
+<h4>Peak Unified Memory</h4>
+<p>If the ratio of unified memory to executor memory is much smaller than "spark.memory.fraction", then more memory has been reserved for execution than is being used. This memory can instead be allocated for user memory, and/or total executor memory could be reduced.</p>
+<p>spark.memory.fraction: this is the fraction of (executor memory - reserved memory) used for execution and storage. This partitions user memory from execution and storage memory.</p>
+<h4>Unified Memory Skew</h4>
+<p>Skew in the amount of unified memory for different executors might indicates a similar imbalance in the amount of work (and data) for tasks. It should be more balanced.</p>

--- a/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
@@ -13,7 +13,12 @@
 * License for the specific language governing permissions and limitations under
 * the License.
 *@
-<p> This is a heuristic for peak Unified Memory </p>
+<p>Peak Unified Memory Heuristic identifies and flags jobs which have over allocated Unified Memory region.</p>
 <h4>Peak Unified Memory</h4>
-<p>If the peak unified memory is much smaller than allocated executor memory then we recommend to decrease spark.memory.fraction, or total executor memory.</p>
-<p>spark.memory.fraction: this is the fraction of (executor memory - reserved memory) used for execution and storage. This partitions user memory from execution and storage memory.</p>
+<p>If the job's Peak Unified Memory Consumption is much smaller than the allocated Unified Memory space, then we recommend decreasing the allocated Unified Memory Region for your job.</p>
+<h3>Action Items</h3>
+<p>The Allocated Unified Memory Region can be reduced in the following ways: </p>
+<p>1. If your job's Executor Memory is already low, then reduce <i>spark.memory.fraction</i> which will reduce the amount of space allocated to the Unified Memory Region.</p>
+<p>2. If your job's Executor Memory is high, then we recommend reducing the <i>spark.executor.memory</i> itself which will lower the Allocated Unified Memory space.</p>
+<p>Note:</p>
+<p><i>spark.memory.fraction</i>: This is the fraction of JVM Used Memory (Executor memory - Reserved memory) dedicated to the unified memory region (execution + storage). It basically partitions user memory from execution and storage memory.</p>

--- a/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
@@ -17,5 +17,3 @@
 <h4>Peak Unified Memory</h4>
 <p>If the peak unified memory is much smaller than allocated executor memory then we recommend to decrease spark.memory.fraction, or total executor memory.</p>
 <p>spark.memory.fraction: this is the fraction of (executor memory - reserved memory) used for execution and storage. This partitions user memory from execution and storage memory.</p>
-<h4>Unified Memory Skew</h4>
-<p>Skew in the amount of unified memory for different executors might indicate a similar imbalance in the amount of work (and data) for tasks. It should be more balanced.</p>

--- a/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
@@ -15,7 +15,7 @@
 *@
 <p> This is a heuristic for peak Unified Memory </p>
 <h4>Peak Unified Memory</h4>
-<p>If the ratio of unified memory to executor memory is much smaller than "spark.memory.fraction", then more memory has been reserved for execution than is being used. This memory can instead be allocated for user memory, and/or total executor memory could be reduced.</p>
+<p>If the peak unified memory is much smaller than allocated executor memory then we recommend to decrease spark.memory.fraction, or total executor memory.</p>
 <p>spark.memory.fraction: this is the fraction of (executor memory - reserved memory) used for execution and storage. This partitions user memory from execution and storage memory.</p>
 <h4>Unified Memory Skew</h4>
-<p>Skew in the amount of unified memory for different executors might indicates a similar imbalance in the amount of work (and data) for tasks. It should be more balanced.</p>
+<p>Skew in the amount of unified memory for different executors might indicate a similar imbalance in the amount of work (and data) for tasks. It should be more balanced.</p>

--- a/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpUnifiedMemoryHeuristic.scala.html
@@ -1,0 +1,18 @@
+@*
+* Copyright 2016 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*@
+<pre>Peak Unified Memory Heuristic : This heuristic whether more memory has been allocated for an executor than being utilised.
+  It also checks for the peak unified memory skew amongst all executors and reports if the skew is significantly more.</pre>
+<p>Other suggestions are provided in the result itself</p>

--- a/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
+++ b/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
@@ -199,6 +199,7 @@ object SparkMetricsAggregatorTest {
     totalGCTime = 0,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,
-    peakJvmUsedMemory = Map.empty
+    peakJvmUsedMemory = Map.empty,
+    peakUnifiedMemory = Map.empty
   )
 }

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
@@ -121,7 +121,8 @@ object ExecutorGcHeuristicTest {
     totalGCTime,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,
-    peakJvmUsedMemory = Map.empty
+    peakJvmUsedMemory = Map.empty,
+    peakUnifiedMemory = Map.empty
   )
 
   def newFakeSparkApplicationData(

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorStorageSpillHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorStorageSpillHeuristicTest.scala
@@ -111,7 +111,9 @@ object ExecutorStorageSpillHeuristicTest {
     maxMemory= 0,
     totalGCTime = 0,
     totalMemoryBytesSpilled,
-    executorLogs = Map.empty
+    executorLogs = Map.empty,
+    peakJvmUsedMemory = Map.empty,
+    peakUnifiedMemory = Map.empty
   )
 
   def newFakeSparkApplicationData(
@@ -124,7 +126,8 @@ object ExecutorStorageSpillHeuristicTest {
       new ApplicationInfoImpl(appId, name = "app", Seq.empty),
       jobDatas = Seq.empty,
       stageDatas = Seq.empty,
-      executorSummaries = executorSummaries
+      executorSummaries = executorSummaries,
+      stagesWithFailedTasks = Seq.empty
     )
 
     val logDerivedData = SparkLogDerivedData(

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
@@ -252,7 +252,8 @@ object ExecutorsHeuristicTest {
     totalGCTime = 0,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,
-    peakJvmUsedMemory = Map.empty
+    peakJvmUsedMemory = Map.empty,
+    peakUnifiedMemory = Map.empty
   )
 
   def newFakeSparkApplicationData(executorSummaries: Seq[ExecutorSummaryImpl]): SparkApplicationData = {

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -86,8 +86,10 @@ object JvmUsedMemoryHeuristicTest {
     totalShuffleWrite = 0,
     maxMemory = 0,
     totalGCTime = 0,
+    totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,
-    peakJvmUsedMemory
+    peakJvmUsedMemory,
+    peakUnifiedMemory = Map.empty
   )
 
   def newFakeSparkApplicationData(
@@ -104,7 +106,8 @@ object JvmUsedMemoryHeuristicTest {
       new ApplicationInfoImpl(appId, name = "app", Seq.empty),
       jobDatas = Seq.empty,
       stageDatas = Seq.empty,
-      executorSummaries = executorSummaries
+      executorSummaries = executorSummaries,
+      stagesWithFailedTasks = Seq.empty
     )
 
     SparkApplicationData(appId, restDerivedData, Some(logDerivedData))

--- a/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
@@ -23,9 +23,9 @@ import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, JobDataImpl, StageDataImpl}
-import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
 import org.scalatest.{FunSpec, Matchers}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 
 class StagesHeuristicTest extends FunSpec with Matchers {
   import StagesHeuristicTest._

--- a/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
@@ -22,10 +22,10 @@ import scala.concurrent.duration.Duration
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
-import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, JobDataImpl, StageDataImpl}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, StageDataImpl}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
 import org.scalatest.{FunSpec, Matchers}
-import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 
 class StagesHeuristicTest extends FunSpec with Matchers {
   import StagesHeuristicTest._

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -1,0 +1,83 @@
+package com.linkedin.drelephant.spark.heuristics
+
+import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
+import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkRestDerivedData}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, ExecutorSummaryImpl}
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.collection.JavaConverters
+
+class UnifiedMemoryHeuristicTest extends FunSpec with Matchers {
+
+  import UnifiedMemoryHeuristicTest._
+
+  val heuristicConfigurationData = newFakeHeuristicConfigurationData()
+
+  val memoryFractionHeuristic = new UnifiedMemoryHeuristic(heuristicConfigurationData)
+
+  val appConfigurationProperties = Map.empty
+  val executorData = Seq(
+    newDummyExecutorData("1", 400000, Map("jvmUsedMemory" -> 394567)),
+    newDummyExecutorData("2", 400000, Map("jvmUsedMemory" -> 234568)),
+    newDummyExecutorData("3", 400000, Map("jvmUsedMemory" -> 334569)),
+    newDummyExecutorData("4", 400000, Map("jvmUsedMemory" -> 23456)),
+    newDummyExecutorData("5", 400000, Map("jvmUsedMemory" -> 234564)),
+    newDummyExecutorData("6", 400000, Map("jvmUsedMemory" -> 394561))
+  )
+  describe(".apply") {
+    val data = newFakeSparkApplicationData(executorData)
+    val heuristicResult = memoryFractionHeuristic.apply(data)
+    val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
+
+    it("has severity") {
+      heuristicResult.getSeverity should be(Severity.CRITICAL)
+    }
+  }
+}
+
+object UnifiedMemoryHeuristicTest {
+
+  import JavaConverters._
+
+  def newFakeHeuristicConfigurationData(params: Map[String, String] = Map.empty): HeuristicConfigurationData =
+    new HeuristicConfigurationData("heuristic", "class", "view", new ApplicationType("type"), params.asJava)
+
+  def newDummyExecutorData(
+                            id: String,
+                            maxMemory: Long,
+                            peakUnifiedMemory: Map[String, Long]
+                          ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
+    id,
+    hostPort = "",
+    rddBlocks = 0,
+    memoryUsed = 0,
+    diskUsed = 0,
+    activeTasks = 0,
+    failedTasks = 0,
+    completedTasks = 0,
+    totalTasks = 0,
+    totalDuration = 0,
+    totalInputBytes = 0,
+    totalShuffleRead = 0,
+    totalShuffleWrite = 0,
+    maxMemory,
+    executorLogs = Map.empty,
+    peakUnifiedMemory
+  )
+
+  def newFakeSparkApplicationData(
+                                   executorSummaries: Seq[ExecutorSummaryImpl]
+                                 ): SparkApplicationData = {
+    val appId = "application_1"
+
+    val restDerivedData = SparkRestDerivedData(
+      new ApplicationInfoImpl(appId, name = "app", Seq.empty),
+      jobDatas = Seq.empty,
+      stageDatas = Seq.empty,
+      executorSummaries = executorSummaries
+    )
+
+    SparkApplicationData(appId, restDerivedData, logDerivedData = None)
+  }
+}

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -17,12 +17,12 @@ class UnifiedMemoryHeuristicTest extends FunSpec with Matchers {
   val memoryFractionHeuristic = new UnifiedMemoryHeuristic(heuristicConfigurationData)
 
   val executorData = Seq(
-    newDummyExecutorData("1", 400000, Map("jvmUsedMemory" -> 394567)),
-    newDummyExecutorData("2", 400000, Map("jvmUsedMemory" -> 234568)),
-    newDummyExecutorData("3", 400000, Map("jvmUsedMemory" -> 334569)),
-    newDummyExecutorData("4", 400000, Map("jvmUsedMemory" -> 23456)),
-    newDummyExecutorData("5", 400000, Map("jvmUsedMemory" -> 234564)),
-    newDummyExecutorData("6", 400000, Map("jvmUsedMemory" -> 394561))
+    newDummyExecutorData("1", 400000, Map("executionMemory" -> 300000, "storageMemory" -> 94567)),
+    newDummyExecutorData("2", 400000, Map("executionMemory" -> 200000, "storageMemory" -> 34568)),
+    newDummyExecutorData("3", 400000, Map("executionMemory" -> 300000, "storageMemory" -> 34569)),
+    newDummyExecutorData("4", 400000, Map("executionMemory" -> 20000, "storageMemory" -> 3456)),
+    newDummyExecutorData("5", 400000, Map("executionMemory" -> 200000, "storageMemory" -> 34564)),
+    newDummyExecutorData("6", 400000, Map("executionMemory" -> 300000, "storageMemory" -> 94561))
   )
   describe(".apply") {
     val data = newFakeSparkApplicationData(executorData)
@@ -43,10 +43,10 @@ object UnifiedMemoryHeuristicTest {
     new HeuristicConfigurationData("heuristic", "class", "view", new ApplicationType("type"), params.asJava)
 
   def newDummyExecutorData(
-                            id: String,
-                            maxMemory: Long,
-                            peakUnifiedMemory: Map[String, Long]
-                          ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
+    id: String,
+    maxMemory: Long,
+    peakUnifiedMemory: Map[String, Long]
+  ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
     id,
     hostPort = "",
     rddBlocks = 0,
@@ -65,11 +65,8 @@ object UnifiedMemoryHeuristicTest {
     peakUnifiedMemory
   )
 
-  def newFakeSparkApplicationData(
-                                   executorSummaries: Seq[ExecutorSummaryImpl]
-                                 ): SparkApplicationData = {
+  def newFakeSparkApplicationData(executorSummaries: Seq[ExecutorSummaryImpl]): SparkApplicationData = {
     val appId = "application_1"
-
     val restDerivedData = SparkRestDerivedData(
       new ApplicationInfoImpl(appId, name = "app", Seq.empty),
       jobDatas = Seq.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -16,7 +16,6 @@ class UnifiedMemoryHeuristicTest extends FunSpec with Matchers {
 
   val memoryFractionHeuristic = new UnifiedMemoryHeuristic(heuristicConfigurationData)
 
-  val appConfigurationProperties = Map.empty
   val executorData = Seq(
     newDummyExecutorData("1", 400000, Map("jvmUsedMemory" -> 394567)),
     newDummyExecutorData("2", 400000, Map("jvmUsedMemory" -> 234568)),

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -61,6 +61,7 @@ object UnifiedMemoryHeuristicTest {
     totalShuffleRead = 0,
     totalShuffleWrite = 0,
     maxMemory,
+    totalGCTime = 0,
     executorLogs = Map.empty,
     peakUnifiedMemory
   )

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -62,7 +62,9 @@ object UnifiedMemoryHeuristicTest {
     totalShuffleWrite = 0,
     maxMemory,
     totalGCTime = 0,
+    totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,
+    peakJvmUsedMemory = Map.empty,
     peakUnifiedMemory
   )
 
@@ -72,7 +74,8 @@ object UnifiedMemoryHeuristicTest {
       new ApplicationInfoImpl(appId, name = "app", Seq.empty),
       jobDatas = Seq.empty,
       stageDatas = Seq.empty,
-      executorSummaries = executorSummaries
+      executorSummaries = executorSummaries,
+      stagesWithFailedTasks = Seq.empty
     )
 
     SparkApplicationData(appId, restDerivedData, logDerivedData = None)

--- a/test/com/linkedin/drelephant/util/SparkUtilsTest.scala
+++ b/test/com/linkedin/drelephant/util/SparkUtilsTest.scala
@@ -287,7 +287,7 @@ object SparkUtilsTest extends MockitoSugar {
         BDDMockito.given(fileStatus.getPath()).willReturn(expectedPath)
         fileStatus
       }
-      val expectedStatusArray =  Array(expectedFileStatus)
+      val expectedStatusArray = Array(expectedFileStatus)
 
       val filter = new PathFilter() {
         override def accept(file: Path): Boolean = {
@@ -298,7 +298,7 @@ object SparkUtilsTest extends MockitoSugar {
       BDDMockito.given(fs.getUri).willReturn(fileSystemUri)
       BDDMockito.given(fs.exists(expectedPath)).willReturn(true)
       BDDMockito.given(fs.getFileStatus(expectedPath)).willReturn(expectedFileStatus)
-      BDDMockito.given(fs.listStatus(org.mockito.Matchers.refEq(new Path( new Path(fileSystemUri), basePath)),
+      BDDMockito.given(fs.listStatus(org.mockito.Matchers.refEq(new Path(new Path(fileSystemUri), basePath)),
         org.mockito.Matchers.any(filter.getClass))).
         willReturn(expectedStatusArray)
       BDDMockito.given(fs.open(expectedPath)).willReturn(


### PR DESCRIPTION
The amount of unified memory can be examined to see if spark.memory.fraction can be adjusted. If the ratio of unified memory to executor memory is much smaller than  spark.memory.fraction, then more memory has been reserved for execution than is being used. This memory can instead be allocated for user memory, and/or total executor memory could be reduced.