### PR TITLE
BUGFIX Updating java_agrs to elephant.conf for resolving argument conflicts

### DIFF
--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -27,7 +27,12 @@ enable_analytics=false
 
 # Additional Configuration
 # Check https://www.playframework.com/documentation/2.2.x/ProductionConfiguration
-jvm_props="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
+#jvm_props="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
+
+# Adding the below line for Heap Tuning and Java OPTS
+# mem - Heap Memory
+jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true -mem 1024 -J-Xloggc:$project_root../logs/elephant/dr-gc.`date +'%Y%m%d%H%M'` -J-XX:+PrintGCDetails"
+
 
 # Property enables dropwizard metrics for the application.
 # More info on Dropwizard metrics at http://metrics.dropwizard.io

--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -27,10 +27,8 @@ enable_analytics=false
 
 # Additional Configuration
 # Check https://www.playframework.com/documentation/2.2.x/ProductionConfiguration
-#jvm_props="-Devolutionplugin=enabled -DapplyEvolutions.default=true"
-
 # Adding the below line for Heap Tuning and Java OPTS
-# mem - Heap Memory
+# Use mem for tuning Heap Memory
 jvm_args="-Devolutionplugin=enabled -DapplyEvolutions.default=true -mem 1024 -J-Xloggc:$project_root../logs/elephant/dr-gc.`date +'%Y%m%d%H%M'` -J-XX:+PrintGCDetails"
 
 


### PR DESCRIPTION
Contains fixes mentioned in #297.

1. Adding `jvm_args` instead of `jvm_props` to enable Java Arguments
2. Adding `-mem 1024` to enable default Heap allocation of 1GB.
3. Adding `-J-Xloggc:$project_root../logs/elephant/dr-gc.`date +'%Y%m%d%H%M'` -J-XX:+PrintGCDetails` to enable GC logging in the same directory of Dr. Elephant Logs