### PR TITLE
Fixing the query for fetching latest JobExecution in AbstractFitnessManager

### DIFF
--- a/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
+++ b/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
@@ -22,6 +22,7 @@ import models.TuningJobExecutionParamSet;
 import models.TuningParameter;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import scala.tools.nsc.typechecker.PatternMatching;
 
 
 /**
@@ -149,7 +150,7 @@ public abstract class AbstractFitnessManager implements Manager {
           "Fitness of param set " + jobSuggestedParamSet.id + " corresponding to execution id: " + jobExecution.id
               + " not computed for more than the maximum duration specified to compute fitness. "
               + "Resetting the param set to CREATED state");
-      resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
+      resetParamSetToCreated(jobSuggestedParamSet);
     }
   }
 
@@ -180,17 +181,27 @@ public abstract class AbstractFitnessManager implements Manager {
    * Resets the param set to CREATED state if its fitness is not already computed
    * @param jobSuggestedParamSet Param set which is to be reset
    */
-  protected void resetParamSetToCreated(JobSuggestedParamSet jobSuggestedParamSet, JobExecution jobExecution) {
-    if (!jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.FITNESS_COMPUTED)) {
+  protected void resetParamSetToCreated(JobSuggestedParamSet jobSuggestedParamSet) {
+    if (!jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.FITNESS_COMPUTED)
+        && !jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.DISCARDED)) {
       logger.debug("Resetting parameter set to created: " + jobSuggestedParamSet.id);
       jobSuggestedParamSet.paramSetState = JobSuggestedParamSet.ParamSetStatus.CREATED;
       jobSuggestedParamSet.save();
-      JobExecution latestJobExecution =
-          JobExecution.find.where().eq(JobExecution.TABLE.id, jobSuggestedParamSet.jobDefinition.id).findUnique();
-      latestJobExecution.resourceUsage = 0D;
-      latestJobExecution.executionTime = 0D;
-      latestJobExecution.inputSizeInBytes = 1D;
-      latestJobExecution.save();
+      TuningJobExecutionParamSet tuningJobExecutionParamSet = TuningJobExecutionParamSet.find.where()
+          .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + JobSuggestedParamSet.TABLE.id, jobSuggestedParamSet.id)
+          .findUnique();
+      if (tuningJobExecutionParamSet != null) {
+        JobExecution latestJobExecution = JobExecution.find.where()
+            .eq(JobExecution.TABLE.id,
+                tuningJobExecutionParamSet.jobExecution.id)
+            .findUnique();
+        latestJobExecution.resourceUsage = 0D;
+        latestJobExecution.executionTime = 0D;
+        latestJobExecution.inputSizeInBytes = 1D;
+        latestJobExecution.save();
+      } else {
+        logger.error("No TuningJobExecutionParamSet found for JobSuggestedParamSet id " + jobSuggestedParamSet.id);
+      }
     }
   }
 

--- a/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
+++ b/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
@@ -22,8 +22,6 @@ import models.TuningJobExecutionParamSet;
 import models.TuningParameter;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
-import scala.tools.nsc.typechecker.PatternMatching;
-
 
 /**
  * This class computes the fitness of the suggested parameters after the execution is complete. This uses

--- a/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
+++ b/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
@@ -118,7 +118,7 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
         // after failure.
         logger.info("HBT Execution id: " + jobExecution.id + " was not successful for reason other than tuning."
             + "Resetting param set: " + jobSuggestedParamSet.id + " to CREATED state");
-        resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
+        resetParamSetToCreated(jobSuggestedParamSet);
       }
     }
   }
@@ -136,27 +136,6 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
     jobSuggestedParamSet.fitnessJobExecution = jobExecution;
     jobSuggestedParamSet = updateBestJobSuggestedParamSet(jobSuggestedParamSet);
     jobSuggestedParamSet.update();
-  }
-
-  /**
-   * Resets the param set to CREATED state if its fitness is not already computed
-   * @param jobSuggestedParamSet Param set which is to be reset
-   */
-  @Override
-  protected void resetParamSetToCreated(JobSuggestedParamSet jobSuggestedParamSet, JobExecution jobExecution) {
-    if (!jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.FITNESS_COMPUTED)
-        && !jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.DISCARDED)) {
-      logger.debug("Resetting parameter set to created: " + jobSuggestedParamSet.id);
-      jobSuggestedParamSet.paramSetState = JobSuggestedParamSet.ParamSetStatus.CREATED;
-      jobSuggestedParamSet.save();
-
-      JobExecution latestJobExecution =
-          JobExecution.find.where().eq(JobExecution.TABLE.id, jobSuggestedParamSet.jobDefinition.id).findUnique();
-      latestJobExecution.resourceUsage = 0D;
-      latestJobExecution.executionTime = 0D;
-      latestJobExecution.inputSizeInBytes = 1D;
-      latestJobExecution.save();
-    }
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoIPSO.java
+++ b/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoIPSO.java
@@ -63,7 +63,7 @@ public class FitnessManagerOBTAlgoIPSO extends FitnessManagerOBT {
         // after failure.
         logger.debug("Execution id: " + jobExecution.id + " was not successful for reason other than tuning."
             + "Resetting param set: " + jobSuggestedParamSet.id + " to CREATED state");
-        resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
+        resetParamSetToCreated(jobSuggestedParamSet);
       }
     }
   }

--- a/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoPSO.java
+++ b/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoPSO.java
@@ -66,7 +66,7 @@ public class FitnessManagerOBTAlgoPSO extends FitnessManagerOBT {
         // after failure.
         logger.debug("Execution id: " + jobExecution.id + " was not successful for reason other than tuning."
             + "Resetting param set: " + jobSuggestedParamSet.id + " to CREATED state");
-        resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
+        resetParamSetToCreated(jobSuggestedParamSet);
       }
     }
   }


### PR DESCRIPTION
In this PR the changes are made to fix the query for getting the latest JobExecution and removing some redundant code from the FitnessManagerHBT for using the resetParamSetToCreated method from the AbstractFitnessManager .