### PR TITLE
changed async to future/blocking and changed the error to warn

### DIFF
--- a/app/com/linkedin/drelephant/ElephantRunner.java
+++ b/app/com/linkedin/drelephant/ElephantRunner.java
@@ -201,7 +201,7 @@ public class ElephantRunner implements Runnable {
         } else {
           if (_analyticJob != null) {
             MetricsController.markSkippedJob();
-            logger.warn("Drop the analytic job. Reason: reached the max retries for application id = ["
+            logger.error("Drop the analytic job. Reason: reached the max retries for application id = ["
                     + _analyticJob.getAppId() + "].");
           }
         }

--- a/app/com/linkedin/drelephant/ElephantRunner.java
+++ b/app/com/linkedin/drelephant/ElephantRunner.java
@@ -192,16 +192,16 @@ public class ElephantRunner implements Runnable {
         logger.error(ExceptionUtils.getStackTrace(e));
 
         if (_analyticJob != null && _analyticJob.retry()) {
-          logger.error("Add analytic job id [" + _analyticJob.getAppId() + "] into the retry list.");
+          logger.warn("Add analytic job id [" + _analyticJob.getAppId() + "] into the retry list.");
           _analyticJobGenerator.addIntoRetries(_analyticJob);
         } else if (_analyticJob != null && _analyticJob.isSecondPhaseRetry()) {
           //Putting the job into a second retry queue which fetches jobs after some interval. Some spark jobs may need more time than usual to process, hence the queue.
-          logger.error("Add analytic job id [" + _analyticJob.getAppId() + "] into the second retry list.");
+          logger.warn("Add analytic job id [" + _analyticJob.getAppId() + "] into the second retry list.");
           _analyticJobGenerator.addIntoSecondRetryQueue(_analyticJob);
         } else {
           if (_analyticJob != null) {
             MetricsController.markSkippedJob();
-            logger.error("Drop the analytic job. Reason: reached the max retries for application id = ["
+            logger.warn("Drop the analytic job. Reason: reached the max retries for application id = ["
                     + _analyticJob.getAppId() + "].");
           }
         }

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -92,7 +92,7 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
         Success(data)
       },
       e => {
-        logger.warn(s"Failed fetching data for ${appId}" + "\n" + e.getMessage + "\n" + "I will retry after some time!")
+        logger.warn(s"Failed fetching data for ${appId}." + " I will retry after some time! " + "Exception Message is: " + e.getMessage)
         Failure(e)
       }
     )

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -16,11 +16,9 @@
 
 package com.linkedin.drelephant.spark.fetchers
 
-import scala.async.Async
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future, blocking}
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.util.{Try, Success, Failure}
-import scala.util.control.NonFatal
 
 import com.linkedin.drelephant.analysis.{AnalyticJob, ElephantFetcher}
 import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData
@@ -35,9 +33,9 @@ import org.apache.spark.SparkConf
   * A fetcher that gets Spark-related data from a combination of the Spark monitoring REST API and Spark event logs.
   */
 class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
-    extends ElephantFetcher[SparkApplicationData] {
+  extends ElephantFetcher[SparkApplicationData] {
+
   import SparkFetcher._
-  import Async.{async, await}
   import ExecutionContext.Implicits.global
 
   private val logger: Logger = Logger.getLogger(classOf[SparkFetcher])
@@ -94,7 +92,7 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
         Success(data)
       },
       e => {
-        logger.error(s"Failed fetching data for ${appId}", e)
+        logger.warn(s"Failed fetching data for ${appId}" + "\n" + e.getMessage + "\n" + "I will retry after some time!")
         Failure(e)
       }
     )
@@ -102,7 +100,7 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
 
   private def doFetchSparkApplicationData(analyticJob: AnalyticJob): Future[SparkApplicationData] = {
     if (shouldProcessLogsLocally) {
-      async {
+      Future {
         sparkRestClient.fetchEventLogAndParse(analyticJob.getAppId)
       }
     } else {
@@ -110,19 +108,23 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
     }
   }
 
-  private def doFetchDataUsingRestAndLogClients(analyticJob: AnalyticJob): Future[SparkApplicationData] = async {
-    val appId = analyticJob.getAppId
-    val restDerivedData = await(sparkRestClient.fetchData(appId, eventLogSource == EventLogSource.Rest))
+  private def doFetchDataUsingRestAndLogClients(analyticJob: AnalyticJob): Future[SparkApplicationData] = Future {
+    blocking {
+      val appId = analyticJob.getAppId
+      val restDerivedData = Await.result(sparkRestClient.fetchData(appId, eventLogSource == EventLogSource.Rest), DEFAULT_TIMEOUT)
 
-    val logDerivedData = eventLogSource match {
-      case EventLogSource.None => None
-      case EventLogSource.Rest => restDerivedData.logDerivedData
-      case EventLogSource.WebHdfs =>
-        val lastAttemptId = restDerivedData.applicationInfo.attempts.maxBy { _.startTime }.attemptId
-        Some(await(sparkLogClient.fetchData(appId, lastAttemptId)))
+      val logDerivedData = eventLogSource match {
+        case EventLogSource.None => None
+        case EventLogSource.Rest => restDerivedData.logDerivedData
+        case EventLogSource.WebHdfs =>
+          val lastAttemptId = restDerivedData.applicationInfo.attempts.maxBy {
+            _.startTime
+          }.attemptId
+          Some(Await.result(sparkLogClient.fetchData(appId, lastAttemptId), DEFAULT_TIMEOUT))
+      }
+
+      SparkApplicationData(appId, restDerivedData, logDerivedData)
     }
-
-    SparkApplicationData(appId, restDerivedData, logDerivedData)
   }
 
 }


### PR DESCRIPTION
Changed the usage of async to Future/blocking. Reason being due to the async keyword, it wasn't able to allocate threads to the process and hence, was timing out very frequently. 
The number of concurrently blocking computations can exceed the parallelism level only if each blocking call is wrapped inside a blocking call. Otherwise, there is a risk that the thread pool in the global execution context is starved, and no computation can proceed.
Reference: https://docs.scala-lang.org/overviews/core/futures.html#the-global-execution-context