### PR TITLE
Integrate CPD into Dr.Elephant for detecting code duplication

### DIFF
--- a/baseline.conf
+++ b/baseline.conf
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #
 # Copyright 2016 LinkedIn Corp.
 #
@@ -14,4 +16,12 @@
 # the License.
 #
 
-sbt.version=0.13.5
+#
+# Configurations for threshold and baseline for various tools.
+#
+
+# ********** Baseline/threshold numbers for Copy Paste Detector(CPD) *************
+# Threshold for CPD when run for Java
+readonly JAVA_CPD_THRESHOLD=32
+# Threshold for CPD when run for Scala
+readonly SCALA_CPD_THRESHOLD=0

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,9 @@ version := "2.1.7"
 
 organization := "com.linkedin.drelephant"
 
+// Enable CPD SBT plugin
+lazy val root = (project in file(".")).enablePlugins(CopyPasteDetector)
+
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
 
 libraryDependencies ++= dependencies map { _.excludeAll(exclusionRules: _*) }

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 LinkedIn Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+#
+# This script contains common functions and constants which will be used by both
+# compile.sh and travis.sh while running different tools.
+#
+
+########################################################
+#
+#                  Global constants
+#
+########################################################
+# Base path for most of the quality tool reports
+readonly REPORTS_BASE_PATH="target/scala-2.10/"
+
+# ******************** Constants for Findbugs *********************
+# Default path for Findbugs report
+readonly FINDBUGS_REPORT_PATH=$REPORTS_BASE_PATH"findbugs/report.xml"
+
+# ************* Constants for Copy Paste Detector(CPD) *************
+# CPD report resides in this path
+readonly CPD_REPORT_BASE_PATH=$REPORTS_BASE_PATH"cpd/"
+# Default path for CPD report
+readonly CPD_REPORT_PATH=$CPD_REPORT_BASE_PATH"cpd.xml"
+
+# ************************ Other constants **************************
+# Color coded prefixes for ERROR, WARNING, INFO and SUCCESS messages
+readonly ERROR_COLOR_PREFIX="[\033[0;31mERROR\033[0m]"
+readonly WARNING_COLOR_PREFIX="[\033[0;33mWARNING\033[0m]"
+readonly INFO_COLOR_PREFIX="[\033[0;36mINFO\033[0m]"
+readonly SUCCESS_COLOR_PREFIX="[\033[0;32mSUCCESS\033[0m]"
+
+##########################################################
+# Get CPD report name based on language.
+#
+# Arguments:
+#   arg1: Report location
+#   arg2: Language for which CPD report willbe generated
+#         (Java or Scala)
+# Returns:
+#   File name where CPD report will be written to.
+##########################################################
+function getCPDReportName() {
+  echo $1"cpd-"$2".xml"
+}
+
+##########################################################
+# Check if there is a failure due to duplicates in CPD
+# report above the configured threshold for the language.
+#
+# Arguments:
+#   arg1: Language for which CPD is run (Java or Scala)
+#   arg2: Duplicates threshold for the language
+#   arg3: Name of the threshold constant for the language
+#   arg4: CPD report file which contains duplicates
+#   arg5: Flag which indicates whether to dump CPD report
+#         Report will be dumped if value of argument is 1
+# Returns:
+#   0: Success
+#   1: Failure due to threshold
+#   2: Failure due to threshold variables not updated
+##########################################################
+function checkIfCPDFailed() {
+  duplicates=`grep "<duplication lines=" $4 | wc -l | xargs`
+  msg="CPD $1 Report has $duplicates duplicates"
+  if [ $duplicates -gt $2 ]; then
+    if [ $5 -eq 1 ]; then
+      echo -e "$ERROR_COLOR_PREFIX Dumping results on failure..."
+      echo "***************** Code duplication report ********************"
+      cat $4
+      echo "**************************************************************"
+    fi
+    echo -e "$ERROR_COLOR_PREFIX CPD for $1 code failed as $duplicates duplicates found (threshold: $2)"
+    return 1;
+  elif [ $duplicates -eq 0 ]; then
+    if [ $duplicates -lt $2 ]; then
+      echo -e "$ERROR_COLOR_PREFIX $msg and you have fixed some CPD issues in this PR which is great! But you forgot to update the threshold, hence failing the build."
+      echo -e "\tPlease modify $3 variable to $duplicates in baseline.conf to ensure that the new threshold takes effect for subsequent builds."
+      return 2;
+    else
+      echo -e "$SUCCESS_COLOR_PREFIX $msg"
+    fi
+  elif [ $duplicates -eq $2 ]; then
+    echo -e "$WARNING_COLOR_PREFIX $msg but it is within threshold hence not failing the build"
+  else
+    echo -e "$ERROR_COLOR_PREFIX $msg and you have fixed some CPD issues in this PR which is great! But you forgot to update the threshold, hence failing the build."
+    echo -e "\tPlease modify $3 variable to $duplicates in baseline.conf to ensure that the new threshold takes effect for subsequent builds."
+    return 2;
+  fi
+  return 0;
+}
+
+##########################################################
+# Parse the findbugs report and if any bugs are found,
+# fail the build.
+#
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
+function checkFindbugsReport() {
+  # Check if there are any bugs in the Findbugs report
+  if [ ! -f $FINDBUGS_REPORT_PATH ]; then
+    echo -e "$ERROR_COLOR_PREFIX Findbugs report was not generated, failing the build..."
+    echo ""
+    exit 1;
+  fi
+
+  # Incorrect report. Summary does not exist hence cannot parse the report.
+  summaryLine=`grep -i 'FindBugsSummary' $FINDBUGS_REPORT_PATH`
+  if [ -z "$summaryLine" ]; then
+    echo -e "$ERROR_COLOR_PREFIX Build failed as Findbugs summary could not be found in report..."
+    echo ""
+    exit 1;
+  fi
+
+  # Fetch bugs from the report and if any bugs are found, fail the build.
+  totalBugs=`echo $summaryLine | grep -o 'total_bugs="[0-9]*'`
+  totalBugs=`echo $totalBugs | awk -F'="' '{print $2}'`
+  if [ $totalBugs -gt 0 ];then
+    echo -e "$ERROR_COLOR_PREFIX Build failed due to "$totalBugs" Findbugs issues..."
+    exit 1;
+  fi
+  echo -e "$INFO_COLOR_PREFIX Findbugs report generated at path $FINDBUGS_REPORT_PATH"
+}
+
+##########################################################
+# Scala CPD reports count even Apache license headers as
+# duplicates. Remove them from the CPD report.
+#
+# Arguments:
+#   arg1: CPD report file to be checked for duplicates
+# Returns:
+#   None
+##########################################################
+function removeLicenseHeaderDuplicates() {
+  mv $1 $1".bak"
+  # For each duplication start tag match, do the following
+  awk '{ p = 1 } /<duplication /{
+    tag = $0;
+    while (getline > 0) {
+      tag = tag ORS $0;
+      # Remove section which contains the License
+      if (/Licensed under the Apache License/) {
+        p = 0;
+      }
+      # Break out of loop if duplication end tag matches
+      if (/<\/duplication>/) {
+        break;
+      }
+    }
+    $0 = tag
+  } p' $1".bak" > $1
+  rm -rf $1".bak"
+}
+
+##########################################################
+# Change cpdLanguage setting in cpd.sbt from the passed
+# language in first argument to language in second
+# argument.
+# Note: For consistency across platforms not using sed's
+# -i option and instead redirecting output and moving
+# files.
+#
+# Arguments:
+#   arg1: Language setting changed from
+#   arg2: Language setting changed to
+# Returns:
+#   None
+##########################################################
+function changeCPDLanguageSetting() {
+  sed "s/$1/$2/g" cpd.sbt > cpd.sbt.bak
+  mv cpd.sbt.bak cpd.sbt
+}

