### PR TITLE
Making changes to TuneIn recommendation UI for adding more information

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -25,12 +25,10 @@ import com.linkedin.drelephant.ElephantContext;
 import com.linkedin.drelephant.analysis.Metrics;
 import com.linkedin.drelephant.analysis.Severity;
 import com.linkedin.drelephant.util.Utils;
-import java.lang.reflect.Array;
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -51,7 +49,6 @@ import models.JobDefinition;
 import models.JobExecution;
 import models.JobSuggestedParamSet;
 import models.JobSuggestedParamValue;
-import models.TuningAlgorithm;
 import models.TuningJobDefinition;
 import models.TuningParameter;
 import org.apache.commons.collections.map.ListOrderedMap;
@@ -59,7 +56,6 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 
-import org.codehaus.jettison.json.JSONArray;
 import play.api.templates.Html;
 import play.data.DynamicForm;
 import play.data.Form;
@@ -1802,7 +1798,7 @@ public class Application extends Controller {
       tuneIn.addProperty("tuningAlgorithmId", tuningAlgorithm.id);
       tuneIn.addProperty("autoApply", autoApply);
       tuneIn.addProperty("tuningAlgorithm", currentTuningAlgorithm);
-      tuneIn.addProperty("reasonForTuningDisable", checkIfTuningEnabled(tuningJobDefinition));
+      tuneIn.addProperty("reasonForTuningDisable", reasonForDisablingTuning(tuningJobDefinition));
       tuneIn.add("tuningAlgorithmList", tuningAlgorithmList);
       tuneIn.addProperty("iterationCount",tuningJobDefinition.numberOfIterations);
       tuneIn.add("tuningParameters", tuningParameters);
@@ -1817,7 +1813,7 @@ public class Application extends Controller {
     }
   }
 
