### PR TITLE
Peak JVM used memory heuristic - (Depends on Custom SHS - Requires peakJvmUsedMemory metric)

### DIFF
--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -81,7 +81,7 @@
   -->
   <fetcher>
     <applicationtype>spark</applicationtype>
-    <classname>com.linkedin.drelephant.spark.fetchers.FSFetcher</classname>
+    <classname>com.linkedin.drelephant.spark.fetchers.SparkFetcher</classname>
   </fetcher>
 
   <!--

--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -195,7 +195,7 @@
   </heuristic>
   <heuristic>
     <applicationtype>spark</applicationtype>
-    <heuristicname>Spark JVM Used Memory</heuristicname>
+    <heuristicname>JVM Used Memory</heuristicname>
     <classname>com.linkedin.drelephant.spark.heuristics.JvmUsedMemoryHeuristic</classname>
     <viewname>views.html.help.spark.helpJvmUsedMemoryHeuristic</viewname>
   </heuristic>

--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -195,6 +195,12 @@
   </heuristic>
   <heuristic>
     <applicationtype>spark</applicationtype>
+    <heuristicname>Spark JVM Used Memory</heuristicname>
+    <classname>com.linkedin.drelephant.spark.heuristics.JvmUsedMemoryHeuristic</classname>
+    <viewname>views.html.help.spark.helpJvmUsedMemoryHeuristic</viewname>
+  </heuristic>
+  <heuristic>
+    <applicationtype>spark</applicationtype>
     <heuristicname>Executor GC</heuristicname>
     <classname>com.linkedin.drelephant.spark.heuristics.ExecutorGcHeuristic</classname>
     <viewname>views.html.help.spark.helpExecutorGcHeuristic</viewname>

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
@@ -87,7 +87,9 @@ trait ExecutorSummary{
   def totalShuffleWrite: Long
   def maxMemory: Long
   def totalGCTime: Long
-  def executorLogs: Map[String, String]}
+  def executorLogs: Map[String, String]
+  def peakJvmUsedMemory: Map[String, Long]
+}
 
 trait JobData{
   def jobId: Int
@@ -293,7 +295,8 @@ class ExecutorSummaryImpl(
   var totalShuffleWrite: Long,
   var maxMemory: Long,
   var totalGCTime: Long,
-  var executorLogs: Map[String, String]) extends ExecutorSummary
+  var executorLogs: Map[String, String],
+  var peakJvmUsedMemory: Map[String, Long]) extends ExecutorSummary
 
 class JobDataImpl(
   var jobId: Int,

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -47,7 +47,7 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
 
     if(evaluator.severityExecutor.getValue > Severity.LOW.getValue) {
       new HeuristicResultDetails("Note", "The allocated memory for the executor (in " + SPARK_EXECUTOR_MEMORY +") is much more than the peak JVM used memory by executors.")
-      new HeuristicResultDetails("Reasonable size for executor memory", ((1+BUFFER_PERCENT/100)*evaluator.maxExecutorPeakJvmUsedMemory).toString)
+      new HeuristicResultDetails("Reasonable size for executor memory", ((1+BUFFER_PERCENT.toDouble/100.0)*evaluator.maxExecutorPeakJvmUsedMemory).toString)
     }
 
     if(evaluator.severityDriver.getValue > Severity.LOW.getValue) {

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -48,12 +48,12 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
     )
 
     if(evaluator.severityExecutor.getValue > Severity.LOW.getValue) {
-      resultDetails :+ new HeuristicResultDetails("Note", "The allocated memory for the executor (in " + SPARK_EXECUTOR_MEMORY +") is much more than the peak JVM used memory by executors.")
+      resultDetails :+ new HeuristicResultDetails("Executor Memory", "The allocated memory for the executor (in " + SPARK_EXECUTOR_MEMORY +") is much more than the peak JVM used memory by executors.")
       resultDetails :+ new HeuristicResultDetails("Reasonable size for executor memory", ((1+BUFFER_PERCENT.toDouble/100.0)*evaluator.maxExecutorPeakJvmUsedMemory).toString)
     }
 
     if(evaluator.severityDriver.getValue > Severity.LOW.getValue) {
-      resultDetails :+ new HeuristicResultDetails("Note", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
+      resultDetails :+ new HeuristicResultDetails("Driver Memory", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
     }
 
     val result = new HeuristicResult(

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -54,9 +54,10 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
       new HeuristicResultDetails("Note", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
     }
 
-    if(evaluator.severitySkew.getValue > Severity.LOW.getValue) {
-      new HeuristicResultDetails("Note", "As there is a big difference between median and maximum values of the peak JVM used memory, there could also be a skew in the data being processed. Please look into that.")
-    }
+//    Disabling the skew test for executors
+//    if(evaluator.severitySkew.getValue > Severity.LOW.getValue) {
+//      new HeuristicResultDetails("Note", "As there is a big difference between median and maximum values of the peak JVM used memory, there could also be a skew in the data being processed. Please look into that.")
+//    }
 
     val result = new HeuristicResult(
       heuristicConfigurationData.getClassName,
@@ -106,7 +107,10 @@ object JvmUsedMemoryHeuristic {
 
     val severityExecutor = DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkExecutorMemory)
     val severityDriver = DEFAULT_MAX_DRIVER_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkDriverMemory)
-    val severitySkew = DEFAULT_JVM_MEMORY_SKEW_THRESHOLDS.severityOf(maxExecutorPeakJvmUsedMemory)
-    val severity : Severity = Severity.max(severityDriver, severityExecutor, severitySkew)
+    /**
+      * disabling the skew check for executors
+      * val severitySkew = DEFAULT_JVM_MEMORY_SKEW_THRESHOLDS.severityOf(maxExecutorPeakJvmUsedMemory)
+      */
+    val severity : Severity = Severity.max(severityDriver, severityExecutor)
   }
 }

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -41,8 +41,10 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
     val evaluator = new Evaluator(this, data)
 
     var resultDetails = Seq(
-      new HeuristicResultDetails("Max peak JVM used memory", evaluator.maxExecutorPeakJvmUsedMemory.toString),
-      new HeuristicResultDetails("Median peak JVM used memory", evaluator.medianPeakJvmUsedMemory.toString)
+      new HeuristicResultDetails("Max executor peak JVM used memory", MemoryFormatUtils.bytesToString(evaluator.maxExecutorPeakJvmUsedMemory)),
+      new HeuristicResultDetails("Max driver peak JVM used memory", MemoryFormatUtils.bytesToString(evaluator.maxDriverPeakJvmUsedMemory)),
+      new HeuristicResultDetails("spark.executor.memory", MemoryFormatUtils.bytesToString(evaluator.sparkExecutorMemory)),
+      new HeuristicResultDetails("spark.driver.memory", MemoryFormatUtils.bytesToString(evaluator.sparkDriverMemory))
     )
 
     if(evaluator.severityExecutor.getValue > Severity.LOW.getValue) {
@@ -53,11 +55,6 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
     if(evaluator.severityDriver.getValue > Severity.LOW.getValue) {
       new HeuristicResultDetails("Note", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
     }
-
-//    Disabling the skew test for executors
-//    if(evaluator.severitySkew.getValue > Severity.LOW.getValue) {
-//      new HeuristicResultDetails("Note", "As there is a big difference between median and maximum values of the peak JVM used memory, there could also be a skew in the data being processed. Please look into that.")
-//    }
 
     val result = new HeuristicResult(
       heuristicConfigurationData.getClassName,
@@ -71,7 +68,6 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
 }
 
 object JvmUsedMemoryHeuristic {
-
   val JVM_USED_MEMORY = "jvmUsedMemory"
   val SPARK_EXECUTOR_MEMORY = "spark.executor.memory"
   val SPARK_DRIVER_MEMORY = "spark.driver.memory"
@@ -83,27 +79,23 @@ object JvmUsedMemoryHeuristic {
       data.appConfigurationProperties
 
     lazy val executorSummaries: Seq[ExecutorSummary] = data.executorSummaries
-
-    val driverSummary : Option[ExecutorSummary] = executorSummaries.find(_.id.equals("driver"))
+    lazy val driverSummary : Option[ExecutorSummary] = executorSummaries.find(_.id.equals("driver"))
     val maxDriverPeakJvmUsedMemory : Long = driverSummary.get.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
-    val executorList : Seq[ExecutorSummary] = executorSummaries.patch(executorSummaries.indexWhere(_.id.equals("driver")), Nil, 1)
+    val executorList : Seq[ExecutorSummary] = executorSummaries.filterNot(_.id.equals("driver"))
     val sparkExecutorMemory : Long = (appConfigurationProperties.get(SPARK_EXECUTOR_MEMORY).map(MemoryFormatUtils.stringToBytes)).getOrElse(0)
     val sparkDriverMemory : Long = appConfigurationProperties.get(SPARK_DRIVER_MEMORY).map(MemoryFormatUtils.stringToBytes).getOrElse(0)
     val medianPeakJvmUsedMemory: Long = executorList.map {
       _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
     }.sortWith(_< _).drop(executorList.size/2).head
-    val maxExecutorPeakJvmUsedMemory: Long = (executorList.map {
+    lazy val maxExecutorPeakJvmUsedMemory: Long = (executorList.map {
       _.peakJvmUsedMemory.get(JVM_USED_MEMORY)
-    }.max).getOrElse(0)
+    }.max).getOrElse(0.asInstanceOf[Number].longValue())
 
     val DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS =
       SeverityThresholds(low = 1.5 * (maxExecutorPeakJvmUsedMemory + reservedMemory), moderate = 2 * (maxExecutorPeakJvmUsedMemory + reservedMemory), severe = 4 * (maxExecutorPeakJvmUsedMemory + reservedMemory), critical = 8 * (maxExecutorPeakJvmUsedMemory + reservedMemory), ascending = true)
 
     val DEFAULT_MAX_DRIVER_PEAK_JVM_USED_MEMORY_THRESHOLDS =
       SeverityThresholds(low = 1.5 * (maxDriverPeakJvmUsedMemory + reservedMemory), moderate = 2 * (maxDriverPeakJvmUsedMemory + reservedMemory), severe = 4 * (maxDriverPeakJvmUsedMemory + reservedMemory), critical = 8 * (maxDriverPeakJvmUsedMemory + reservedMemory), ascending = true)
-
-    val DEFAULT_JVM_MEMORY_SKEW_THRESHOLDS =
-      SeverityThresholds(low = 1.5 * medianPeakJvmUsedMemory, moderate = 2 * medianPeakJvmUsedMemory, severe = 4 * medianPeakJvmUsedMemory, critical = 8 * medianPeakJvmUsedMemory, ascending = true)
 
     val severityExecutor = DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkExecutorMemory)
     val severityDriver = DEFAULT_MAX_DRIVER_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkDriverMemory)

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -67,7 +67,6 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
     )
     result
   }
-
 }
 
 object JvmUsedMemoryHeuristic {

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -29,8 +29,6 @@ import scala.collection.JavaConverters
   * A heuristic based on peak JVM used memory for the spark executors and drivers
   *
   */
-
-
 class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicConfigurationData)
   extends Heuristic[SparkApplicationData] {
 

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -48,12 +48,12 @@ class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicCo
     )
 
     if(evaluator.severityExecutor.getValue > Severity.LOW.getValue) {
-      new HeuristicResultDetails("Note", "The allocated memory for the executor (in " + SPARK_EXECUTOR_MEMORY +") is much more than the peak JVM used memory by executors.")
-      new HeuristicResultDetails("Reasonable size for executor memory", ((1+BUFFER_PERCENT.toDouble/100.0)*evaluator.maxExecutorPeakJvmUsedMemory).toString)
+      resultDetails :+ new HeuristicResultDetails("Note", "The allocated memory for the executor (in " + SPARK_EXECUTOR_MEMORY +") is much more than the peak JVM used memory by executors.")
+      resultDetails :+ new HeuristicResultDetails("Reasonable size for executor memory", ((1+BUFFER_PERCENT.toDouble/100.0)*evaluator.maxExecutorPeakJvmUsedMemory).toString)
     }
 
     if(evaluator.severityDriver.getValue > Severity.LOW.getValue) {
-      new HeuristicResultDetails("Note", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
+      resultDetails :+ new HeuristicResultDetails("Note", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
     }
 
     val result = new HeuristicResult(

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -107,6 +107,7 @@ object JvmUsedMemoryHeuristic {
 
     val severityExecutor = DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkExecutorMemory)
     val severityDriver = DEFAULT_MAX_DRIVER_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkDriverMemory)
+    
     /**
       * disabling the skew check for executors
       * val severitySkew = DEFAULT_JVM_MEMORY_SKEW_THRESHOLDS.severityOf(maxExecutorPeakJvmUsedMemory)

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -80,16 +80,16 @@ object JvmUsedMemoryHeuristic {
 
     lazy val executorSummaries: Seq[ExecutorSummary] = data.executorSummaries
     lazy val driverSummary : Option[ExecutorSummary] = executorSummaries.find(_.id.equals("driver"))
-    val maxDriverPeakJvmUsedMemory : Long = driverSummary.get.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
+    val maxDriverPeakJvmUsedMemory : Long = driverSummary.get.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0L).asInstanceOf[Number].longValue
     val executorList : Seq[ExecutorSummary] = executorSummaries.filterNot(_.id.equals("driver"))
-    val sparkExecutorMemory : Long = (appConfigurationProperties.get(SPARK_EXECUTOR_MEMORY).map(MemoryFormatUtils.stringToBytes)).getOrElse(0)
-    val sparkDriverMemory : Long = appConfigurationProperties.get(SPARK_DRIVER_MEMORY).map(MemoryFormatUtils.stringToBytes).getOrElse(0)
+    val sparkExecutorMemory : Long = (appConfigurationProperties.get(SPARK_EXECUTOR_MEMORY).map(MemoryFormatUtils.stringToBytes)).getOrElse(0L)
+    val sparkDriverMemory : Long = appConfigurationProperties.get(SPARK_DRIVER_MEMORY).map(MemoryFormatUtils.stringToBytes).getOrElse(0L)
     val medianPeakJvmUsedMemory: Long = executorList.map {
-      _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
+      _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0L).asInstanceOf[Number].longValue
     }.sortWith(_< _).drop(executorList.size/2).head
     lazy val maxExecutorPeakJvmUsedMemory: Long = (executorList.map {
       _.peakJvmUsedMemory.get(JVM_USED_MEMORY)
-    }.max).getOrElse(0.asInstanceOf[Number].longValue())
+    }.max).getOrElse(0L)
 
     val DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS =
       SeverityThresholds(low = 1.5 * (maxExecutorPeakJvmUsedMemory + reservedMemory), moderate = 2 * (maxExecutorPeakJvmUsedMemory + reservedMemory), severe = 4 * (maxExecutorPeakJvmUsedMemory + reservedMemory), critical = 8 * (maxExecutorPeakJvmUsedMemory + reservedMemory), ascending = true)

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -87,9 +87,9 @@ object JvmUsedMemoryHeuristic {
     val medianPeakJvmUsedMemory: Long = executorList.map {
       _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0L).asInstanceOf[Number].longValue
     }.sortWith(_< _).drop(executorList.size/2).head
-    lazy val maxExecutorPeakJvmUsedMemory: Long = (executorList.map {
-      _.peakJvmUsedMemory.get(JVM_USED_MEMORY)
-    }.max).getOrElse(0L)
+    lazy val maxExecutorPeakJvmUsedMemory: Long = executorList.map {
+      _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0L)
+    }.max
 
     val DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS =
       SeverityThresholds(low = 1.5 * (maxExecutorPeakJvmUsedMemory + reservedMemory), moderate = 2 * (maxExecutorPeakJvmUsedMemory + reservedMemory), severe = 4 * (maxExecutorPeakJvmUsedMemory + reservedMemory), critical = 8 * (maxExecutorPeakJvmUsedMemory + reservedMemory), ascending = true)

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -84,11 +84,11 @@ object JvmUsedMemoryHeuristic {
     val executorList : Seq[ExecutorSummary] = executorSummaries.filterNot(_.id.equals("driver"))
     val sparkExecutorMemory : Long = (appConfigurationProperties.get(SPARK_EXECUTOR_MEMORY).map(MemoryFormatUtils.stringToBytes)).getOrElse(0L)
     val sparkDriverMemory : Long = appConfigurationProperties.get(SPARK_DRIVER_MEMORY).map(MemoryFormatUtils.stringToBytes).getOrElse(0L)
-    val medianPeakJvmUsedMemory: Long = executorList.map {
+    val medianPeakJvmUsedMemory: Long = if (executorList.isEmpty) 0L else executorList.map {
       _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0L).asInstanceOf[Number].longValue
     }.sortWith(_< _).drop(executorList.size/2).head
-    lazy val maxExecutorPeakJvmUsedMemory: Long = executorList.map {
-      _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0L)
+    lazy val maxExecutorPeakJvmUsedMemory: Long = if (executorList.isEmpty) 0L else executorList.map {
+      _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
     }.max
 
     val DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS =

--- a/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristic.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.spark.heuristics
+
+import com.linkedin.drelephant.analysis._
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
+import com.linkedin.drelephant.spark.data.SparkApplicationData
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.ExecutorSummary
+import com.linkedin.drelephant.util.MemoryFormatUtils
+
+import scala.collection.JavaConverters
+
+
+/**
+  * A heuristic based on peak JVM used memory for the spark executors and drivers
+  *
+  */
+
+
+class JvmUsedMemoryHeuristic(private val heuristicConfigurationData: HeuristicConfigurationData)
+  extends Heuristic[SparkApplicationData] {
+
+  import JvmUsedMemoryHeuristic._
+  import JavaConverters._
+
+  override def getHeuristicConfData(): HeuristicConfigurationData = heuristicConfigurationData
+
+  override def apply(data: SparkApplicationData): HeuristicResult = {
+    val evaluator = new Evaluator(this, data)
+
+    var resultDetails = Seq(
+      new HeuristicResultDetails("Max peak JVM used memory", evaluator.maxExecutorPeakJvmUsedMemory.toString),
+      new HeuristicResultDetails("Median peak JVM used memory", evaluator.medianPeakJvmUsedMemory.toString)
+    )
+
+    if(evaluator.severityExecutor.getValue > Severity.LOW.getValue) {
+      new HeuristicResultDetails("Note", "The allocated memory for the executor (in " + SPARK_EXECUTOR_MEMORY +") is much more than the peak JVM used memory by executors.")
+      new HeuristicResultDetails("Reasonable size for executor memory", ((1+BUFFER_PERCENT/100)*evaluator.maxExecutorPeakJvmUsedMemory).toString)
+    }
+
+    if(evaluator.severityDriver.getValue > Severity.LOW.getValue) {
+      new HeuristicResultDetails("Note", "The allocated memory for the driver (in " + SPARK_DRIVER_MEMORY + ") is much more than the peak JVM used memory by the driver.")
+    }
+
+    if(evaluator.severitySkew.getValue > Severity.LOW.getValue) {
+      new HeuristicResultDetails("Note", "As there is a big difference between median and maximum values of the peak JVM used memory, there could also be a skew in the data being processed. Please look into that.")
+    }
+
+    val result = new HeuristicResult(
+      heuristicConfigurationData.getClassName,
+      heuristicConfigurationData.getHeuristicName,
+      evaluator.severity,
+      0,
+      resultDetails.asJava
+    )
+    result
+  }
+
+}
+
+object JvmUsedMemoryHeuristic {
+
+  val JVM_USED_MEMORY = "jvmUsedMemory"
+  val SPARK_EXECUTOR_MEMORY = "spark.executor.memory"
+  val SPARK_DRIVER_MEMORY = "spark.driver.memory"
+  val reservedMemory : Long = 314572800
+  val BUFFER_PERCENT : Int = 20
+
+  class Evaluator(memoryFractionHeuristic: JvmUsedMemoryHeuristic, data: SparkApplicationData) {
+    lazy val appConfigurationProperties: Map[String, String] =
+      data.appConfigurationProperties
+
+    lazy val executorSummaries: Seq[ExecutorSummary] = data.executorSummaries
+
+    val driverSummary : Option[ExecutorSummary] = executorSummaries.find(_.id.equals("driver"))
+    val maxDriverPeakJvmUsedMemory : Long = driverSummary.get.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
+    val executorList : Seq[ExecutorSummary] = executorSummaries.patch(executorSummaries.indexWhere(_.id.equals("driver")), Nil, 1)
+    val sparkExecutorMemory : Long = (appConfigurationProperties.get(SPARK_EXECUTOR_MEMORY).map(MemoryFormatUtils.stringToBytes)).getOrElse(0)
+    val sparkDriverMemory : Long = appConfigurationProperties.get(SPARK_DRIVER_MEMORY).map(MemoryFormatUtils.stringToBytes).getOrElse(0)
+    val medianPeakJvmUsedMemory: Long = executorList.map {
+      _.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue
+    }.sortWith(_< _).drop(executorList.size/2).head
+    val maxExecutorPeakJvmUsedMemory: Long = (executorList.map {
+      _.peakJvmUsedMemory.get(JVM_USED_MEMORY)
+    }.max).getOrElse(0)
+
+    val DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS =
+      SeverityThresholds(low = 1.5 * (maxExecutorPeakJvmUsedMemory + reservedMemory), moderate = 2 * (maxExecutorPeakJvmUsedMemory + reservedMemory), severe = 4 * (maxExecutorPeakJvmUsedMemory + reservedMemory), critical = 8 * (maxExecutorPeakJvmUsedMemory + reservedMemory), ascending = true)
+
+    val DEFAULT_MAX_DRIVER_PEAK_JVM_USED_MEMORY_THRESHOLDS =
+      SeverityThresholds(low = 1.5 * (maxDriverPeakJvmUsedMemory + reservedMemory), moderate = 2 * (maxDriverPeakJvmUsedMemory + reservedMemory), severe = 4 * (maxDriverPeakJvmUsedMemory + reservedMemory), critical = 8 * (maxDriverPeakJvmUsedMemory + reservedMemory), ascending = true)
+
+    val DEFAULT_JVM_MEMORY_SKEW_THRESHOLDS =
+      SeverityThresholds(low = 1.5 * medianPeakJvmUsedMemory, moderate = 2 * medianPeakJvmUsedMemory, severe = 4 * medianPeakJvmUsedMemory, critical = 8 * medianPeakJvmUsedMemory, ascending = true)
+
+    val severityExecutor = DEFAULT_MAX_EXECUTOR_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkExecutorMemory)
+    val severityDriver = DEFAULT_MAX_DRIVER_PEAK_JVM_USED_MEMORY_THRESHOLDS.severityOf(sparkDriverMemory)
+    val severitySkew = DEFAULT_JVM_MEMORY_SKEW_THRESHOLDS.severityOf(maxExecutorPeakJvmUsedMemory)
+    val severity : Severity = Severity.max(severityDriver, severityExecutor, severitySkew)
+  }
+}

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -174,7 +174,8 @@ object LegacyDataConverters {
         executorInfo.shuffleWrite,
         executorInfo.maxMem,
         executorInfo.totalGCTime,
-        executorLogs = Map.empty
+        executorLogs = Map.empty,
+        peakJvmUsedMemory = Map.empty
       )
     }
 

--- a/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
@@ -19,4 +19,4 @@
 <h4>Executor JVM Used Memory Skew</h4>
 <p>If there is a big difference between median and maximum values of the peak JVM used memory, then there could be skew in the data being processed.</p>
 <h4>Driver Max Peak JVM Used Memory</h4>
-<p>Allocated memory for the driver (spark.driver.memory) is examined and is checked if its much more than the peak JVM memory used by the driver</p>
+<p>Allocated memory for the driver (spark.driver.memory) is examined and it checks if its much more than the peak JVM memory used by the driver</p>

--- a/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
@@ -15,16 +15,6 @@
 *@
 <p>This is a heuristic for peak JVM used memory.</p>
 <h4>Executor Max Peak JVM Used Memory</h4>
-<p>This is to analyse whether the executor memory is set to a good value. To avoid wasted memory, it checks if the peak JVM used memory is reasonably close to the allocated executor memory, (spark.executor.memory) -- if it is much smaller, then executor memory should be reduced.</p>
-<p>The thresholds set currently are : <br>
-    Low: spark.executor.memory >= 1.5 * (max peakJvmUsedMemory + 300MB)<br>
-    Moderate: spark.executor.memory >= 2 * (max peakJvmUsedMemory + 300MB)<br>
-    Severe: spark.executor.memory >= 2.5 * (max peakJvmUsedMemory + 300MB)<br>
-    Critical: spark.executor.memory >= 3 * (max peakJvmUsedMemory + 300MB)</p>
+<p>This is to analyse whether the executor memory is set to a good value. To avoid wasted memory, it checks if the peak JVM used memory by the executor is reasonably close to the blocked executor memory which is specified in spark.executor.memory. If the peak JVM memory is much smaller, then the executor memory should be reduced.</p>
 <h4>Driver Max Peak JVM Used Memory</h4>
-<p>Allocated memory for the driver (spark.driver.memory) is examined and it checks if its much more than the peak JVM memory used by the driver</p>
-<p>The thresholds set currently are : <br>
-    Low: spark.driver.memory >= 1.5 * (max peakJvmUsedMemory + 300MB)<br>
-    Moderate: spark.driver.memory >= 2 * (max peakJvmUsedMemory + 300MB)<br>
-    Severe: spark.driver.memory >= 2.5 * (max peakJvmUsedMemory + 300MB)<br>
-    Critical: spark.driver.memory >= 3 * (max peakJvmUsedMemory + 300MB)</p>
+<p>This is to analyse whether the driver memory is set to a good value. To avoid wasted memory, it checks if the peak JVM used memory by the driver is reasonably close to the blocked driver memory which is specified in spark.driver.memory. If the peak JVM memory is much smaller, then the driver memory should be reduced.</p>

--- a/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
@@ -16,7 +16,15 @@
 <p>This is a heuristic for peak JVM used memory.</p>
 <h4>Executor Max Peak JVM Used Memory</h4>
 <p>This is to analyse whether the executor memory is set to a good value. To avoid wasted memory, it checks if the peak JVM used memory is reasonably close to the allocated executor memory, (spark.executor.memory) -- if it is much smaller, then executor memory should be reduced.</p>
-<h4>Executor JVM Used Memory Skew</h4>
-<p>If there is a big difference between median and maximum values of the peak JVM used memory, then there could be skew in the data being processed.</p>
+<p>The thresholds set currently are : <br>
+    Low: spark.executor.memory >= 1.5 * (max peakJvmUsedMemory + 300MB)<br>
+    Moderate: spark.executor.memory >= 2 * (max peakJvmUsedMemory + 300MB)<br>
+    Severe: spark.executor.memory >= 2.5 * (max peakJvmUsedMemory + 300MB)<br>
+    Critical: spark.executor.memory >= 3 * (max peakJvmUsedMemory + 300MB)</p>
 <h4>Driver Max Peak JVM Used Memory</h4>
 <p>Allocated memory for the driver (spark.driver.memory) is examined and it checks if its much more than the peak JVM memory used by the driver</p>
+<p>The thresholds set currently are : <br>
+    Low: spark.driver.memory >= 1.5 * (max peakJvmUsedMemory + 300MB)<br>
+    Moderate: spark.driver.memory >= 2 * (max peakJvmUsedMemory + 300MB)<br>
+    Severe: spark.driver.memory >= 2.5 * (max peakJvmUsedMemory + 300MB)<br>
+    Critical: spark.driver.memory >= 3 * (max peakJvmUsedMemory + 300MB)</p>

--- a/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
@@ -1,0 +1,22 @@
+@*
+* Copyright 2016 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*@
+<p>This is a heuristic for peak JVM used memory.</p>
+<h4>Executor Max Peak JVM Used Memory</h4>
+<p>This is to analyse whether the executor memory is set to a good value. To avoid wasted memory, its checked that the peak JVM used memory is reasonably close to the allocated executor memory, (spark.executor.memory) -- if it is much smaller, then executor memory should be reduced.</p>
+<h4>Executor JVM Used Memory Skew</h4>
+<p>If there is a big difference between median and maximum values of the peak JVM used memory, then there could be skew in the data being processed.</p>
+<h4>Driver Max Peak JVM Used Memory</h4>
+<p>Allocated memory for the driver (spark.driver.memory) is examined and is checked if its much more than the peak JVM memory used by the driver</p>

--- a/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
+++ b/app/views/help/spark/helpJvmUsedMemoryHeuristic.scala.html
@@ -15,7 +15,7 @@
 *@
 <p>This is a heuristic for peak JVM used memory.</p>
 <h4>Executor Max Peak JVM Used Memory</h4>
-<p>This is to analyse whether the executor memory is set to a good value. To avoid wasted memory, its checked that the peak JVM used memory is reasonably close to the allocated executor memory, (spark.executor.memory) -- if it is much smaller, then executor memory should be reduced.</p>
+<p>This is to analyse whether the executor memory is set to a good value. To avoid wasted memory, it checks if the peak JVM used memory is reasonably close to the allocated executor memory, (spark.executor.memory) -- if it is much smaller, then executor memory should be reduced.</p>
 <h4>Executor JVM Used Memory Skew</h4>
 <p>If there is a big difference between median and maximum values of the peak JVM used memory, then there could be skew in the data being processed.</p>
 <h4>Driver Max Peak JVM Used Memory</h4>

--- a/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
+++ b/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
@@ -195,6 +195,7 @@ object SparkMetricsAggregatorTest {
     totalShuffleWrite = 0,
     maxMemory = 0,
     totalGCTime = 0,
-    executorLogs = Map.empty
+    executorLogs = Map.empty,
+    peakJvmUsedMemory = Map.empty
   )
 }

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
@@ -119,7 +119,8 @@ object ExecutorGcHeuristicTest {
     totalShuffleWrite= 0,
     maxMemory= 0,
     totalGCTime,
-    executorLogs = Map.empty
+    executorLogs = Map.empty,
+    peakJvmUsedMemory = Map.empty
   )
 
   def newFakeSparkApplicationData(

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
@@ -250,7 +250,8 @@ object ExecutorsHeuristicTest {
     totalShuffleWrite,
     maxMemory,
     totalGCTime = 0,
-    executorLogs = Map.empty
+    executorLogs = Map.empty,
+    peakJvmUsedMemory = Map.empty
   )
 
   def newFakeSparkApplicationData(executorSummaries: Seq[ExecutorSummaryImpl]): SparkApplicationData = {

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -18,6 +18,7 @@ class JvmUsedMemoryHeuristicTest extends FunSpec with Matchers {
   val peakJvmUsedMemoryHeuristic = new JvmUsedMemoryHeuristic(heuristicConfigurationData)
 
   val appConfigurationProperties = Map("spark.driver.memory"->"40000000000", "spark.executor.memory"->"500000000")
+
   val executorData = Seq(
     newDummyExecutorData("1", Map("jvmUsedMemory" -> 394567123)),
     newDummyExecutorData("2", Map("jvmUsedMemory" -> 23456834)),
@@ -29,7 +30,6 @@ class JvmUsedMemoryHeuristicTest extends FunSpec with Matchers {
   describe(".apply") {
     val data = newFakeSparkApplicationData(appConfigurationProperties, executorData)
     val heuristicResult = peakJvmUsedMemoryHeuristic.apply(data)
-    val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
 
     it("has severity") {
       heuristicResult.getSeverity should be(Severity.CRITICAL)
@@ -44,18 +44,19 @@ class JvmUsedMemoryHeuristicTest extends FunSpec with Matchers {
       it("has severity executor") {
         evaluator.severityExecutor should be(Severity.NONE)
       }
+
       it("has severity driver") {
         evaluator.severityDriver should be(Severity.CRITICAL)
       }
-      it("has severity skew") {
-        evaluator.severitySkew should be(Severity.CRITICAL)
-      }
+
       it("has median peak jvm memory") {
         evaluator.medianPeakJvmUsedMemory should be (334569)
       }
+
       it("has max peak jvm memory") {
         evaluator.maxExecutorPeakJvmUsedMemory should be (394567123)
       }
+
       it("has max driver peak jvm memory") {
         evaluator.maxDriverPeakJvmUsedMemory should be (394561)
       }

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -71,9 +71,9 @@ object JvmUsedMemoryHeuristicTest {
     new HeuristicConfigurationData("heuristic", "class", "view", new ApplicationType("type"), params.asJava)
 
   def newDummyExecutorData(
-                            id: String,
-                            peakJvmUsedMemory: Map[String, Long]
-                          ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
+    id: String,
+    peakJvmUsedMemory: Map[String, Long]
+  ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
     id,
     hostPort = "",
     rddBlocks = 0,
@@ -93,9 +93,9 @@ object JvmUsedMemoryHeuristicTest {
   )
 
   def newFakeSparkApplicationData(
-                                   appConfigurationProperties: Map[String, String],
-                                   executorSummaries: Seq[ExecutorSummaryImpl]
-                                 ): SparkApplicationData = {
+    appConfigurationProperties: Map[String, String],
+    executorSummaries: Seq[ExecutorSummaryImpl]
+  ): SparkApplicationData = {
 
     val logDerivedData = SparkLogDerivedData(
       SparkListenerEnvironmentUpdate(Map("Spark Properties" -> appConfigurationProperties.toSeq))

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -1,0 +1,114 @@
+package com.linkedin.drelephant.spark.heuristics
+
+import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
+import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, ExecutorSummaryImpl}
+import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.collection.JavaConverters
+
+class JvmUsedMemoryHeuristicTest extends FunSpec with Matchers {
+
+  import JvmUsedMemoryHeuristicTest._
+
+  val heuristicConfigurationData = newFakeHeuristicConfigurationData()
+
+  val peakJvmUsedMemoryHeuristic = new JvmUsedMemoryHeuristic(heuristicConfigurationData)
+
+  val appConfigurationProperties = Map("spark.driver.memory"->"40000000000", "spark.executor.memory"->"500000000")
+  val executorData = Seq(
+    newDummyExecutorData("1", Map("jvmUsedMemory" -> 394567123)),
+    newDummyExecutorData("2", Map("jvmUsedMemory" -> 23456834)),
+    newDummyExecutorData("3", Map("jvmUsedMemory" -> 334569)),
+    newDummyExecutorData("4", Map("jvmUsedMemory" -> 134563)),
+    newDummyExecutorData("5", Map("jvmUsedMemory" -> 234564)),
+    newDummyExecutorData("driver", Map("jvmUsedMemory" -> 394561))
+  )
+  describe(".apply") {
+    val data = newFakeSparkApplicationData(appConfigurationProperties, executorData)
+    val heuristicResult = peakJvmUsedMemoryHeuristic.apply(data)
+    val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
+
+    it("has severity") {
+      heuristicResult.getSeverity should be(Severity.CRITICAL)
+    }
+
+    describe(".Evaluator") {
+      import JvmUsedMemoryHeuristic.Evaluator
+
+      val data = newFakeSparkApplicationData(appConfigurationProperties, executorData)
+      val evaluator = new Evaluator(peakJvmUsedMemoryHeuristic, data)
+
+      it("has severity executor") {
+        evaluator.severityExecutor should be(Severity.NONE)
+      }
+      it("has severity driver") {
+        evaluator.severityDriver should be(Severity.CRITICAL)
+      }
+      it("has severity skew") {
+        evaluator.severitySkew should be(Severity.CRITICAL)
+      }
+      it("has median peak jvm memory") {
+        evaluator.medianPeakJvmUsedMemory should be (334569)
+      }
+      it("has max peak jvm memory") {
+        evaluator.maxExecutorPeakJvmUsedMemory should be (394567123)
+      }
+      it("has max driver peak jvm memory") {
+        evaluator.maxDriverPeakJvmUsedMemory should be (394561)
+      }
+    }
+  }
+}
+
+object JvmUsedMemoryHeuristicTest {
+
+  import JavaConverters._
+
+  def newFakeHeuristicConfigurationData(params: Map[String, String] = Map.empty): HeuristicConfigurationData =
+    new HeuristicConfigurationData("heuristic", "class", "view", new ApplicationType("type"), params.asJava)
+
+  def newDummyExecutorData(
+                            id: String,
+                            peakJvmUsedMemory: Map[String, Long]
+                          ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
+    id,
+    hostPort = "",
+    rddBlocks = 0,
+    memoryUsed = 0,
+    diskUsed = 0,
+    activeTasks = 0,
+    failedTasks = 0,
+    completedTasks = 0,
+    totalTasks = 0,
+    totalDuration = 0,
+    totalInputBytes = 0,
+    totalShuffleRead = 0,
+    totalShuffleWrite = 0,
+    maxMemory = 0,
+    executorLogs = Map.empty,
+    peakJvmUsedMemory
+  )
+
+  def newFakeSparkApplicationData(
+                                   appConfigurationProperties: Map[String, String],
+                                   executorSummaries: Seq[ExecutorSummaryImpl]
+                                 ): SparkApplicationData = {
+
+    val logDerivedData = SparkLogDerivedData(
+      SparkListenerEnvironmentUpdate(Map("Spark Properties" -> appConfigurationProperties.toSeq))
+    )
+    val appId = "application_1"
+
+    val restDerivedData = SparkRestDerivedData(
+      new ApplicationInfoImpl(appId, name = "app", Seq.empty),
+      jobDatas = Seq.empty,
+      stageDatas = Seq.empty,
+      executorSummaries = executorSummaries
+    )
+
+    SparkApplicationData(appId, restDerivedData, Some(logDerivedData))
+  }
+}

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -49,10 +49,6 @@ class JvmUsedMemoryHeuristicTest extends FunSpec with Matchers {
         evaluator.severityDriver should be(Severity.CRITICAL)
       }
 
-      it("has median peak jvm memory") {
-        evaluator.medianPeakJvmUsedMemory should be (334569)
-      }
-
       it("has max peak jvm memory") {
         evaluator.maxExecutorPeakJvmUsedMemory should be (394567123)
       }

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -89,6 +89,7 @@ object JvmUsedMemoryHeuristicTest {
     totalShuffleRead = 0,
     totalShuffleWrite = 0,
     maxMemory = 0,
+    totalGCTime = 0,
     executorLogs = Map.empty,
     peakJvmUsedMemory
   )


### PR DESCRIPTION
To calculate if the executor memory is set to a good value, the average (or median) and maximum peak JVM used memory for executors is examined. Information about each executor’s peak JVM used memory will be available from the executors REST API, in maxPeakJvmUsedMemory.peakJvmUsedMemory. To avoid wasted memory, its checked that the peak JVM used memory is reasonably close to the allocated executor memory, spark.executor.memory -- if it is much smaller, then executor memory can be reduced.