--- a/compile.sh
+++ b/compile.sh
@@ -16,8 +16,15 @@
 # the License.
 #
 
-function print_usage(){
-  echo "usage: ./compile.sh PATH_TO_CONFIG_FILE(optional)"
+function print_usage() {
+  echo ""
+  echo "Usage: ./compile.sh [config_file_path] [additional_options]"
+  echo "  compile.sh takes optionally, custom configuration file path(denoted as config_file_path above) as first argument."\
+      "This argument can't be at any other position."
+  echo "  We can also, optionally pass, additional_options, in any order. Additional options are as under:"
+  echo -e "\tcoverage: Runs Jacoco code coverage and fails the build as per configured threshold"
+  echo -e "\tfindbugs: Runs Findbugs for Java code"
+  echo -e "\tcpd: Runs Copy Paste Detector(CPD) for Java and Scala code"
 }
 
 function play_command() {
@@ -46,46 +53,139 @@ function require_programs() {
   fi
 }
 
+############################################################
+# Generate CPD report based on language in the report path.
+# For Scala, also remove duplicates generated due to license
+# header as they are false negatives. In the end, fail the
+# build if failures are found.
+#
+# Arguments:
+#   arg1: Language (one of Java or Scala)
+#   arg2: Duplicates threshold for the language
+#   arg3: Name of the threshold constant for the language
+# Returns:
+#   None
+############################################################
+function processCPDReportByLanguage() {
+  cpd_result_file=$(getCPDReportName $CPD_REPORT_BASE_PATH $1)
+  mv $CPD_REPORT_PATH $cpd_result_file
+  if [ $1 = "Scala" ]; then
+    removeLicenseHeaderDuplicates $cpd_result_file
+  fi
+  echo "CPD report generated at path $cpd_result_file"
+  checkIfCPDFailed $1 $2 $3 $cpd_result_file "0"
+  result=$?
+  if [ $result -gt 0 ]; then
+    if [ $result -eq 2 ]; then
+      echo ""
+      echo -e "$WARNING_COLOR_PREFIX Note: Make sure your local repo is up to date with the branch you want to merge to, otherwise threshold/baseline "\
+          "values to be updated in baseline.conf\n\tmight be different and that can lead to CI failure..."
+    fi
+    echo ""
+    exit 1;
+  fi
+}
+
+##########################################################
+# Run CPD for Java and Scala one by one. For Scala, first
+# change cpdLanguage setting in cpd.sbt to Language.Scala
+# and then run CPD. Ensure that specific CPD reports are
+# generated for each language in the report folder.
+#
+# Arguments:
+#   arg1: Play command OPTS
+# Returns:
+#   None
+##########################################################
+function runCPD() {
+  echo "Running CPD for Java"
+  play_command $1 cpd
+  if [ $? -ne 0 ]; then
+    exit 1;
+  fi
+  processCPDReportByLanguage "Java" $JAVA_CPD_THRESHOLD "JAVA_CPD_THRESHOLD"
+
+  echo "Running CPD for Scala"
+  changeCPDLanguageSetting "Language.Java" "Language.Scala"
+  play_command $OPTS cpd
+  if [ $? -ne 0 ]; then
+    # Reset language back to Java
+    changeCPDLanguageSetting "Language.Scala" "Language.Java"
+    exit 1;
+  fi
+  processCPDReportByLanguage "Scala" $SCALA_CPD_THRESHOLD "SCALA_CPD_THRESHOLD"
+  # Reset language back to Java
+  changeCPDLanguageSetting "Language.Scala" "Language.Java"
+}
+
 require_programs zip unzip
 
 # Default configurations
 HADOOP_VERSION="2.3.0"
 SPARK_VERSION="1.4.0"
 
-# User should pass an optional argument which is a path to config file
-if [ -z "$1" ];
-then
-  echo "Using the default configuration"
-else
-  CONF_FILE_PATH=$1
-  echo "Using config file: "$CONF_FILE_PATH
 
-  # User must give a valid file as argument
-  if [ -f $CONF_FILE_PATH ];
-  then
-    echo "Reading from config file..."
+extra_commands=""
+# Indicates whether a custom configuration file is passed as first parameter.
+custom_config="n"
+run_CPD="n"
+# Process command line arguments
+while :; do
+  if [ ! -z $1 ]; then
+    case $1 in
+      coverage)
+        extra_commands=$extra_commands" jacoco:cover"
+        ;;
+      findbugs)
+        extra_commands=$extra_commands" findbugs"
+        ;;
+      cpd)
+        run_CPD="y"
+        ;;
+      *)
+        # User may pass the first argument(optional) which is a path to config file
+        if [[ -z $extra_commands && $custom_config = "n" ]]; then
+          CONF_FILE_PATH=$1
+
+          # User must give a valid file as argument
+          if [ -f $CONF_FILE_PATH ]; then
+            echo "Using config file: "$CONF_FILE_PATH
+          else
+            echo "error: Couldn't find a valid config file at: " $CONF_FILE_PATH
+            print_usage
+            exit 1
+          fi
+
+          custom_config="y"
+          source $CONF_FILE_PATH
+
+          # Fetch the Hadoop version
+          if [ -n "${hadoop_version}" ]; then
+            HADOOP_VERSION=${hadoop_version}
+          fi
+
+          # Fetch the Spark version
+          if [ -n "${spark_version}" ]; then
+            SPARK_VERSION=${spark_version}
+          fi
+
+          # Fetch other play opts
+          if [ -n "${play_opts}" ]; then
+            PLAY_OPTS=${play_opts}
+          fi
+        else
+          echo "Invalid option: $1"
+          print_usage
+          exit 1;
+        fi
+    esac
+    shift
   else
