### PR TITLE
Fixing query to fetch latest TuningJobExecutionParamSet

### DIFF
--- a/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
+++ b/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
@@ -148,7 +148,7 @@ public abstract class AbstractFitnessManager implements Manager {
           "Fitness of param set " + jobSuggestedParamSet.id + " corresponding to execution id: " + jobExecution.id
               + " not computed for more than the maximum duration specified to compute fitness. "
               + "Resetting the param set to CREATED state");
-      resetParamSetToCreated(jobSuggestedParamSet);
+      resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
     }
   }
 
@@ -179,31 +179,21 @@ public abstract class AbstractFitnessManager implements Manager {
    * Resets the param set to CREATED state if its fitness is not already computed
    * @param jobSuggestedParamSet Param set which is to be reset
    */
-  protected void resetParamSetToCreated(JobSuggestedParamSet jobSuggestedParamSet) {
+  protected void resetParamSetToCreated(JobSuggestedParamSet jobSuggestedParamSet, JobExecution jobExecution) {
     if (!jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.FITNESS_COMPUTED)
         && !jobSuggestedParamSet.paramSetState.equals(JobSuggestedParamSet.ParamSetStatus.DISCARDED)) {
       logger.debug("Resetting parameter set to created: " + jobSuggestedParamSet.id);
       jobSuggestedParamSet.paramSetState = JobSuggestedParamSet.ParamSetStatus.CREATED;
       jobSuggestedParamSet.save();
-      TuningJobExecutionParamSet tuningJobExecutionParamSet = TuningJobExecutionParamSet.find.where()
-          .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + '.'  +JobSuggestedParamSet.TABLE.id, jobSuggestedParamSet.id)
-          .order()
-          .desc(TuningJobExecutionParamSet.TABLE.jobExecution + '.' + JobExecution.TABLE.id)
-          .setMaxRows(1)
+      JobExecution latestJobExecution = JobExecution.find.where()
+          .eq(JobExecution.TABLE.id,
+              jobExecution.id)
           .findUnique();
-      if (tuningJobExecutionParamSet != null) {
-        JobExecution latestJobExecution = JobExecution.find.where()
-            .eq(JobExecution.TABLE.id,
-                tuningJobExecutionParamSet.jobExecution.id)
-            .findUnique();
-        latestJobExecution.resourceUsage = 0D;
-        latestJobExecution.executionTime = 0D;
-        latestJobExecution.inputSizeInBytes = 1D;
-        latestJobExecution.update();
-        logger.info("Updated JobExecution: " + latestJobExecution.id + "after resetting param set to CREATED");
-      } else {
-        logger.error("No TuningJobExecutionParamSet found for JobSuggestedParamSet id " + jobSuggestedParamSet.id);
-      }
+      latestJobExecution.resourceUsage = 0D;
+      latestJobExecution.executionTime = 0D;
+      latestJobExecution.inputSizeInBytes = 1D;
+      latestJobExecution.update();
+      logger.info("Updated JobExecution: " + latestJobExecution.id + " after resetting param set to CREATED");
     }
   }
 

--- a/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
+++ b/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
@@ -186,7 +186,10 @@ public abstract class AbstractFitnessManager implements Manager {
       jobSuggestedParamSet.paramSetState = JobSuggestedParamSet.ParamSetStatus.CREATED;
       jobSuggestedParamSet.save();
       TuningJobExecutionParamSet tuningJobExecutionParamSet = TuningJobExecutionParamSet.find.where()
-          .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + JobSuggestedParamSet.TABLE.id, jobSuggestedParamSet.id)
+          .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + '.'  +JobSuggestedParamSet.TABLE.id, jobSuggestedParamSet.id)
+          .order()
+          .desc(TuningJobExecutionParamSet.TABLE.jobExecution + '.' + JobExecution.TABLE.id)
+          .setMaxRows(1)
           .findUnique();
       if (tuningJobExecutionParamSet != null) {
         JobExecution latestJobExecution = JobExecution.find.where()
@@ -196,7 +199,8 @@ public abstract class AbstractFitnessManager implements Manager {
         latestJobExecution.resourceUsage = 0D;
         latestJobExecution.executionTime = 0D;
         latestJobExecution.inputSizeInBytes = 1D;
-        latestJobExecution.save();
+        latestJobExecution.update();
+        logger.info("Updated JobExecution: " + latestJobExecution.id + "after resetting param set to CREATED");
       } else {
         logger.error("No TuningJobExecutionParamSet found for JobSuggestedParamSet id " + jobSuggestedParamSet.id);
       }

--- a/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
+++ b/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
@@ -118,7 +118,7 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
         // after failure.
         logger.info("HBT Execution id: " + jobExecution.id + " was not successful for reason other than tuning."
             + "Resetting param set: " + jobSuggestedParamSet.id + " to CREATED state");
-        resetParamSetToCreated(jobSuggestedParamSet);
+        resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
       }
     }
   }

--- a/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoIPSO.java
+++ b/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoIPSO.java
@@ -63,7 +63,7 @@ public class FitnessManagerOBTAlgoIPSO extends FitnessManagerOBT {
         // after failure.
         logger.debug("Execution id: " + jobExecution.id + " was not successful for reason other than tuning."
             + "Resetting param set: " + jobSuggestedParamSet.id + " to CREATED state");
-        resetParamSetToCreated(jobSuggestedParamSet);
+        resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
       }
     }
   }

--- a/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoPSO.java
+++ b/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBTAlgoPSO.java
@@ -66,7 +66,7 @@ public class FitnessManagerOBTAlgoPSO extends FitnessManagerOBT {
         // after failure.
         logger.debug("Execution id: " + jobExecution.id + " was not successful for reason other than tuning."
             + "Resetting param set: " + jobSuggestedParamSet.id + " to CREATED state");
-        resetParamSetToCreated(jobSuggestedParamSet);
+        resetParamSetToCreated(jobSuggestedParamSet, jobExecution);
       }
     }
   }


### PR DESCRIPTION
**DESCRIPTION**

In this PR changes are made to the query to fetch TuningJobExecutionParamSet in the AbstractFitnessManager method. Earlier it was assumed that there will be unique row for each JobSuggestedParamSet in TuningJobExecutionParamSet, it is fixed in this PR.

**HOW IT IS TESTED**

Testing is done on EI.