### PR TITLE
TUNING Updating default MR fetcher for performance

### DIFF
--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -29,6 +29,7 @@
   </fetcher>
 -->
 <fetchers>
+  <!--
   <fetcher>
     <applicationtype>mapreduce</applicationtype>
     <classname>com.linkedin.drelephant.mapreduce.fetchers.MapReduceFetcherHadoop2</classname>
@@ -36,6 +37,7 @@
       <sampling_enabled>false</sampling_enabled>
     </params>
   </fetcher>
+  -->
   <!--
      This is an experimental replacement for the MapReduceFetcherHadoop2 that attempts to burn
      through queues of jobs faster by pulling data directly from HDFS rather than going through
@@ -49,17 +51,19 @@
      To work properly, this fetcher should use the same timezone with the job history server.
      If not set, the local timezone will be used.
    -->
-  <!--
+  
   <fetcher>
     <applicationtype>mapreduce</applicationtype>
     <classname>com.linkedin.drelephant.mapreduce.fetchers.MapReduceFSFetcherHadoop2</classname>
     <params>
       <sampling_enabled>false</sampling_enabled>
+      <!--
       <history_log_size_limit_in_mb>500</history_log_size_limit_in_mb>
       <history_server_time_zone>PST</history_server_time_zone>
+      -->
     </params>
   </fetcher>
-  -->
+  
 
   <!--
     FSFetcher for Spark. Loads the eventlog from HDFS and replays to get the metrics and application properties

--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -57,10 +57,8 @@
     <classname>com.linkedin.drelephant.mapreduce.fetchers.MapReduceFSFetcherHadoop2</classname>
     <params>
       <sampling_enabled>false</sampling_enabled>
-      <!--
       <history_log_size_limit_in_mb>500</history_log_size_limit_in_mb>
       <history_server_time_zone>PST</history_server_time_zone>
-      -->
     </params>
   </fetcher>
   

--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -39,14 +39,14 @@
   </fetcher>
   -->
   <!--
-     This is an experimental replacement for the MapReduceFetcherHadoop2 that attempts to burn
+     This is a replacement for the MapReduceFetcherHadoop2 that attempts to burn
      through queues of jobs faster by pulling data directly from HDFS rather than going through
      the job history server.
 
      Increasing the param history_log_size_limit_in_mb allows this fetcher to accept larger log
      files, but also increase the risk of OutOfMemory error. The default heap size of Dr. Elephant
-     is 1024MB. To increase this, e.g. to 2048MB, run this before start.sh:
-       export OPTS="-mem 2048"
+     is 1024MB. To increase this, e.g. to 2048MB, update the below conf in app-conf/elephant.conf:
+       jvm_args="-mem 2048"
 
      To work properly, this fetcher should use the same timezone with the job history server.
      If not set, the local timezone will be used.

--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -45,7 +45,7 @@
 
      Increasing the param history_log_size_limit_in_mb allows this fetcher to accept larger log
      files, but also increase the risk of OutOfMemory error. The default heap size of Dr. Elephant
-     is 1024MB. To increase this, e.g. to 2048MB, update the below conf in app-conf/elephant.conf:
+     is 1024MB. To increase this, e.g. to 2048MB, update the below mem conf in app-conf/elephant.conf:
        jvm_args="-mem 2048"
 
      To work properly, this fetcher should use the same timezone with the job history server.


### PR DESCRIPTION
Updating `FetcherConf.xml` to use `MapReduceFSFetcherHadoop` by default for improving performance

Using `MapReduceFSFetcherHadoop` increases the performance ~100 times with the amount of time required for processing and number of jobs processed in a minute.

With the original `MapReduceFetcherHadoop` class in a Production Cluster , there is a lot of lag in using it, as the number of applications to be processed are very high.