-    echo "error: Couldn't find a valid config file at: " $CONF_FILE_PATH
-    print_usage
-    exit 1
+    break
   fi
-
-  source $CONF_FILE_PATH
-
-  # Fetch the Hadoop version
-  if [ -n "${hadoop_version}" ]; then
-    HADOOP_VERSION=${hadoop_version}
-  fi
-
-  # Fetch the Spark version
-  if [ -n "${spark_version}" ]; then
-    SPARK_VERSION=${spark_version}
-  fi
-
-  # Fetch other play opts
-  if [ -n "${play_opts}" ]; then
-    PLAY_OPTS=${play_opts}
-  fi
+done
+if [ $custom_config = "n" ]; then
+  echo "Using the default configuration"
 fi
 
 echo "Hadoop Version : $HADOOP_VERSION"
@@ -137,17 +237,44 @@ else
 fi
 
 trap "exit" SIGINT SIGTERM
+set +x
+set +v
 
 start_script=${project_root}/scripts/start.sh
 stop_script=${project_root}/scripts/stop.sh
 app_conf=${project_root}/app-conf
 pso_dir=${project_root}/scripts/pso
 
+# Import baseline/threshold numbers used across compile.sh and travis.sh
+source baseline.conf
+# Import common functions used across compile.sh and travis.sh
+source common.sh
+
+# Run the main command alongwith the extra commands passed as arguments to compile.sh
+echo "Command is: play $OPTS clean compile test $extra_commands"
+play_command $OPTS clean compile test $extra_commands
+if [ $? -ne 0 ]; then
+  echo "Build failed..."
+  exit 1;
+fi
+
+if [[ $extra_commands == *"findbugs"* ]]; then
+  # Parse and check findbugs report
+  checkFindbugsReport
+fi
+
+# Run CPD if passed as an argument
+if [ $run_CPD = "y" ]; then
+  runCPD $OPTS
+fi
+
+set -v
+set -x
 # Echo the value of pwd in the script so that it is clear what is being removed.
 rm -rf ${project_root}/dist
 mkdir dist
