### PR TITLE
openjdk7 support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 sudo: true
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7
 python: "2.6"
 install:
   - sudo pip install inspyred


### PR DESCRIPTION
JDK 7 builds for Dr.Elephant fail in Travis CI because oraclejdk7 support is no longer available after corresponding build machines were updated to Ubuntu Trusty.

Use openjdk7 instead.