-  public static Result showTuneinParams() {
+  public static Result updateShowRecommendationCount() {
     JsonNode requestBodyRoot = request().body().asJson();
     Integer jobDefinitionId = requestBodyRoot.path("id").asInt();
     TuningJobDefinition tuningJobDefinition = TuningJobDefinition.find.select("*")
@@ -1957,7 +1953,7 @@ public class Application extends Controller {
     return tuningAlgorithm.optimizationAlgo.name().contains("PSO") ? "OBT" : "HBT";
   }
 
-  private static String checkIfTuningEnabled(TuningJobDefinition tuningJobDefinition) {
+  private static String reasonForDisablingTuning(TuningJobDefinition tuningJobDefinition) {
     if (tuningJobDefinition.tuningEnabled) {
       logger.debug("Tuning is disabled for this application");
       if (tuningJobDefinition.tuningDisabledReason != null) {

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -1802,6 +1802,7 @@ public class Application extends Controller {
       tuneIn.addProperty("tuningAlgorithmId", tuningAlgorithm.id);
       tuneIn.addProperty("autoApply", autoApply);
       tuneIn.addProperty("tuningAlgorithm", currentTuningAlgorithm);
+      tuneIn.addProperty("reasonForTuningDisable", checkIfTuningEnabled(tuningJobDefinition));
       tuneIn.add("tuningAlgorithmList", tuningAlgorithmList);
       tuneIn.addProperty("iterationCount",tuningJobDefinition.numberOfIterations);
       tuneIn.add("tuningParameters", tuningParameters);
@@ -1814,6 +1815,20 @@ public class Application extends Controller {
       parent.add("tunein", tuneIn);
       return ok(new Gson().toJson(parent));
     }
+  }
+
+  public static Result showTuneinParams() {
+    JsonNode requestBodyRoot = request().body().asJson();
+    Integer jobDefinitionId = requestBodyRoot.path("id").asInt();
+    TuningJobDefinition tuningJobDefinition = TuningJobDefinition.find.select("*")
+        .where()
+        .eq(TuningJobDefinition.TABLE.job + '.' + JobDefinition.TABLE.id, jobDefinitionId)
+        .findUnique();
+    tuningJobDefinition.showRecommendationCount += 1;
+    tuningJobDefinition.save();
+    JsonObject parent = new JsonObject();
+    parent.addProperty("showRecommendationCount", tuningJobDefinition.showRecommendationCount);
+    return ok(new Gson().toJson(parent));
   }
 
   /**
@@ -1940,5 +1955,17 @@ public class Application extends Controller {
 
   private static String getCurrentTuningAlgorithmName(TuningAlgorithm tuningAlgorithm) {
     return tuningAlgorithm.optimizationAlgo.name().contains("PSO") ? "OBT" : "HBT";
+  }
+
+  private static String checkIfTuningEnabled(TuningJobDefinition tuningJobDefinition) {
+    if (tuningJobDefinition.tuningEnabled) {
+      logger.debug("Tuning is disabled for this application");
+      if (tuningJobDefinition.tuningDisabledReason != null) {
+        return tuningJobDefinition.tuningDisabledReason;
+      } else {
+        logger.info("No Reason provided to disable tuning for this application");
+      }
+    }
+    return "NONE";
   }
 }

--- a/app/models/TuningJobDefinition.java
+++ b/app/models/TuningJobDefinition.java
@@ -58,6 +58,7 @@ public class TuningJobDefinition extends Model {
     public static final String numberOfIterations = "numberOfIterations";
     public static final String createdTs = "createdTs";
     public static final String updatedTs = "updatedTs";
+    public static final String showRecommendationCount = "showRecommendationCount";
 
   }
 
@@ -103,6 +104,9 @@ public class TuningJobDefinition extends Model {
       return null;
     }
   }
+
+  @Column(nullable = false)
+  public Integer showRecommendationCount;
 
   public static Model.Finder<Integer, TuningJobDefinition> find =
       new Model.Finder<Integer, TuningJobDefinition>(Integer.class, TuningJobDefinition.class);

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS tuning_parameter_constraint (
 
 create index index_tuning_parameter_constraint on tuning_parameter_constraint (job_definition_id);
 
-alter table tuning_job_definition add column show_recommendation_count INT NOT NULL default 0;
+alter table tuning_job_definition add column show_recommendation_count INT default 0;
 
 # --- !Downs
 DELETE FROM tuning_parameter WHERE tuning_algorithm_id=3;

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -62,6 +62,8 @@ CREATE TABLE IF NOT EXISTS tuning_parameter_constraint (
 
 create index index_tuning_parameter_constraint on tuning_parameter_constraint (job_definition_id);
 
+alter table tuning_job_definition add column show_recommendation_count INT NOT NULL default 0;
+
 # --- !Downs
 DELETE FROM tuning_parameter WHERE tuning_algorithm_id=3;
 DELETE FROM tuning_parameter WHERE tuning_algorithm_id=4;

--- a/conf/routes
+++ b/conf/routes
@@ -57,7 +57,7 @@ GET        /rest/workflow-exceptions            controllers.api.v1.Web.restExcep
 GET        /rest/exception-statuses             controllers.api.v1.Web.restExceptionStatuses()
 GET        /rest/tunein                         controllers.Application.getTuningParameter(id: String)
 POST       /rest/getCurrentRunParameters        controllers.Application.getCurrentRunParameters()
-POST       /rest/showTuneinParams               controllers.Application.showTuneinParams
+POST       /rest/showTuneinParams               controllers.Application.updateShowRecommendationCount()
 
 # Metrics calls
 GET        /ping                                controllers.MetricsController.ping()

--- a/conf/routes
+++ b/conf/routes
@@ -57,6 +57,7 @@ GET        /rest/workflow-exceptions            controllers.api.v1.Web.restExcep
 GET        /rest/exception-statuses             controllers.api.v1.Web.restExceptionStatuses()
 GET        /rest/tunein                         controllers.Application.getTuningParameter(id: String)
 POST       /rest/getCurrentRunParameters        controllers.Application.getCurrentRunParameters()
+POST       /rest/showTuneinParams               controllers.Application.showTuneinParams
 
 # Metrics calls
 GET        /ping                                controllers.MetricsController.ping()

--- a/test/resources/test-init-baseline.sql
+++ b/test/resources/test-init-baseline.sql
@@ -175,7 +175,7 @@ INSERT INTO flow_definition VALUES (10046,'https://ltx1-faroaz01.grid.linkedin.c
 
 INSERT INTO job_definition VALUES (100046,'https://ltx1-faroaz01.grid.linkedin.com:8443/manager?project=tuning_hbt&flow=dimDataSimpleFlow&job=dimDataSimpleFlow_dimDataSimple','https://ltx1-faroaz01.grid.linkedin.com:8443/manager?project=tuning_hbt&flow=dimDataSimpleFlow&job=dimDataSimpleFlow_dimDataSimple',10046,'dimDataSimpleFlow_dimDataSimple','azkaban','pkumar2','2018-09-12 08:57:43','2018-09-11 20:27:44');
 
-INSERT INTO tuning_job_definition VALUES (100046,'azkaban',3,1,1,NULL,1.15030667,1912288051,150,150,NULL,10,'2018-09-12 08:57:43','2018-09-11 20:27:49');
+INSERT INTO tuning_job_definition VALUES (100046,'azkaban',3,1,1,NULL,1.15030667,1912288051,150,150,NULL,10,'2018-09-12 08:57:43','2018-09-11 20:27:49',0);
 
 INSERT INTO flow_execution VALUES (1084,'https://ltx1-faroaz01.grid.linkedin.com:8443/executor?execid=1122321','https://ltx1-faroaz01.grid.linkedin.com:8443/executor?execid=1122321',10046,'2018-09-12 08:57:43','2018-09-11 20:27:44'),(1085,'https://ltx1-faroaz01.grid.linkedin.com:8443/executor?execid=1122375','https://ltx1-faroaz01.grid.linkedin.com:8443/executor?execid=1122375',10046,'2018-09-12 09:20:16','2018-09-11 20:50:16');
 

--- a/web/app/controllers/job.js
+++ b/web/app/controllers/job.js
@@ -17,6 +17,14 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-    queryParams: ['jobid'],
-    jobid: null
+  queryParams: ['jobid'],
+  jobid: null,
+  showTuneinRecommendations: false,
+
+  actions: {
+    showRecommendation(jobDefinitionId) {
+      this.set("showTuneinRecommendations", true),
+      this.send("showRecommendations", jobDefinitionId);
+    }
+  }
 });

--- a/web/app/models/tunein.js
+++ b/web/app/models/tunein.js
@@ -26,5 +26,6 @@ export default DS.Model.extend({
   tuningAlgorithm: DS.attr('string'),
   tuningAlgorithmList: DS.attr(),
   iterationCount: DS.attr('number'),
-  tuningParameters: DS.attr()
+  tuningParameters: DS.attr(),
+  reasonForTuningDisable: DS.attr('string')
 });

--- a/web/app/routes/job.js
+++ b/web/app/routes/job.js
@@ -20,6 +20,8 @@ export default Ember.Route.extend({
   beforeModel: function (transition) {
     this.jobid = transition.queryParams.jobid;
   },
+  ajax: Ember.inject.service(),
+
   model(){
     return Ember.RSVP.hash({
       jobs:   this.store.queryRecord('job', {jobid: this.get("jobid")}),
@@ -27,6 +29,14 @@ export default Ember.Route.extend({
     });
   },
   actions: {
+    showRecommendations(jobDefinitionId) {
+      return this.get('ajax').post('/rest/showTuneinParams', {
+        contentType: 'application/json; charset=UTF-8',
+        data: JSON.stringify({
+          id: jobDefinitionId
+        })
+      });
+    },
     error(error, transition) {
       if (error.errors[0].status == 404) {
         return this.transitionTo('not-found', { queryParams: {'previous': window.location.href}});

--- a/web/app/styles/app.css
+++ b/web/app/styles/app.css
@@ -337,7 +337,7 @@ input:checked + .slider:after
   font-weight: 500;
   border: #0084BF 1px solid;
   color: white;
-  padding: 5px;
+  padding: 9px 11px;
 }
 
 .recommendation-button:hover {

--- a/web/app/styles/app.css
+++ b/web/app/styles/app.css
@@ -326,3 +326,26 @@ input:checked + .slider:after
   margin-left: 5px;
   color: #0e90d2;
 }
+
+.recommendation-button {
+  background-color: #008cc9;
+  margin:auto;
+  display: block;
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 14px;
+  font-weight: 500;
+  border: #0084BF 1px solid;
+  color: white;
+  padding: 5px;
+}
+
+.recommendation-button:hover {
+  background-color: white;
+  color: #008cc9;
+}
+
+.info-text {
+  margin: 2px;
+  color: #0e90d2;
+}

--- a/web/app/templates/job.hbs
+++ b/web/app/templates/job.hbs
@@ -123,8 +123,6 @@
             <div class="col-sm-3 heading bold">Tuning Algorithm</div>
             <div class="col-sm-3 heading bold">Number of Iterations</div>
           </div>
-        </div>
-        <div class="container">
           <div class="row">
             <div class="col-sm-3">
               <label class="switch">
@@ -160,7 +158,7 @@
           <button class="recommendation-button" {{action "showRecommendation" model.tunein.jobDefinitionId}}>Show TuneIn Recommended Parameters</button>
         </div>
       {{/if}}
-      <div class="info-text text-right">For any queries contact <b>ask_tunein</b></div>
+      <div class="info-text text-right">For any queries, contact <b>ask_tunein</b></div>
     </div>
   {{/unless}}
 

--- a/web/app/templates/job.hbs
+++ b/web/app/templates/job.hbs
@@ -95,9 +95,10 @@
   {{#unless (eq model.tunein.jobSuggestedParamSetId "null")}}
     <div class="shadow details-container box">
       <h4>TuneIn Recommended Parameters</h4>
-      <hr class="bold-horizontal-line">
-      <table class="table info borderless">
-        <tbody>
+      {{#if showTuneinRecommendations}}
+        <hr class="bold-horizontal-line">
+        <table class="table info borderless">
+          <tbody>
           <tr class="heading">
             <th>Parameter Name</th>
             <th>Suggested Value</th>
@@ -112,45 +113,54 @@
               </td>
             </tr>
           {{/each}}
-        </tbody>
-      </table>
-      <div class="severity-None">*These parameter suggestions are based on latest job execution</div>
-      <hr class="bold-horizontal-line">
-      <div class="container">
-        <div class="row">
-          <div class="col-sm-3 heading bold">Auto Tuning</div>
-          <div class="col-sm-3 heading bold">Tuning Algorithm</div>
-          <div class="col-sm-3 heading bold">Number of Iterations</div>
+          </tbody>
+        </table>
+        <div class="severity-None">*These parameter suggestions are based on latest job execution</div>
+        <hr class="bold-horizontal-line">
+        <div class="container">
+          <div class="row">
+            <div class="col-sm-3 heading bold">Auto Tuning</div>
+            <div class="col-sm-3 heading bold">Tuning Algorithm</div>
+            <div class="col-sm-3 heading bold">Number of Iterations</div>
+          </div>
         </div>
-      </div>
-      <div class="container">
-        <div class="row">
-          <div class="col-sm-3">
-            <label class="switch">
-              {{input type="checkbox" checked=model.tunein.autoApply disabled=true}}
-              <div class="slider round"></div>
-            </label>
-          </div>
-          <div class="col-sm-3">
-            <select id='soflow' disabled>
-              {{#each model.tunein.tuningAlgorithmList as |algorithm|}}
-                <option value={{algorithm.name}} selected={{eq algorithm.name model.tunein.tuningAlgorithm}}>{{algorithm.name}}</option>
-              {{/each}}
-            </select>
-          </div>
-          <div class="col-sm-3">
-            {{input type="text" class="iteration-count" id="form-workflow-id" name="iterationCount" value=model.tunein.iterationCount disabled=true}}
-          </div>
+        <div class="container">
+          <div class="row">
+            <div class="col-sm-3">
+              <label class="switch">
+                {{input type="checkbox" checked=model.tunein.autoApply disabled=true}}
+                <div class="slider round"></div>
+              </label>
+            </div>
+            <div class="col-sm-3">
+              <select id='soflow' disabled>
+                {{#each model.tunein.tuningAlgorithmList as |algorithm|}}
+                  <option value={{algorithm.name}} selected={{eq algorithm.name model.tunein.tuningAlgorithm}}>{{algorithm.name}}</option>
+                {{/each}}
+              </select>
+            </div>
+            <div class="col-sm-3">
+              {{input type="text" class="iteration-count" id="form-workflow-id" name="iterationCount" value=model.tunein.iterationCount disabled=true}}
+            </div>
 
-          <div class="col-sm-3">
-            <button type="submit" class="btn wf-button" disabled title="This will be available in the next release"> Submit</button>
+            <div class="col-sm-3">
+              <button type="submit" class="btn wf-button" disabled title="This will be available in the next release"> Submit</button>
+            </div>
           </div>
         </div>
         <div class="severity-Critical">Above shown features will be enabled in the next release</div>
-      </div>
-      {{#if (eq model.jobs.severity "None")}}
-        <div class="severity-None">All Heuristics Passed with the above mentioned parameters</div>
+        {{#if (eq model.jobs.severity "None")}}
+          <div class="severity-None">All Heuristics Passed with the above mentioned parameters</div>
+        {{/if}}
+        {{#unless (eq model.tunein.reasonForTuningDisable "NONE")}}
+          <div class="text info-text">Disabling TuneIn for this application as {{model.tunein.reasonForTuningDisable}}</div>
+        {{/unless}}
+      {{else}}
+        <div class="wrapper">
+          <button class="recommendation-button" {{action "showRecommendation" model.tunein.jobDefinitionId}}>Show TuneIn Recommended Parameters</button>
+        </div>
       {{/if}}
+      <div class="info-text text-right">For any queries contact <b>ask_tunein</b></div>
     </div>
   {{/unless}}
 


### PR DESCRIPTION
**DESCRIPTION**

In this PR, there are changes made to the TuneIn UI to add some helpful information for the user such as 

- Reason to disable TuneIn for some job

- Contact info in case of any query

There is one significant change to provide a button to the user for requesting to show tuning parameters instead of showing all the parameters directly. After this change UI will look like as below: 

<img width="1147" alt="screen shot 2018-11-18 at 4 47 10 pm" src="https://user-images.githubusercontent.com/24277980/48671664-d3050500-eb51-11e8-831b-7b4b7a33f67f.png">

and after request is processed all the tuning recommendations will be visible to the user

<img width="1162" alt="screen shot 2018-11-18 at 4 47 22 pm" src="https://user-images.githubusercontent.com/24277980/48671673-f5971e00-eb51-11e8-9b4c-ce3af5b9d641.png">


**How This is Tested**

Testing is done on the EI.