-
-play_command $OPTS clean test compile jacoco:cover dist
+# Run distribution
+play_command $OPTS dist
 
 cd target/universal
 

--- a/cpd.sbt
+++ b/cpd.sbt
@@ -1,0 +1,28 @@
+//
+// Copyright 2016 LinkedIn Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+
+//
+// cpd4sbt plugin settings for integrating with CPD which is used for code duplication
+//
+import de.johoop.cpd4sbt._
+
+// By default language will be Java but this will be changed to run for Scala as well
+// while running build through Travis CI.
+cpdLanguage := Language.Java
+
+// Take distinct source directories to ensure whole file is not reported as duplicate
+// of itself.
+cpdSourceDirectories in Compile := (cpdSourceDirectories in Compile).value.distinct

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,3 +27,6 @@ addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
 
 // Findbugs plugin
 addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
+
+// Copy paste detector plugin
+addSbtPlugin("de.johoop" % "cpd4sbt" % "1.2.0")

--- a/travis.sh
+++ b/travis.sh
@@ -16,19 +16,113 @@
 # the License.
 #
 
-########################################################
 #
-# Global constants
+# Script to be used for building on Travis CI
 #
-########################################################
-# Base path for most of the quality tool reports
-readonly REPORTS_BASE_PATH="target/scala-2.10/"
-# Default path for Findbugs report
-readonly FINDBUGS_REPORT_PATH=$REPORTS_BASE_PATH"findbugs/report.xml"
 
