### PR TITLE
Changing severity threshold from Moderate to Low for showing the slow…

### DIFF
--- a/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
@@ -144,7 +144,7 @@ object StagesHeuristic {
 
     lazy val stagesWithLongAverageExecutorRuntimes: Seq[(StageData, Long)] =
       stagesAndAverageExecutorRuntimeSeverities
-        .collect { case (stageData, runtime, severity) if severity.getValue > Severity.MODERATE.getValue => (stageData, runtime) }
+        .collect { case (stageData, runtime, severity) if severity.getValue > Severity.LOW.getValue => (stageData, runtime) }
 
     lazy val severity: Severity = Severity.max((stageFailureRateSeverity +: (taskFailureRateSeverities ++ runtimeSeverities)): _*)
 


### PR DESCRIPTION
Changing the severity threshold for getting and showing the stages with long executor runtime. Currently  if the Stage Heuristic severity is greater than MODERATE then only the stages with long executor time are shown on the UI, after this change such stages will be shown if the severity will be greater than LOW.