### PR TITLE
Ensure code coverage for Dr.Elephant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ install:
   - sudo pip install inspyred
   - sudo pip install argparse
 
+script:
+  - sbt test jacoco:cover
+
 # only build PRs and master (not all branch pushes)
 branches:
   only:

--- a/app/com/linkedin/drelephant/ElephantRunner.java
+++ b/app/com/linkedin/drelephant/ElephantRunner.java
@@ -127,7 +127,7 @@ public class ElephantRunner implements Runnable {
   }
 
   @VisibleForTesting
-  AnalyticJobGenerator getAnalyticJobGenerator() {
+  public AnalyticJobGenerator getAnalyticJobGenerator() {
     if (HadoopSystemContext.isHadoop2Env()) {
       return new AnalyticJobGeneratorHadoop2();
     } else {
@@ -253,12 +253,12 @@ public class ElephantRunner implements Runnable {
   }
 
   @VisibleForTesting
-  ElephantBackfillFetcher getBackfillFetcher(ApplicationType appType) {
+  public ElephantBackfillFetcher getBackfillFetcher(ApplicationType appType) {
     return ElephantContext.instance().getBackfillFetcherForApplicationType(appType);
   }
 
   @VisibleForTesting
-  ApplicationType getAppTypeForName(String appType) {
+  public ApplicationType getAppTypeForName(String appType) {
     return ElephantContext.instance().getApplicationTypeForName(appType);
   }
 

--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.*;
+import play.Play;
 
 
 /**
@@ -94,7 +95,7 @@ public final class Utils {
   public static Document loadXMLDoc(String filePath) {
     InputStream instream = null;
     logger.info("Loading configuration file " + filePath);
-    instream = ClassLoader.getSystemClassLoader().getResourceAsStream(filePath);
+    instream = Play.application().resourceAsStream(filePath);
 
     if (instream == null) {
       logger.info("Configuation file not present in classpath. File:  " + filePath);

--- a/compile.sh
+++ b/compile.sh
@@ -147,7 +147,7 @@ pso_dir=${project_root}/scripts/pso
 rm -rf ${project_root}/dist
 mkdir dist
 
-play_command $OPTS clean test compile dist
+play_command $OPTS clean test compile jacoco:cover dist
 
 cd target/universal
 

--- a/jacoco.sbt
+++ b/jacoco.sbt
@@ -17,7 +17,16 @@
 import de.johoop.jacoco4sbt.JacocoPlugin._
 import de.johoop.jacoco4sbt._
 
-jacoco.settings
+// Baselining coverage thresholds to current coverage values so that build fails with any drop in coverage
+jacoco.settings ++ Seq(
+  jacoco.thresholds in jacoco.Config := Thresholds(
+  instruction = 51,
+  method = 50,
+  branch = 34,
+  complexity = 35,
+  line = 53,
+  clazz = 79)
+)
 
 parallelExecution      in jacoco.Config := false
 


### PR DESCRIPTION
Currently, code coverage in Dr.Elephant does not run as part of CI build. And running command "play jacoco:cover" locally leads to test failures (which do not happen with play test). Moreover, there is no threshold set to ensure build failure if coverage breaches a certain value, making integration with jacoco meaningless.
Right now, line coverage in Dr.Elephant stands at a mere 53% and instruction coverage at 52%.
  
**To resolve issues above, this PR does the following:**
1. Introduce coverage thresholds and set them to current coverage numbers to ensure build fails whenever a new PR drops the coverage below current levels. We will take up a separate exercise to push coverage towards 80% initially and 90% eventually.
2. Run code coverage as part of Travis CI build.
3. Ensure jacoco code coverage is run when compile.sh is executed. compile.sh is used by Dr.Elephant developers for build and running tests. 
4. Resolve issues related to tests not finding test configurations which are present in test-classes folder due to using system classloader.
5. Fix test failures due to mockito errors when running it with jacoco(same tests pass while running play test)
  
**Testing done:**
1. Ran play jacoco:cover and ensured build passes with current coverage numbers set as threshold. Also, Travis CI ran as part of this PR ensures Travis CI integration for code coverage is also done. For Travis CI build, refer to 
[https://travis-ci.org/linkedin/dr-elephant/jobs/471532336](url) and for code coverage, refer to below. 
<img width="598" alt="screenshot 2018-12-23 at 1 24 00 pm" src="https://user-images.githubusercontent.com/10049695/50381810-3553a700-06b6-11e9-895f-861af71dce89.png">
2. Ran play jacoco:cover with higher threshold numbers and ensured that build fails due to coverage numbers not being met. Refer to image below. Had ran Travis CI with higher threshold as well and ensured Travis CI build fails. 
<img width="666" alt="screenshot 2018-12-23 at 1 05 13 pm" src="https://user-images.githubusercontent.com/10049695/50381865-b2335080-06b7-11e9-95fc-87f849a8af36.png">
3. Ran compile.sh and ensured jacoco coverage report is generated.  
<br/><br/>

**Current code coverage:**
<img width="1205" alt="dr_elephant_current_coverage" src="https://user-images.githubusercontent.com/10049695/50381658-66ca7380-06b2-11e9-9f76-96bcba0d1e8e.png">