-# Color coded prefixes for ERROR and SUCCESS messages
-readonly SUCCESS_COLOR_PREFIX="[\033[0;32mSUCCESS\033[0m]"
-readonly ERROR_COLOR_PREFIX="[\033[0;31mERROR\033[0m]"
+############################################################
+# Get files chnged in this PR using git commands.
+#
+# Arguments:
+#   None
+# Returns:
+#   List of files changed in the PR
+############################################################
+function getChangedFiles() {
+  # Get commit hashes which have been added in the PR
+  commitHashes=`git rev-list origin/HEAD..HEAD`
+  # Extract file names changed for each commit hash
+  changedFiles=$(for hash in $commitHashes; do
+    fileNamesForHash=`git show --name-only --oneline $hash | awk '{if (NR > 1) print}'`
+    if [ ! -z "${fileNamesForHash}" ]; then
+      echo "${fileNamesForHash}"
+    fi
+  done)
+  echo "${changedFiles}" | sort | uniq
+}
+
+##########################################################
+# Check if there are duplicates in CPD report above the
+# configured threshold for the language.
+#
+# Arguments:
+#   arg1: CPD report file to be checked for duplicates
+#   arg2: List of files changed in the PR
+# Returns:
+#   None
+##########################################################
+function dumpCPDSummaryForChangedFiles() {
+  reportDump=`cat $1`
+  for changedFile in $2; do
+    fileDuplicateCnt=`echo "${reportDump}" | grep $changedFile | wc -l`
+    if [ $fileDuplicateCnt -gt 0 ]; then
+      echo -e "\tDuplicate info for file $changedFile:"
+      echo -e "\t------------------------------------------------------------------------------------";
+      echo $reportDump | awk -v filename="$changedFile" '{
+        # Iterate over all the duplicates in CPD report
+        numDuplicates = split($0, duplicates, "<duplication")
+        for (duplicateIdx = 2; duplicateIdx <= numDuplicates; duplicateIdx++) {
+          # Remove codefragment before searching for filename in this duplication instance.
+          sub(/<codefragment>.*<\/codefragment>/, "", duplicates[duplicateIdx]);
+          # Proceed only if filename is found.
+          if (index(duplicates[duplicateIdx], filename) > 0) {
+            # Sanitize the report for processing.
+            sub(/<\/duplication>/, "", duplicates[duplicateIdx])
+            sub(/<\/pmd-cpd>/, "", duplicates[duplicateIdx])
+            gsub(/<file/, "\n<file", duplicates[duplicateIdx])
+            sub(/">/, "", duplicates[duplicateIdx])
+            gsub(/"\/>/, "", duplicates[duplicateIdx])
+            gsub(/<file line="/, "", duplicates[duplicateIdx])
+            gsub(/" /, ",", duplicates[duplicateIdx])
+            gsub(/path="/, "", duplicates[duplicateIdx])
+            gsub(/lines="/, "", duplicates[duplicateIdx])
+            gsub(/tokens="/, "", duplicates[duplicateIdx])
+            gsub(/ /, "", duplicates[duplicateIdx])
+            numFiles = split(duplicates[duplicateIdx], files, "\n")
+            # Extract file and duplication info and print it out.
+            for (fileIdx = 1; fileIdx <= numFiles; fileIdx++) {
+              split(files[fileIdx], line, ",");
+              if (fileIdx == 1) {
+                printf("\t  - %s lines and %s tokens are duplicate for the following:\n", line[1], line[2]);
+              } else {
+                printf("\t\tFilename: %s at line: %s\n", line[2], line[1]);
+              }
+            }
+          }
+        }
+      }'
+      echo ""
+    fi
+  done
+}
+
+##########################################################
+# Check if there are duplicates in CPD report above the
+# configured threshold for the language.
+#
+# Arguments:
+#   arg1: Language for which CPD is run (Java or Scala)
+#   arg2: Duplicates threshold for the language
+#   arg3: Name of the threshold constant for the language
+#   arg4: CPD report file to be checked for duplicates
+#   arg5: List of files changed in the PR
+# Returns:
+#   None
+##########################################################
+function checkCPDReport() {
+  checkIfCPDFailed $1 $2 $3 $4 "1"
+  result=$?
+  # On failure exit. If result code is 1, also dump CPD summary for changed files.
+  if [ $result -gt 0 ]; then
+    if [ $result -eq 1 ]; then
+      echo -e "$ERROR_COLOR_PREFIX Copy Paste Detector(CPD) Summary for files changed in this PR:"
+      echo ""
+      dumpCPDSummaryForChangedFiles $4 "${5}"
+    fi
+    echo ""
+    exit 1;
+  fi
+}
 
 ##########################################################
 # Run sbt findbugs command, parse the report and if any
@@ -40,33 +134,65 @@ readonly ERROR_COLOR_PREFIX="[\033[0;31mERROR\033[0m]"
 #   None
 ##########################################################
 function runFindbugs() {
+  echo -e "$INFO_COLOR_PREFIX Running Findbugs..."
   # Run findbugs
   sbt findbugs
   if [ $? -ne 0 ]; then
     echo -e "$ERROR_COLOR_PREFIX Findbugs step failed..."
+    echo ""
     exit 1;
   fi
 
-  # Check if there are any bugs in the Findbugs report
-  if [ ! -f $FINDBUGS_REPORT_PATH ]; then
-    echo -e "$ERROR_COLOR_PREFIX Findbugs report was not generated, failing the build..."
-    exit 1;
-  fi
+  # Parse and check findbugs report
+  checkFindbugsReport
+}
 
-  # Incorrect report. Summary does not exist hence cannot parse the report.
-  summaryLine=`grep -i 'FindBugsSummary' $FINDBUGS_REPORT_PATH`
-  if [ -z "$summaryLine" ]; then
-    echo -e "$ERROR_COLOR_PREFIX Build failed as Findbugs summary could not be found in report..."
+##########################################################
+# Run CPD for the langauge passed, check for failures and
+# move the final result to a separate file.
+#
+# Arguments:
+#   arg1: Language for which CPD is run (Java or Scala)
+#   arg2: Duplicates threshold for the language
+#   arg3: Name of the threshold constant for the language
+#   arg4: List of files changed in the PR
+# Returns:
+#   None
+##########################################################
+function runCPDForLanguage() {
+  sbt cpd
+  if [ $? -ne 0 ]; then
+    echo -e "$ERROR_COLOR_PREFIX CPD for "$1" failed..."
     exit 1;
   fi
+  cpd_result_file=$(getCPDReportName $CPD_REPORT_BASE_PATH $1)
+  mv $CPD_REPORT_PATH $cpd_result_file
+  if [ $1 = "Scala" ]; then
+    removeLicenseHeaderDuplicates $cpd_result_file
+  fi
+  checkCPDReport $1 $2 $3 $cpd_result_file "${4}"
+}
 
-  # Fetch bugs from the report and if any bugs are found, fail the build.
-  totalBugs=`echo $summaryLine | grep -o 'total_bugs="[0-9]*'`
-  totalBugs=`echo $totalBugs | awk -F'="' '{print $2}'`
-  if [ $totalBugs -gt 0 ];then
-    echo -e "$ERROR_COLOR_PREFIX Build failed due to "$totalBugs" Findbugs issues..."
-    exit 1;
-  fi
+##########################################################
+# Run CPD for Java and Scala one by one. For Scala, first
+# change cpdLanguage setting in cpd.sbt to Language.Scala
+# and then run CPD.
+#
+# Arguments:
+#   arg1: List of files changed in the PR
+# Returns:
+#   None
+##########################################################
+function runCPD() {
+  echo -e "$INFO_COLOR_PREFIX Running Copy Paste Detector(CPD) for Java..."
+  runCPDForLanguage "Java" $JAVA_CPD_THRESHOLD "JAVA_CPD_THRESHOLD" "${1}"
+
+  echo ""
+  # Change language to Scala before running CPD again.
+  changeCPDLanguageSetting "Language.Java" "Language.Scala"
+  echo -e "$INFO_COLOR_PREFIX Running Copy Paste Detector(CPD) for Scala..."
+  runCPDForLanguage "Scala" $SCALA_CPD_THRESHOLD "SCALA_CPD_THRESHOLD" "${1}"
+  echo ""
 }
 
 ########################################################
@@ -75,10 +201,28 @@ function runFindbugs() {
 #
 ########################################################
 
+# Import baseline/threshold numbers used across compile.sh and travis.sh
+source baseline.conf
+# Import common functions used across compile.sh and travis.sh
+source common.sh
+readonly changedFilesList=$(getChangedFiles)
+echo ""
+if [ ! -z "${changedFilesList}" ]; then
+  echo "***********************************************************"
+  echo -e "$INFO_COLOR_PREFIX Files changed (added, modified, deleted) in this PR are:"
+  echo "${changedFilesList}" | awk '{
+    numFiles = split($0, files, "\n")
+    for (fileIdx = 1; fileIdx <= numFiles; fileIdx++) {
+      printf("\t- %s\n", files[fileIdx]);
+    }
+  }'
+fi
+
 echo ""
 echo "************************************************************"
 echo "  1. Compile Dr.Elephant code"
 echo "************************************************************"
+echo -e "$INFO_COLOR_PREFIX Compiling code..."
 sbt clean compile
 if [ $? -ne 0 ]; then
   echo -e "$ERROR_COLOR_PREFIX Compilation failed..."
@@ -95,8 +239,16 @@ echo -e "$SUCCESS_COLOR_PREFIX Findbugs step succeeded..."
 
 echo ""
 echo "************************************************************"
-echo "  3. Run unit tests and code coverage"
+echo "  3. Run Copy Paste Detector(CPD)"
 echo "************************************************************"
+runCPD "${changedFilesList}"
+echo -e "$SUCCESS_COLOR_PREFIX Copy Paste Detector(CPD) step succeeded..."
+
+echo ""
+echo "************************************************************"
+echo "  4. Run unit tests and code coverage"
+echo "************************************************************"
+echo -e "$INFO_COLOR_PREFIX Running unit tests and code coverage..."
 sbt test jacoco:cover
 if [ $? -ne 0 ]; then
   echo -e "$ERROR_COLOR_PREFIX Unit tests or code coverage failed..."


### PR DESCRIPTION
CPD or Copy Paste Detector is part of PMD which is a source code analyzer tool. CPD is useful in detecting duplicate code. Duplicate code while not desirable can also be a nightmare for code maintainability as same changes may have to be replicated across multiple areas of code. Dr.Elephant too has a fair bit of code duplication and we would want to not allow that. In some cases, upto 70-80 lines are duplicated. This PR is for integration of CPD into Dr.Elephant.

**This PR does the following:**
1. Integrate cpd4sbt plugin into Dr.Elephant to invoke CPD.
2. Make necessary changes in travis.sh script so that CPD runs for both Java and Scala code. As such CPD settings only allow one language to be configured. While running CI build, we first run CPD for Java and then modify cpd.sbt(file for CPD settings) from travis.sh to configure language as Scala and run CPD again.
3. Find out which files have changed in the PR by making changes in travis.sh
4. Set threshold values for both Java and Scala duplication instances. Till we figure out a better way in Travis CI to set baseline numbers on every build, current CPD issues will act as a baseline. But despite existing errors, we would not allow new errors to be introduced as we will fail the build if numbers breach threshold. Current threshold numbers for Java are 32 and for Scala it is 0. Clearing backlog issues can be taken up as a separate task. 
5. Changes in the CI script to fail the build if numbers breach threshold for the respective language i.e. not allow new code duplication.
6. We will also fail the build if duplication numbers have reduced but the threshold numbers are not updated in travis.sh (respective variables are JAVA_CPD_THRESHOLD and SCALA_CPD_THRESHOLD).
7. Change the CI script to ensure the printing of a warning if CPD numbers are same as threshold and print success if there are no CPD issues. Unless there is an error i.e. even on warning, CPD step would be deemed to be successful and we would not fail the build.
8. If PR introduces new CPD issues, by making changes in CI script, we will extract code duplication info from both the Java and Scala XML reports and print out only the duplication information associated with files changed in the PR. This will primarily be a summary of issue(i.e. number of lines and tokens which are duplicate and the associated files and their line numbers such duplication exists). This would help developers to quickly identify and fix the issues instead of going through full report.
9. If PR introduces new CPD issues, dump the complete CPD XML report, which contains code fragment for duplication, as well. Using summary and the report, contributors can fix the issues. The dumping of XML report has primarily been done because CPD report for both Scala and Java will be generated when Travis CI runs(due to changes in travis.sh). If CPD has to be run for both Java and Scala locally, the developer will have to change the language setting in cpd.sbt manually. By default language set is Java.
10. CPD for Scala also detects file headers(i.e. the Apache license header) across files as duplicates. Added necessary code in CI script i.e. travis.sh to ignore such duplicates.
11. Update sbt version to 0.13.5 as this is an auto plugin and this version is minimum requirement for auto plugins.
12. Change compile.sh to take arguments for running Findbugs, Jacoco code coverage and CPD. By default these tools wont be run.

**Testing Done:**
1. Verified that CPD runs for both Java and Scala code.
2. Verified that files changed in the PR are displayed correctly. Refer to screenshot below:
<img width="505" alt="screenshot 2019-01-03 at 4 20 01 pm" src="https://user-images.githubusercontent.com/10049695/50635905-1f799800-0f7a-11e9-825a-195edc558877.png">
3. Verified that build fails when the number of CPD issues breach the threshold. Refer to screenshot below:
<img width="519" alt="screenshot 2019-01-03 at 5 16 00 pm" src="https://user-images.githubusercontent.com/10049695/50636226-513f2e80-0f7b-11e9-9107-b3eaff82410e.png">
4. Verified that a summary of issues for only the files changed in the PR is printed on build failure due to breaching of threshold. Refer to screenshot below of this test which was run locally:
<img width="761" alt="screenshot 2019-01-03 at 5 17 33 pm" src="https://user-images.githubusercontent.com/10049695/50636281-7fbd0980-0f7b-11e9-8d60-c9909c5b3a98.png">
5. Verified that CPD report is dumped on build failure due to breaching of threshold. Refer to screenshot below:
<img width="866" alt="screenshot 2019-01-03 at 5 14 37 pm" src="https://user-images.githubusercontent.com/10049695/50636321-a2e7b900-0f7b-11e9-9cb0-47c64de960c7.png">
5. Verified that file license header issues are NOT counted towards duplicates. For instance, for Scala CPD generates 8 issues but all of them are due to file license header. The CI build reports 0 errors though. Refer to screenshot below for number of errors in XML report and refer to screenshot in point 6 for 0 Scala errors in CI build.
<img width="775" alt="screenshot 2019-01-03 at 5 46 00 pm" src="https://user-images.githubusercontent.com/10049695/50637321-8c436100-0f7f-11e9-8d46-40e2b6af7411.png">
<img width="820" alt="screenshot 2019-01-03 at 5 44 55 pm" src="https://user-images.githubusercontent.com/10049695/50637325-91081500-0f7f-11e9-8209-fb5fb80aab3d.png">
6. Verified that a success message is printed if CPD report has 0 issues.
<img width="662" alt="screenshot 2019-01-03 at 5 27 54 pm" src="https://user-images.githubusercontent.com/10049695/50636818-8a789e00-0f7d-11e9-9ca3-d21a90e7e54c.png">
7. Verified that only a WARNING message is printed and build proceeds if there are some CPD issues found but its not breaching threshold.
<img width="720" alt="screenshot 2019-01-03 at 5 28 07 pm" src="https://user-images.githubusercontent.com/10049695/50636810-82b8f980-0f7d-11e9-825a-92bff333931e.png">
8. Verified that build fails if developer has fixed some CPD issues in the PR but not reset the threhsold variable in baseline.conf from where threshold configurations are taken up by Travis CI script and compile.sh
<img width="1186" alt="screenshot 2019-01-11 at 12 43 01 am" src="https://user-images.githubusercontent.com/10049695/50991169-02286900-153a-11e9-842b-3cc59b93a493.png">
<img width="1183" alt="screenshot 2019-01-11 at 12 45 52 am" src="https://user-images.githubusercontent.com/10049695/50991268-4a478b80-153a-11e9-9506-b08c7f1a5af5.png">
9. Verified that changes take effect and build runs successfully in Travis CI. Refer to build run as part of this PR.<br>
10. Ran compile.sh with findbugs, cpd and coverage options as command line arguments in different orders, all 3 together, 2 of the arguments together, etc. The script invoked Findbugs, CPD and Jacoco Code coverage accordingly.<br>
11. Verified that configuration file as first argument, if passed is taken in compile.sh and if not passed, then additional options talked in point 10 are taken.<br>
12. compile.sh works as earlier if no option is passed.<br>
13. If "cpd" as an argument is passed to compile.sh, there will be a failure when threshold is breached for CPD or the relevant threshold variables are not updated in baseline.conf. Also fail compile.sh if findbugs is one of the arguments and high priority warnings are generated in findbugs report.<br>
14. The message printed for updating threshold values(which leads to build failure) when compile.sh is run, is followed by a warning message indicating that local repo should be update otherwise threshold numbers suggested to be updated may not be accurate. Refer to image below:
<img width="1192" alt="screenshot 2019-01-11 at 5 49 06 pm" src="https://user-images.githubusercontent.com/10049695/51033603-f3899280-15c9-11e9-98be-4bd5de559be2.png">
15. Help has been updated as well and is shown if incorrect arguments are passed.
<img width="1136" alt="screenshot 2019-01-10 at 11 21 25 pm" src="https://user-images.githubusercontent.com/10049695/50990863-3f402b80-1539-11e9-8266-fbdb3efacde3.png">
<img width="1139" alt="screenshot 2019-01-10 at 11 21 52 pm" src="https://user-images.githubusercontent.com/10049695/50990864-3f402b80-1539-11e9-86b8-5c3363f52bff.png">
