### PR TITLE
Check for required programs in compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -28,6 +28,26 @@ function play_command() {
   fi
 }
 
+function require_programs() {
+  echo "Checking for required programs..."
+  missing_programs=""
+  
+  for program in $@; do
+    if ! command -v "$program" > /dev/null; then
+      missing_programs=$(printf "%s\n\t- %s" "$missing_programs" "$program")
+    fi
+  done 
+
+  if [ ! -z "$missing_programs" ]; then
+    echo "[ERROR] The following programs are required and are missing: $missing_programs"
+    exit 1
+  else
+    echo "[SUCCESS] Program requirement is fulfilled!"
+  fi
+}
+
+require_programs zip unzip
+
 # Default configurations
 HADOOP_VERSION="2.3.0"
 SPARK_VERSION="1.4.0"


### PR DESCRIPTION
I have added a function that checks for the required programs before starting the compilation process.  If a program is not found, an indicative message will be shown to the user.

It should also be POSIX-compatible :)