### PR TITLE
Add support for non compression files

### DIFF
--- a/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
+++ b/app/org/apache/spark/deploy/history/SparkFSFetcher.scala
@@ -97,10 +97,12 @@ class SparkFSFetcher(fetcherConfData: FetcherConfigurationData) extends Elephant
       logger.info("The event log of Spark application: " + appId + " is over the limit size of "
         + eventLogSizeLimitMb + " MB, the parsing process gets throttled.")
     } else {
-      logger.info("Replaying Spark logs for application: " + appId +
+      if (eventLogCodec.nonEmpty) {
+        logger.info("Replaying Spark logs for application: " + appId +
                           " withlogPath: " + eventLogPath +
-                          " with codec:" + eventLogCodec)
+  			   " with codec:" + eventLogCodec)
 
+      }
       sparkUtils.withEventLog(eventLogFileSystem, eventLogPath, eventLogCodec) { in =>
         dataCollection.load(in, eventLogPath.toString())
       }


### PR DESCRIPTION
Currently in the pathAndCodecforEventLog function in the second case block there is no support for un compressed files, this makes Dr. Elephant look for files with lz4 compression default. This patch adds support for the same.