### PR TITLE
Making getFlowExecution synchronized block to avoid the race condition

### DIFF
--- a/app/com/linkedin/drelephant/tuning/AutoTuningAPIHelper.java
+++ b/app/com/linkedin/drelephant/tuning/AutoTuningAPIHelper.java
@@ -198,11 +198,12 @@ public class AutoTuningAPIHelper {
    *                    is to be returned
    * @return FlowExecution flow execution
    */
-  private FlowExecution getFlowExecution(TuningInput tuningInput) {
+   private synchronized FlowExecution getFlowExecution(TuningInput tuningInput) {
     FlowExecution flowExecution =
         FlowExecution.find.where().eq(FlowExecution.TABLE.flowExecId, tuningInput.getFlowExecId()).findUnique();
 
     if (flowExecution == null) {
+      logger.info("Creating flow execution for " + tuningInput.getJobExecId());
       flowExecution = new FlowExecution();
       flowExecution.flowExecId = tuningInput.getFlowExecId();
       flowExecution.flowExecUrl = tuningInput.getFlowExecUrl();


### PR DESCRIPTION
**DESCRIPTION**

In this PR the changes are made to fix the bug due to race condition while adding flow execution details in the Flow Execution table. This is achieved by using the synchronized keyword for  getFlowExecution method.