### PR TITLE
Configuration Threshold Heuristic

### DIFF
--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/StageStatus.java
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/StageStatus.java
@@ -1,0 +1,18 @@
+package com.linkedin.drelephant.spark.fetchers.statusapiv1;
+
+import org.apache.spark.util.EnumUtil;
+
+public enum StageStatus {
+  ACTIVE,
+  COMPLETE,
+  FAILED,
+  SKIPPED,
+  PENDING;
+
+  private StageStatus() {
+  }
+
+  public static com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus fromString(String str) {
+    return (com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus) EnumUtil.parseIgnoreCase(com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus.class, str);
+  }
+}

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/StageStatus.java
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/StageStatus.java
@@ -1,3 +1,9 @@
+/*
+*Added this class to accommodate the status "PENDING" for stages.
+*
+*TODO: remove this class if using the spark version having "PENDING" StageStatus.
+ */
+
 package com.linkedin.drelephant.spark.fetchers.statusapiv1;
 
 import org.apache.spark.util.EnumUtil;
@@ -12,7 +18,7 @@ public enum StageStatus {
   private StageStatus() {
   }
 
-  public static com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus fromString(String str) {
-    return (com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus) EnumUtil.parseIgnoreCase(com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus.class, str);
+  public static StageStatus fromString(String str) {
+    return (StageStatus) EnumUtil.parseIgnoreCase(StageStatus.class, str);
   }
 }

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
@@ -42,7 +42,6 @@ import java.util.Date
 import scala.collection.Map
 
 import org.apache.spark.JobExecutionStatus
-import org.apache.spark.status.api.v1.StageStatus
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 

--- a/app/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristic.scala
@@ -110,10 +110,10 @@ class ConfigurationHeuristic(private val heuristicConfigurationData: HeuristicCo
         "Spark shuffle service is not enabled.")
     }
     if (evaluator.severityMinExecutors == Severity.CRITICAL) {
-      result.addResultDetail("Minimum Executors", "The minimum executors for Dynamic Allocation should be <=1. Please change it in the spark.dynamicAllocation.minExecutors field.")
+      result.addResultDetail("Minimum Executors", "The minimum executors for Dynamic Allocation should be <=1. Please change it in the " + SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS + " field.")
     }
     if (evaluator.severityMaxExecutors == Severity.CRITICAL) {
-      result.addResultDetail("Maximum Executors", "The maximum executors for Dynamic Allocation should be <=900. Please change it in the spark.dynamicAllocation.maxExecutors field.")
+      result.addResultDetail("Maximum Executors", "The maximum executors for Dynamic Allocation should be <=900. Please change it in the " + SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS + " field.")
     }
     if (evaluator.jarsSeverity == Severity.CRITICAL) {
       result.addResultDetail("Jars notation", "It is recommended to not use * notation while specifying jars in the field " + SPARK_YARN_JARS)
@@ -241,10 +241,10 @@ object ConfigurationHeuristic {
       severityMinExecutors, severityMaxExecutors, jarsSeverity, severityExecutorMemoryOverhead, severityDriverMemoryOverhead)
 
     /**
-      * The following logic computes severity based on shuffle service and dynamic allocation flags.
-      * If dynamic allocation is disabled, then the severity will be MODERATE if shuffle service is disabled or not specified.
-      * If dynamic allocation is enabled, then the severity will be SEVERE if shuffle service is disabled or not specified.
-      */
+     * The following logic computes severity based on shuffle service and dynamic allocation flags.
+     * If dynamic allocation is disabled, then the severity will be MODERATE if shuffle service is disabled or not specified.
+     * If dynamic allocation is enabled, then the severity will be SEVERE if shuffle service is disabled or not specified.
+     */
 
     lazy val isDynamicAllocationEnabled: Option[Boolean] = Some(getProperty(SPARK_DYNAMIC_ALLOCATION_ENABLED).exists(_.toBoolean == true))
     lazy val isShuffleServiceEnabled: Option[Boolean] = Some(getProperty(SPARK_SHUFFLE_SERVICE_ENABLED).exists(_.toBoolean == true))

--- a/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
@@ -26,8 +26,7 @@ import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationDa
 import com.linkedin.drelephant.math.Statistics
 import com.linkedin.drelephant.spark.data.SparkApplicationData
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageData
-import org.apache.spark.status.api.v1.StageStatus
-
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 
 /**
   * A heuristic based on metrics for a Spark app's stages.

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 import com.linkedin.drelephant.spark.fetchers.statusapiv1._
 import org.apache.spark.JobExecutionStatus
-import org.apache.spark.status.api.v1.StageStatus
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 
 /**
   * Converters for legacy SparkApplicationData to current SparkApplicationData.

--- a/app/com/linkedin/drelephant/util/SparkUtils.scala
+++ b/app/com/linkedin/drelephant/util/SparkUtils.scala
@@ -180,7 +180,7 @@ trait SparkUtils {
   }
 
   private val IN_PROGRESS = ".inprogress"
-  private val DEFAULT_COMPRESSION_CODEC = "snappy"
+  private val DEFAULT_COMPRESSION_CODEC = "lz4"
 
   private val compressionCodecClassNamesByShortName = Map(
     "lz4" -> classOf[LZ4CompressionCodec].getName,

--- a/app/views/help/spark/helpConfigurationHeuristic.scala.html
+++ b/app/views/help/spark/helpConfigurationHeuristic.scala.html
@@ -16,5 +16,6 @@
 <p>The results from this heuristic primarily inform you about key app
 configuration settings, including driver memory, driver cores, executor cores,
 executor instances, executor memory, and the serializer.</p>
-<p>The recommended values for dynamic min executors is <=1 and for dynamic max executors is <=900.</p>
-<p>This heuristic also checks whether the specified values for configuration are above or below threshold.</p>
+<p>It also checks the values of dynamically allocated min and max executors, the specified yarn jars, executor and driver memory overhead and whether other configuration values are within threshold.</p>
+<h3>Suggestions</h3>
+<p>Suggestions based on the configurations you have set are given in the heuristic result itself.</p>

--- a/app/views/help/spark/helpConfigurationHeuristic.scala.html
+++ b/app/views/help/spark/helpConfigurationHeuristic.scala.html
@@ -14,5 +14,6 @@
 * the License.
 *@
 <p>The results from this heuristic primarily inform you about key app
-configuration settings, including driver memory, executor cores,
+configuration settings, including driver memory, driver cores, executor cores,
 executor instances, executor memory, and the serializer.</p>
+<p>It also checks whether the specified values for configuration are above threshold.</p>

--- a/app/views/help/spark/helpConfigurationHeuristic.scala.html
+++ b/app/views/help/spark/helpConfigurationHeuristic.scala.html
@@ -16,4 +16,5 @@
 <p>The results from this heuristic primarily inform you about key app
 configuration settings, including driver memory, driver cores, executor cores,
 executor instances, executor memory, and the serializer.</p>
-<p>It also checks whether the specified values for configuration are above threshold.</p>
+<p>The recommended values for dynamic min executors is <=1 and for dynamic max executors is <=900.</p>
+<p>This heuristic also checks whether the specified values for configuration are above or below threshold.</p>

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -22,8 +22,7 @@ import java.util.zip.{ZipInputStream, ZipEntry, ZipOutputStream}
 import java.util.{Calendar, Date, SimpleTimeZone}
 import javax.ws.rs.client.WebTarget
 
-import org.apache.spark.status.api.v1.StageStatus
-
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/test/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristicTest.scala
@@ -50,7 +50,8 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
         "spark.executor.memory" -> "1g",
         "spark.shuffle.memoryFraction" -> "0.5",
         "spark.shuffle.service.enabled" -> "true",
-        "spark.dynamicAllocation.enabled" -> "true"
+        "spark.dynamicAllocation.enabled" -> "true",
+        "spark.yarn.secondary.jars" -> "something without star"
       )
 
       val data = newFakeSparkApplicationData(configurationProperties)
@@ -208,6 +209,16 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       it("has the serializer when it's present") {
         val evaluator = newEvaluatorWithConfigurationProperties(Map("spark.serializer" -> "org.apache.spark.serializer.KryoSerializer"))
         evaluator.serializer should be(Some("org.apache.spark.serializer.KryoSerializer"))
+      }
+
+      it("jars severity when NONE") {
+        val evaluator = newEvaluatorWithConfigurationProperties(Map("spark.yarn.secondary.jars" -> "somethingWithoutStar"))
+        evaluator.jarsSeverity should be(Severity.NONE)
+      }
+
+      it("jars severity when CRITICAL") {
+        val evaluator = newEvaluatorWithConfigurationProperties(Map("spark.yarn.secondary.jars" -> "somethingWith*.jar"))
+        evaluator.jarsSeverity should be(Severity.CRITICAL)
       }
 
       it("has no serializer, dynamic allocation flag, and shuffle flag when they are absent") {

--- a/test/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristicTest.scala
@@ -51,7 +51,8 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
         "spark.shuffle.memoryFraction" -> "0.5",
         "spark.shuffle.service.enabled" -> "true",
         "spark.dynamicAllocation.enabled" -> "true",
-        "spark.yarn.secondary.jars" -> "something without star"
+        "spark.yarn.secondary.jars" -> "something without star",
+        "spark.yarn.driver.memoryOverhead" -> "500"
       )
 
       val data = newFakeSparkApplicationData(configurationProperties)
@@ -59,7 +60,7 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
 
       it("returns the size of result details") {
-        heuristicResultDetails.size() should be(7)
+        heuristicResultDetails.size() should be(9)
       }
 
       it("returns the severity") {
@@ -107,6 +108,12 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
         details.getName should include("spark.driver.cores")
         details.getValue should include("default")
       }
+
+      it("returns the driver overhead memory") {
+        val details = heuristicResultDetails.get(7)
+        details.getName should include("spark.yarn.driver.memoryOverhead")
+        details.getValue should include("500 MB")
+      }
     }
 
     describe("apply with Severity") {
@@ -121,7 +128,7 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
 
       it("returns the size of result details") {
-        heuristicResultDetails.size() should be(9)
+        heuristicResultDetails.size() should be(11)
       }
 
       it("returns the severity") {
@@ -135,14 +142,14 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       }
 
       it("returns the serializer") {
-        val details = heuristicResultDetails.get(7)
+        val details = heuristicResultDetails.get(9)
         details.getName should include("spark.serializer")
         details.getValue should be("dummySerializer")
         details.getDetails should be("KyroSerializer is Not Enabled.")
       }
 
       it("returns the shuffle service flag") {
-        val details = heuristicResultDetails.get(8)
+        val details = heuristicResultDetails.get(10)
         details.getName should include("spark.shuffle.service.enabled")
         details.getValue should be("false")
         details.getDetails should be("Spark shuffle service is not enabled.")

--- a/test/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ConfigurationHeuristicTest.scala
@@ -58,7 +58,7 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
 
       it("returns the size of result details") {
-        heuristicResultDetails.size() should be(6)
+        heuristicResultDetails.size() should be(7)
       }
 
       it("returns the severity") {
@@ -100,6 +100,12 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
         details.getName should include("spark.dynamicAllocation.enabled")
         details.getValue should be("true")
       }
+
+      it("returns the driver cores") {
+        val details = heuristicResultDetails.get(6)
+        details.getName should include("spark.driver.cores")
+        details.getValue should include("default")
+      }
     }
 
     describe("apply with Severity") {
@@ -114,7 +120,7 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
 
       it("returns the size of result details") {
-        heuristicResultDetails.size() should be(8)
+        heuristicResultDetails.size() should be(9)
       }
 
       it("returns the severity") {
@@ -128,14 +134,14 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
       }
 
       it("returns the serializer") {
-        val details = heuristicResultDetails.get(6)
+        val details = heuristicResultDetails.get(7)
         details.getName should include("spark.serializer")
         details.getValue should be("dummySerializer")
         details.getDetails should be("KyroSerializer is Not Enabled.")
       }
 
       it("returns the shuffle service flag") {
-        val details = heuristicResultDetails.get(7)
+        val details = heuristicResultDetails.get(8)
         details.getName should include("spark.shuffle.service.enabled")
         details.getValue should be("false")
         details.getDetails should be("Spark shuffle service is not enabled.")
@@ -184,9 +190,19 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
         evaluator.executorCores should be(Some(2))
       }
 
+      it("has the driver cores when they're present") {
+        val evaluator = newEvaluatorWithConfigurationProperties(Map("spark.driver.cores" -> "3"))
+        evaluator.driverCores should be(Some(3))
+      }
+
       it("has no executor cores when they're absent") {
         val evaluator = newEvaluatorWithConfigurationProperties(Map.empty)
         evaluator.executorCores should be(None)
+      }
+
+      it("has no driver cores when they're absent") {
+        val evaluator = newEvaluatorWithConfigurationProperties(Map.empty)
+        evaluator.driverCores should be(None)
       }
 
       it("has the serializer when it's present") {
@@ -254,6 +270,7 @@ class ConfigurationHeuristicTest extends FunSpec with Matchers {
         evaluator.isShuffleServiceEnabled should be(Some(false))
         evaluator.serializerSeverity should be(Severity.NONE)
         evaluator.shuffleAndDynamicAllocationSeverity should be(Severity.SEVERE)
+        evaluator.severityConfThresholds should be(Severity.NONE)
         evaluator.severity should be(Severity.SEVERE)
       }
 

--- a/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/StagesHeuristicTest.scala
@@ -23,10 +23,9 @@ import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, JobDataImpl, StageDataImpl}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
-import org.apache.spark.status.api.v1.StageStatus
 import org.scalatest.{FunSpec, Matchers}
-
 
 class StagesHeuristicTest extends FunSpec with Matchers {
   import StagesHeuristicTest._

--- a/test/com/linkedin/drelephant/spark/legacydata/LegacyDataConvertersTest.scala
+++ b/test/com/linkedin/drelephant/spark/legacydata/LegacyDataConvertersTest.scala
@@ -19,9 +19,8 @@ package com.linkedin.drelephant.spark.legacydata
 import java.util.Date
 
 import org.apache.spark.JobExecutionStatus
-import org.apache.spark.status.api.v1.StageStatus
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import org.scalatest.{FunSpec, Matchers}
-
 
 class LegacyDataConvertersTest extends FunSpec with Matchers {
   describe("LegacyDataConverters") {

--- a/test/com/linkedin/drelephant/util/SparkUtilsTest.scala
+++ b/test/com/linkedin/drelephant/util/SparkUtilsTest.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.{FSDataInputStream, FileStatus, FileSystem, Path, Pa
 import org.apache.hadoop.io.compress.CompressionInputStream
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
-import org.apache.spark.io.SnappyCompressionCodec
+import org.apache.spark.io.{LZ4CompressionCodec, SnappyCompressionCodec}
 import org.mockito.BDDMockito
 import org.mockito.Matchers
 import org.scalatest.{FunSpec, Matchers, OptionValues}
@@ -46,8 +46,8 @@ class SparkUtilsTest extends FunSpec with org.scalatest.Matchers with OptionValu
         }
 
         val (fs, path) = sparkUtils.fileSystemAndPathForEventLogDir(hadoopConfiguration,
-              sparkConf,
-              Some("webhdfs://nn1.grid.example.com:50070/logs/spark"))
+          sparkConf,
+          Some("webhdfs://nn1.grid.example.com:50070/logs/spark"))
         fs.getUri.toString should be("webhdfs://nn1.grid.example.com:50070")
         path should be(new Path("/logs/spark"))
       }
@@ -180,7 +180,7 @@ class SparkUtilsTest extends FunSpec with org.scalatest.Matchers with OptionValu
         val sparkUtils = SparkUtilsTest.newFakeSparkUtilsForEventLog(
           new URI("webhdfs://nn1.grid.example.com:50070"),
           new Path("/logs/spark"),
-          new Path("application_1_1.snappy"),
+          new Path("application_1_1.lz4"),
           Array.empty[Byte]
         )
 
@@ -189,8 +189,8 @@ class SparkUtilsTest extends FunSpec with org.scalatest.Matchers with OptionValu
         val (path, codec) =
           sparkUtils.pathAndCodecforEventLog(sparkConf: SparkConf, fs: FileSystem, basePath: Path, "application_1", Some("1"))
 
-        path should be(new Path("webhdfs://nn1.grid.example.com:50070/logs/spark/application_1_1.snappy"))
-        codec.value should be(a[SnappyCompressionCodec])
+        path should be(new Path("webhdfs://nn1.grid.example.com:50070/logs/spark/application_1_1.lz4"))
+        codec.value should be(a[LZ4CompressionCodec])
       }
       it("returns the path and codec for the event log, given the base path and appid. Extracts attempt and codec from path") {
         val hadoopConfiguration = new Configuration(false)
@@ -300,8 +300,8 @@ object SparkUtilsTest extends MockitoSugar {
       BDDMockito.given(fs.exists(expectedPath)).willReturn(true)
       BDDMockito.given(fs.getFileStatus(expectedPath)).willReturn(expectedFileStatus)
       BDDMockito.given(fs.listStatus(org.mockito.Matchers.refEq(new Path( new Path(fileSystemUri), basePath)),
-                                      org.mockito.Matchers.any(filter.getClass))).
-                 willReturn(expectedStatusArray)
+        org.mockito.Matchers.any(filter.getClass))).
+        willReturn(expectedStatusArray)
       BDDMockito.given(fs.open(expectedPath)).willReturn(
         new FSDataInputStream(new FakeCompressionInputStream(new ByteArrayInputStream(bytes)))
       )

--- a/test/com/linkedin/drelephant/util/SparkUtilsTest.scala
+++ b/test/com/linkedin/drelephant/util/SparkUtilsTest.scala
@@ -25,10 +25,9 @@ import org.apache.hadoop.fs.{FSDataInputStream, FileStatus, FileSystem, Path, Pa
 import org.apache.hadoop.io.compress.CompressionInputStream
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
-import org.apache.spark.io.{LZ4CompressionCodec, SnappyCompressionCodec}
+import org.apache.spark.io.LZ4CompressionCodec
 import org.mockito.BDDMockito
-import org.mockito.Matchers
-import org.scalatest.{FunSpec, Matchers, OptionValues}
+import org.scalatest.{FunSpec, OptionValues}
 import org.scalatest.mockito.MockitoSugar
 import org.xerial.snappy.SnappyOutputStream
 
@@ -203,7 +202,7 @@ class SparkUtilsTest extends FunSpec with org.scalatest.Matchers with OptionValu
         val sparkUtils = SparkUtilsTest.newFakeSparkUtilsForEventLog(
           new URI("webhdfs://nn1.grid.example.com:50070"),
           new Path("/logs/spark"),
-          new Path("application_1_1.snappy"),
+          new Path("application_1_1.lz4"),
           Array.empty[Byte]
         )
 
@@ -212,8 +211,8 @@ class SparkUtilsTest extends FunSpec with org.scalatest.Matchers with OptionValu
         val (path, codec) =
           sparkUtils.pathAndCodecforEventLog(sparkConf: SparkConf, fs: FileSystem, basePath: Path, "application_1", None)
 
-        path should be(new Path("webhdfs://nn1.grid.example.com:50070/logs/spark/application_1_1.snappy"))
-        codec.value should be(a[SnappyCompressionCodec])
+        path should be(new Path("webhdfs://nn1.grid.example.com:50070/logs/spark/application_1_1.lz4"))
+        codec.value should be(a[LZ4CompressionCodec])
       }
     }
 


### PR DESCRIPTION
A threshold is set for executor/driver memory and if the application is using more memory than normal for a Spark application running on the cluster then the users are warned. 
The executor/driver cores are also checked to avoid unreasonable numbers.