### PR TITLE
 Enabling Dr Elephant to work with YARN in HTTPS mode

### DIFF
--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -31,7 +31,6 @@ import org.apache.log4j.Logger;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
-
 /**
  * This class provides a list of analysis promises to be generated under Hadoop YARN environment
  */
@@ -42,12 +41,10 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
   private static final String RESOURCE_MANAGER_IDS = "yarn.resourcemanager.ha.rm-ids";
   private static final String FETCH_INITIAL_WINDOW_MS = "drelephant.analysis.fetch.initial.windowMillis";
 
-
-  //Assigning URL's a header of http:// or https:// depending if YARN https is enabled or not
-  private static String RM_URL_HEADER;
+  //Assigning URL's a header scheme of http:// or https:// depending if YARN https is enabled or not
+  private static String RM_URL_SCHEME;
   private static String RESOURCE_MANAGER_ADDRESS;
   private static String RM_NODE_STATE_URL;
-
   private static Configuration configuration;
 
   // We provide one minute job fetch delay due to the job sending lag from AM/NM to JobHistoryServer HDFS
@@ -66,37 +63,34 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
   private AuthenticatedURL.Token _token;
   private AuthenticatedURL _authenticatedURL;
   private final ObjectMapper _objectMapper = new ObjectMapper();
-
   private final Queue<AnalyticJob> _firstRetryQueue = new ConcurrentLinkedQueue<AnalyticJob>();
-
   private final ArrayList<AnalyticJob> _secondRetryQueue = new ArrayList<AnalyticJob>();
 
