### PR TITLE
Fix wrong metrics for Pig job using TEZ

### DIFF
--- a/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java
@@ -85,11 +85,12 @@ public class TezMetricsAggregator implements HadoopMetricsAggregator {
 
   private long getMapContainerSize(HadoopApplicationData data) {
     try {
-      long mapContainerSize = Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG));
-      if (mapContainerSize > 0)
-        return mapContainerSize;
-      else
-        return Long.parseLong(data.getConf().getProperty(MAP_CONTAINER_CONFIG));
+      if (data.getConf().containsKey(TEZ_CONTAINER_CONFIG)){
+        long mapContainerSize = Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG));
+        if (mapContainerSize > 0)
+          return mapContainerSize;
+      }
+      return Long.parseLong(data.getConf().getProperty(MAP_CONTAINER_CONFIG));
     } catch ( NumberFormatException ex) {
       return CONTAINER_MEMORY_DEFAULT_BYTES;
     }
@@ -97,11 +98,12 @@ public class TezMetricsAggregator implements HadoopMetricsAggregator {
 
   private long getReducerContainerSize(HadoopApplicationData data) {
     try {
-      long reducerContainerSize = Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG));
-      if (reducerContainerSize > 0)
-        return reducerContainerSize;
-      else
-        return Long.parseLong(data.getConf().getProperty(REDUCER_CONTAINER_CONFIG));
+      if (data.getConf().containsKey(TEZ_CONTAINER_CONFIG)){
+        long reducerContainerSize = Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG));
+        if (reducerContainerSize > 0)
+          return reducerContainerSize;
+      }
+      return Long.parseLong(data.getConf().getProperty(REDUCER_CONTAINER_CONFIG));
     } catch ( NumberFormatException ex) {
       return CONTAINER_MEMORY_DEFAULT_BYTES;
     }

--- a/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java
@@ -85,12 +85,9 @@ public class TezMetricsAggregator implements HadoopMetricsAggregator {
 
   private long getMapContainerSize(HadoopApplicationData data) {
     try {
-      if (data.getConf().containsKey(TEZ_CONTAINER_CONFIG)){
-        long mapContainerSize = Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG));
-        if (mapContainerSize > 0)
-          return mapContainerSize;
-      }
-      return Long.parseLong(data.getConf().getProperty(MAP_CONTAINER_CONFIG));
+      // Trying to get container size from tez config, if not found trying from MapReduce config
+      long mapContainerSize = data.getConf().containsKey(TEZ_CONTAINER_CONFIG) ? Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG)) : -1;
+      return mapContainerSize > 0 ? mapContainerSize : Long.parseLong(data.getConf().getProperty(MAP_CONTAINER_CONFIG));
     } catch ( NumberFormatException ex) {
       return CONTAINER_MEMORY_DEFAULT_BYTES;
     }
@@ -98,12 +95,9 @@ public class TezMetricsAggregator implements HadoopMetricsAggregator {
 
   private long getReducerContainerSize(HadoopApplicationData data) {
     try {
-      if (data.getConf().containsKey(TEZ_CONTAINER_CONFIG)){
-        long reducerContainerSize = Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG));
-        if (reducerContainerSize > 0)
-          return reducerContainerSize;
-      }
-      return Long.parseLong(data.getConf().getProperty(REDUCER_CONTAINER_CONFIG));
+      // Trying to get container size from tez config, if not found trying from MapReduce config
+      long reducerContainerSize = data.getConf().containsKey(TEZ_CONTAINER_CONFIG) ? Long.parseLong(data.getConf().getProperty(TEZ_CONTAINER_CONFIG)) : -1;
+      return reducerContainerSize > 0 ? reducerContainerSize: Long.parseLong(data.getConf().getProperty(REDUCER_CONTAINER_CONFIG));
     } catch ( NumberFormatException ex) {
       return CONTAINER_MEMORY_DEFAULT_BYTES;
     }


### PR DESCRIPTION
When DrElephant analyze Pig job running on TEZ, all metrics are wrong.

My JobTypeConf.xml for tez is:

```xml
  <jobType>
    <name>HiveTez</name>
    <applicationtype>tez</applicationtype>
    <conf>hive.mapred.mode</conf>
    <isDefault/>
  </jobType>
  <jobType>
    <name>TezPig</name>
    <applicationtype>tez</applicationtype>
    <conf>pig.script</conf>
  </jobType>
```

After some diggings, I found that in the methods getMapContainerSize and getReducerContainerSize,  line 88 and 100 always throw NumberFormatException when DrElephant analyze a Pig job.

https://github.com/linkedin/dr-elephant/blob/44419ed7036f55d30d32e6af46871993f0918055/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java#L86-L96

https://github.com/linkedin/dr-elephant/blob/44419ed7036f55d30d32e6af46871993f0918055/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java#L98-L108

https://github.com/linkedin/dr-elephant/blob/44419ed7036f55d30d32e6af46871993f0918055/app/com/linkedin/drelephant/tez/TezMetricsAggregator.java#L32

It's because TEZ_CONTAINER_CONFIG key existence is not test before using it. So when it's a Pig job, the TEZ_CONTAINER_CONFIG configuration doesn't exist, so the parseLong throw NumberFormatException and used CONTAINER_MEMORY_DEFAULT_BYTES.