### PR TITLE
reducing time out of spark fetcher from 60 to 5 seconds

### DIFF
--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -141,6 +141,6 @@ object SparkFetcher {
   }
 
   val SPARK_EVENT_LOG_ENABLED_KEY = "spark.eventLog.enabled"
-  val DEFAULT_TIMEOUT = Duration(60, SECONDS)
+  val DEFAULT_TIMEOUT = Duration(5, SECONDS)
   val LOG_LOCATION_URI_XML_FIELD = "event_log_location_uri"
 }


### PR DESCRIPTION
Reducing time out of spark fetcher from 60 to 5 seconds so that the analytic queue does not wait on response from SHS for Spark Jobs.