-  public void updateResourceManagerAddresses() {
-
+  public void setPolicybasedRMAddresses() {
     String rm_http_policy = configuration.get(RM_HTTP_POLICY);
-
     if (rm_http_policy == null) {
       throw new RuntimeException(
               "Cannot get YARN HTTP Policy [" + rm_http_policy + "] from Hadoop Configuration property: [" + RM_HTTP_POLICY
                       + "].");
     }
-
     if (rm_http_policy.equals("HTTP_ONLY")) {
       RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.address";
-      RM_URL_HEADER = "http://";
-      RM_NODE_STATE_URL = RM_URL_HEADER + "%s/ws/v1/cluster/info";
+      RM_URL_SCHEME = "http://";
+      RM_NODE_STATE_URL = RM_URL_SCHEME + "%s/ws/v1/cluster/info";
     } else if (rm_http_policy.equals("HTTPS_ONLY")) {
       RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.https.address";
-      RM_URL_HEADER = "https://";
-      RM_NODE_STATE_URL = RM_URL_HEADER + "%s/ws/v1/cluster/info";
+      RM_URL_SCHEME = "https://";
+      RM_NODE_STATE_URL = RM_URL_SCHEME + "%s/ws/v1/cluster/info";
     }
-
     if (RESOURCE_MANAGER_ADDRESS == null) {
       throw new RuntimeException(
               "RESOURCE_MANAGER_ADDRESS is not assigned - [" + RESOURCE_MANAGER_ADDRESS
                     + "] as [" + RM_HTTP_POLICY + "] = [" + rm_http_policy + "].");
     }
+  }
 
+  public void updateResourceManagerAddresses() {
+    setPolicybasedRMAddresses();
     if (Boolean.valueOf(configuration.get(IS_RM_HA_ENABLED))) {
       String resourceManagers = configuration.get(RESOURCE_MANAGER_IDS);
       if (resourceManagers != null) {
@@ -169,7 +163,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
         + ", and current time: " + _currentTime);
 
     // Fetch all succeeded apps
-    URL succeededAppsURL = new URL(new URL(RM_URL_HEADER + _resourceManagerAddress), String.format(
+    URL succeededAppsURL = new URL(new URL(RM_URL_SCHEME + _resourceManagerAddress), String.format(
             "/ws/v1/cluster/apps?finalStatus=SUCCEEDED&finishedTimeBegin=%s&finishedTimeEnd=%s",
             String.valueOf(_lastTime + 1), String.valueOf(_currentTime)));
     logger.info("The succeeded apps URL is " + succeededAppsURL);
@@ -179,7 +173,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
     // Fetch all failed apps
     // state: Application Master State
     // finalStatus: Status of the Application as reported by the Application Master
-    URL failedAppsURL = new URL(new URL(RM_URL_HEADER + _resourceManagerAddress), String.format(
+    URL failedAppsURL = new URL(new URL(RM_URL_SCHEME + _resourceManagerAddress), String.format(
         "/ws/v1/cluster/apps?finalStatus=FAILED&state=FINISHED&finishedTimeBegin=%s&finishedTimeEnd=%s",
         String.valueOf(_lastTime + 1), String.valueOf(_currentTime)));
     List<AnalyticJob> failedApps = readApps(failedAppsURL);

--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -45,13 +45,8 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
 
   //Assigning URL's a header of http:// or https:// depending if YARN https is enabled or not
   private static String RM_URL_HEADER;
-
   private static String RESOURCE_MANAGER_ADDRESS;
   private static String RM_NODE_STATE_URL;
-
-
-  //private static final String RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.address";
-  //private static final String RM_NODE_STATE_URL = "http://%s/ws/v1/cluster/info";
 
   private static Configuration configuration;
 
@@ -85,7 +80,6 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
               "Cannot get YARN HTTP Policy [" + rm_http_policy + "] from Hadoop Configuration property: [" + RM_HTTP_POLICY
                       + "].");
     }
-
 
     if (rm_http_policy.equals("HTTP_ONLY")) {
       RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.address";

--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -37,11 +37,21 @@ import org.codehaus.jackson.map.ObjectMapper;
  */
 public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
   private static final Logger logger = Logger.getLogger(AnalyticJobGeneratorHadoop2.class);
-  private static final String RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.address";
+  private static final String RM_HTTP_POLICY = "yarn.http.policy";
   private static final String IS_RM_HA_ENABLED = "yarn.resourcemanager.ha.enabled";
   private static final String RESOURCE_MANAGER_IDS = "yarn.resourcemanager.ha.rm-ids";
-  private static final String RM_NODE_STATE_URL = "http://%s/ws/v1/cluster/info";
   private static final String FETCH_INITIAL_WINDOW_MS = "drelephant.analysis.fetch.initial.windowMillis";
+
+
+  //Assigning URL's a header of http:// or https:// depending if YARN https is enabled or not
+  private static String RM_URL_HEADER;
+
+  private static String RESOURCE_MANAGER_ADDRESS;
+  private static String RM_NODE_STATE_URL;
+
+
+  //private static final String RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.address";
+  //private static final String RM_NODE_STATE_URL = "http://%s/ws/v1/cluster/info";
 
   private static Configuration configuration;
 
@@ -67,6 +77,32 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
   private final ArrayList<AnalyticJob> _secondRetryQueue = new ArrayList<AnalyticJob>();
 
   public void updateResourceManagerAddresses() {
+
+    String rm_http_policy = configuration.get(RM_HTTP_POLICY);
+
+    if (rm_http_policy == null) {
+      throw new RuntimeException(
+              "Cannot get YARN HTTP Policy [" + rm_http_policy + "] from Hadoop Configuration property: [" + RM_HTTP_POLICY
+                      + "].");
+    }
+
+
+    if (rm_http_policy.equals("HTTP_ONLY")) {
+      RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.address";
+      RM_URL_HEADER = "http://";
+      RM_NODE_STATE_URL = RM_URL_HEADER + "%s/ws/v1/cluster/info";
+    } else if (rm_http_policy.equals("HTTPS_ONLY")) {
+      RESOURCE_MANAGER_ADDRESS = "yarn.resourcemanager.webapp.https.address";
+      RM_URL_HEADER = "https://";
+      RM_NODE_STATE_URL = RM_URL_HEADER + "%s/ws/v1/cluster/info";
+    }
+
+    if (RESOURCE_MANAGER_ADDRESS == null) {
+      throw new RuntimeException(
+              "RESOURCE_MANAGER_ADDRESS is not assigned - [" + RESOURCE_MANAGER_ADDRESS
+                    + "] as [" + RM_HTTP_POLICY + "] = [" + rm_http_policy + "].");
+    }
+
     if (Boolean.valueOf(configuration.get(IS_RM_HA_ENABLED))) {
       String resourceManagers = configuration.get(RESOURCE_MANAGER_IDS);
       if (resourceManagers != null) {
@@ -139,7 +175,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
         + ", and current time: " + _currentTime);
 
     // Fetch all succeeded apps
-    URL succeededAppsURL = new URL(new URL("http://" + _resourceManagerAddress), String.format(
+    URL succeededAppsURL = new URL(new URL(RM_URL_HEADER + _resourceManagerAddress), String.format(
             "/ws/v1/cluster/apps?finalStatus=SUCCEEDED&finishedTimeBegin=%s&finishedTimeEnd=%s",
             String.valueOf(_lastTime + 1), String.valueOf(_currentTime)));
     logger.info("The succeeded apps URL is " + succeededAppsURL);
@@ -149,7 +185,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
     // Fetch all failed apps
     // state: Application Master State
     // finalStatus: Status of the Application as reported by the Application Master
-    URL failedAppsURL = new URL(new URL("http://" + _resourceManagerAddress), String.format(
+    URL failedAppsURL = new URL(new URL(RM_URL_HEADER + _resourceManagerAddress), String.format(
         "/ws/v1/cluster/apps?finalStatus=FAILED&state=FINISHED&finishedTimeBegin=%s&finishedTimeEnd=%s",
         String.valueOf(_lastTime + 1), String.valueOf(_currentTime)));
     List<AnalyticJob> failedApps = readApps(failedAppsURL);

--- a/app/com/linkedin/drelephant/tez/fetchers/TezFetcher.java
+++ b/app/com/linkedin/drelephant/tez/fetchers/TezFetcher.java
@@ -47,42 +47,42 @@ public class TezFetcher implements ElephantFetcher<TezApplicationData> {
   private String _timelineWebAddr;
 
   private FetcherConfigurationData _fetcherConfigurationData;
-  private static String RM_URL_HEADER;
+  private static String TIMELINE_SERVER_URL_SCHEME;
   private static String TIMELINE_SERVER_URL;
 
-  public TezFetcher(FetcherConfigurationData fetcherConfData) throws IOException {
-
+  public void setPolicybasedTimelineAddresses() {
     String rm_http_policy = new Configuration().get(RM_HTTP_POLICY);
-
     if (rm_http_policy == null) {
       throw new RuntimeException(
               "Cannot get YARN HTTP Policy [" + rm_http_policy + "] from Hadoop Configuration property: [" + RM_HTTP_POLICY
                       + "].");
     }
-
     if (rm_http_policy.equals("HTTP_ONLY")) {
       TIMELINE_SERVER_URL = "yarn.timeline-service.webapp.address";
-      RM_URL_HEADER = "http://";
+      TIMELINE_SERVER_URL_SCHEME = "http://";
     } else if (rm_http_policy.equals("HTTPS_ONLY")) {
       TIMELINE_SERVER_URL = "yarn.timeline-service.webapp.https.address";
-      RM_URL_HEADER = "https://";
+      TIMELINE_SERVER_URL_SCHEME = "https://";
     }
-
     if (TIMELINE_SERVER_URL == null) {
       throw new RuntimeException(
               "TIMELINE_SERVER_URL is not assigned - [" + TIMELINE_SERVER_URL
                     + "] as [" + RM_HTTP_POLICY + "] = [" + rm_http_policy + "].");
     }
+  }
+
+  public TezFetcher(FetcherConfigurationData fetcherConfData) throws IOException {
+    setPolicybasedTimelineAddresses();
 
     this._fetcherConfigurationData = fetcherConfData;
     final String applicationHistoryAddr = new Configuration().get(TIMELINE_SERVER_URL);
 
     //Connection validity checked using method verifyURL(_timelineWebAddr) inside URLFactory constructor;
-    _urlFactory = new URLFactory(applicationHistoryAddr,RM_URL_HEADER);
+    _urlFactory = new URLFactory(applicationHistoryAddr,TIMELINE_SERVER_URL_SCHEME);
     logger.info("Connection success.");
 
     _jsonFactory = new JSONFactory();
-    _timelineWebAddr = RM_URL_HEADER + _timelineWebAddr + "/ws/v1/timeline/";
+    _timelineWebAddr = TIMELINE_SERVER_URL_SCHEME + _timelineWebAddr + "/ws/v1/timeline/";
 
   }
 
@@ -167,8 +167,8 @@ public class TezFetcher implements ElephantFetcher<TezApplicationData> {
 
     private String _timelineWebAddr;
 
-    private URLFactory(String hserverAddr,String RM_URL_HEADER) throws IOException {
-      _timelineWebAddr = RM_URL_HEADER + hserverAddr + "/ws/v1/timeline";
+    private URLFactory(String hserverAddr,String TIMELINE_SERVER_URL_SCHEME) throws IOException {
+      _timelineWebAddr = TIMELINE_SERVER_URL_SCHEME + hserverAddr + "/ws/v1/timeline";
       verifyURL(_timelineWebAddr);
     }
 


### PR DESCRIPTION
This pull request is to address #472

Configuration value of the property -  `yarn.http.policy` which can have either of the values - `HTTP_ONLY / HTTPS_ONLY`, defines whether YARN is in HTTPS mode

Changes Addressed to below files - 
1. [TezFetcher](https://github.com/linkedin/dr-elephant/blob/master/app/com/linkedin/drelephant/tez/fetchers/TezFetcher.java)
2. [AnalyticJobGeneratorHadoop2](https://github.com/linkedin/dr-elephant/blob/master/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java)


If statement inserted to check the configuration value of the property - `yarn.http.policy` which can have either of the values - `HTTP_ONLY` / `HTTPS_ONLY`. Based on the value below properties need to be addressed

RESOURCE_MANAGER_ADDRESS as `yarn.resourcemanager.webapp.address` or `yarn.resourcemanager.webapp.https.address`

RM_NODE_STATE_URL as `http://%s/ws/v1/cluster/info
 or https://%s/ws/v1/cluster/info`

succeededAppsURL and failedAppsURL as `new URL("http://" + _resourceManagerAddress)` or `new URL("https://" + _resourceManagerAddress)`