### PR TITLE
Spark HBT Improvement: Adding executor instances

### DIFF
--- a/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
+++ b/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
@@ -350,13 +350,15 @@ public class SparkHBTParamRecommender {
     } else {
       suggestedExecutorInstances = lastRunExecutorInstances;
     }
-    if (suggestedExecutorInstances > CLUSTER_DEFAULT_DYNAMIC_ALLOCATION_MAX_EXECUTOR) {
-      suggestedExecutorInstances = CLUSTER_DEFAULT_DYNAMIC_ALLOCATION_MAX_EXECUTOR;
-    }
-    //job fails if max executors is less than executor instances
-    if (lastRunDynamicAllocationMaxExecutors != null
-        && suggestedExecutorInstances > lastRunDynamicAllocationMaxExecutors) {
-      suggestedExecutorInstances = lastRunDynamicAllocationMaxExecutors;
+    if (suggestedExecutorInstances != null) {
+      if (suggestedExecutorInstances > CLUSTER_DEFAULT_DYNAMIC_ALLOCATION_MAX_EXECUTOR) {
+        suggestedExecutorInstances = CLUSTER_DEFAULT_DYNAMIC_ALLOCATION_MAX_EXECUTOR;
+      }
+      //job fails if max executors is less than executor instances
+      if (lastRunDynamicAllocationMaxExecutors != null
+          && suggestedExecutorInstances > lastRunDynamicAllocationMaxExecutors) {
+        suggestedExecutorInstances = lastRunDynamicAllocationMaxExecutors;
+      }
     }
   }
 

--- a/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
+++ b/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
@@ -361,15 +361,9 @@ public class SparkHBTParamRecommender {
   }
 
   private void suggestExecutorInstancesBasedOnCore() {
-    Integer lastRunActualExecutorInstances = lastRunExecutorInstances;
-    if (lastRunDynamicAllocationEnabled && lastRunDynamicAllocationMaxExecutors != null) {
-      if (lastRunActualExecutorInstances == null) {
-        lastRunActualExecutorInstances = lastRunDynamicAllocationMaxExecutors;
-      }
-    }
-    if (lastRunActualExecutorInstances != null) {
+    if (lastRunExecutorInstances != null) {
       suggestedExecutorInstances =
-          (int) Math.ceil(lastRunActualExecutorInstances.doubleValue() * lastRunExecutorCore / suggestedCore);
+          (int) Math.ceil(lastRunExecutorInstances.doubleValue() * lastRunExecutorCore / suggestedCore);
     }
   }
 }

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -1041,6 +1041,15 @@ public class Application extends Controller {
       } else if (param.getKey().equals(SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY)) {
         outputParamFormatted.put(SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY,
             String.valueOf(param.getValue().intValue()));
+      }else if (param.getKey().equals(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS)) {
+        outputParamFormatted.put(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS,
+            String.valueOf(param.getValue().intValue()));
+      }else if (param.getKey().equals(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS)) {
+        outputParamFormatted.put(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS,
+            String.valueOf(param.getValue().intValue()));
+      }else if (param.getKey().equals(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY)) {
+        outputParamFormatted.put(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY,
+            String.valueOf(param.getValue().intValue()));
       } else if (param.getKey().equals(SparkConfigurationConstants.SPARK_EXECUTOR_MEMORY_OVERHEAD)) {
         outputParamFormatted.put(SparkConfigurationConstants.SPARK_EXECUTOR_MEMORY_OVERHEAD, param.getValue()
             .intValue() + "m");
@@ -1062,6 +1071,8 @@ public class Application extends Controller {
     Map<String, Double> outputParams = autoTuningAPIHelper.getCurrentRunParameters(tuningInput);
     if (outputParams != null) {
       logger.info("Output params " + outputParams);
+      JsonNode outputJSON=formatGetCurrentRunParametersOutput(outputParams, tuningInput);
+      logger.info("Output JSON " + outputJSON.toString());
       return ok(formatGetCurrentRunParametersOutput(outputParams, tuningInput));
     } else {
       AutoTuningMetricsController.markGetCurrentRunParametersFailures();
@@ -2000,7 +2011,7 @@ public class Application extends Controller {
       }
     }
     return "NONE";
-  } 
+  }
     private static Map<String, Double> getSparkParamsMap(Long jobSuggestedParamSetId) {
     logger.debug("Fetching params for JobSuggestedParamSet id: " + jobSuggestedParamSetId);
     List<JobSuggestedParamValue> paramValues = JobSuggestedParamValue.find.select("*")

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -1041,12 +1041,6 @@ public class Application extends Controller {
       } else if (param.getKey().equals(SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY)) {
         outputParamFormatted.put(SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY,
             String.valueOf(param.getValue().intValue()));
-      }else if (param.getKey().equals(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS)) {
-        outputParamFormatted.put(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS,
-            String.valueOf(param.getValue().intValue()));
-      }else if (param.getKey().equals(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS)) {
-        outputParamFormatted.put(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS,
-            String.valueOf(param.getValue().intValue()));
       }else if (param.getKey().equals(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY)) {
         outputParamFormatted.put(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY,
             String.valueOf(param.getValue().intValue()));
@@ -1070,7 +1064,6 @@ public class Application extends Controller {
     AutoTuningAPIHelper autoTuningAPIHelper = new AutoTuningAPIHelper();
     Map<String, Double> outputParams = autoTuningAPIHelper.getCurrentRunParameters(tuningInput);
     if (outputParams != null) {
-      logger.info("Output params " + outputParams);
       JsonNode outputJSON=formatGetCurrentRunParametersOutput(outputParams, tuningInput);
       logger.info("Output JSON " + outputJSON.toString());
       return ok(formatGetCurrentRunParametersOutput(outputParams, tuningInput));

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 INSERT INTO tuning_parameter VALUES (25,'spark.dynamicAllocation.minExecutors',5,1,1,900,1,0, current_timestamp(0), current_timestamp(0));
 INSERT INTO tuning_parameter VALUES (26,'spark.dynamicAllocation.maxExecutors',5,1,1,900,1,0, current_timestamp(0), current_timestamp(0));
 INSERT INTO tuning_parameter VALUES (27,'spark.executor.instances',5,1,1,900,1,0, current_timestamp(0), current_timestamp(0));

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,0 +1,5 @@
+INSERT INTO tuning_parameter VALUES (25,'spark.dynamicAllocation.minExecutors',5,1,1,900,1,0, current_timestamp(0), current_timestamp(0));
+INSERT INTO tuning_parameter VALUES (26,'spark.dynamicAllocation.maxExecutors',5,1,1,900,1,0, current_timestamp(0), current_timestamp(0));
+INSERT INTO tuning_parameter VALUES (27,'spark.executor.instances',5,1,1,900,1,0, current_timestamp(0), current_timestamp(0));
+
+

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -16,7 +16,7 @@
 # Currently planning to run Dr Elephant in DEBUG mode
 # So that diagnosis would be simple
 #Define the root logger with appender file
-log4j.rootLogger = DEBUG, FA
+log4j.rootLogger = INFO, FA
 
 #File Appender
 log4j.appender.FA=org.apache.log4j.DailyRollingFileAppender

--- a/test/com/linkedin/drelephant/tuning/TuningManagerTest.java
+++ b/test/com/linkedin/drelephant/tuning/TuningManagerTest.java
@@ -41,6 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import com.linkedin.drelephant.tuning.engine.SparkHBTParamRecommenderTestRunner;;
 
 public class TuningManagerTest {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(TuningManagerTest.class);
@@ -96,6 +97,11 @@ public class TuningManagerTest {
   @Test
   public void testParamGenerterTestRunner() {
     running(testServer(TEST_SERVER_PORT, fakeApp), new ParameterGenerateManagerTestRunner());
+  }
+
+  @Test
+  public void testSparkHBTParamRecommenderTestRunner() {
+    running(testServer(TEST_SERVER_PORT, fakeApp), new SparkHBTParamRecommenderTestRunner());
   }
 
   @Test

--- a/test/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommenderTestRunner.java
+++ b/test/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommenderTestRunner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.linkedin.drelephant.tuning.engine;
 
 import static common.DBTestUtil.initDBUtil;
@@ -23,11 +38,11 @@ public class SparkHBTParamRecommenderTestRunner implements Runnable {
   @Override
   public void run() {
     populateTestData();
-    testGetHBTSuggestion1();
-    testGetHBTSuggestion2();
+    testGetHBTSuggestionWithExecutorInstancesConfig();
+    testGetHBTSuggestionWithoutExecutorInstancesConfig();
   }
 
-  private void testGetHBTSuggestion1() {
+  private void testGetHBTSuggestionWithExecutorInstancesConfig() {
     AppResult appResult = AppResult.find.where().idEq("application_1547833800460_664575").findUnique();
     SparkHBTParamRecommender sparkHBTParamRecommender = new SparkHBTParamRecommender(appResult);
     HashMap<String, Double> suggestedParameters = sparkHBTParamRecommender.getHBTSuggestion();
@@ -41,15 +56,11 @@ public class SparkHBTParamRecommenderTestRunner implements Runnable {
             && suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) < 1);
     assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY, 1857L, suggestedParameters
         .get(SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS, 1L,
-        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS, 600,
-        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 33L,
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 34L,
         suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY).longValue());
   }
 
-  private void testGetHBTSuggestion2() {
+  private void testGetHBTSuggestionWithoutExecutorInstancesConfig() {
     AppResult appResult = AppResult.find.where().idEq("application_1547833800460_664576").findUnique();
     SparkHBTParamRecommender sparkHBTParamRecommender = new SparkHBTParamRecommender(appResult);
     HashMap<String, Double> suggestedParameters = sparkHBTParamRecommender.getHBTSuggestion();
@@ -63,11 +74,7 @@ public class SparkHBTParamRecommenderTestRunner implements Runnable {
             && suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) < 1);
     assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY, 1857L, suggestedParameters
         .get(SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS, 3L,
-        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS, 300,
-        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 16L,
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 10L,
         suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY).longValue());
   }
 

--- a/test/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommenderTestRunner.java
+++ b/test/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommenderTestRunner.java
@@ -1,0 +1,74 @@
+package com.linkedin.drelephant.tuning.engine;
+
+import static common.DBTestUtil.initDBUtil;
+import static common.TestConstants.TEST_SPARK_HBT_PARAM_RECOMMENDER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+
+import models.AppResult;
+
+
+public class SparkHBTParamRecommenderTestRunner implements Runnable {
+
+  public void populateTestData() {
+    try {
+      initDBUtil(TEST_SPARK_HBT_PARAM_RECOMMENDER);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void run() {
+    populateTestData();
+    testGetHBTSuggestion1();
+    testGetHBTSuggestion2();
+  }
+
+  private void testGetHBTSuggestion1() {
+    AppResult appResult = AppResult.find.where().idEq("application_1547833800460_664575").findUnique();
+    SparkHBTParamRecommender sparkHBTParamRecommender = new SparkHBTParamRecommender(appResult);
+    HashMap<String, Double> suggestedParameters = sparkHBTParamRecommender.getHBTSuggestion();
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_MEMORY_KEY, 929L, suggestedParameters
+        .get(SparkConfigurationConstants.SPARK_EXECUTOR_MEMORY_KEY).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY, 3,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY).longValue());
+    assertTrue(
+        "Wrong value for " + SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) > 0
+            && suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) < 1);
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY, 1857L, suggestedParameters
+        .get(SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS, 1L,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS, 600,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 33L,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY).longValue());
+  }
+
+  private void testGetHBTSuggestion2() {
+    AppResult appResult = AppResult.find.where().idEq("application_1547833800460_664576").findUnique();
+    SparkHBTParamRecommender sparkHBTParamRecommender = new SparkHBTParamRecommender(appResult);
+    HashMap<String, Double> suggestedParameters = sparkHBTParamRecommender.getHBTSuggestion();
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_MEMORY_KEY, 1857L, suggestedParameters
+        .get(SparkConfigurationConstants.SPARK_EXECUTOR_MEMORY_KEY).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY, 3,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_CORES_KEY).longValue());
+    assertTrue(
+        "Wrong value for " + SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) > 0
+            && suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) < 1);
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY, 1857L, suggestedParameters
+        .get(SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS, 3L,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MIN_EXECUTORS).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS, 300,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS).longValue());
+    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 16L,
+        suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY).longValue());
+  }
+
+}

--- a/test/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommenderTestRunner.java
+++ b/test/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommenderTestRunner.java
@@ -74,8 +74,8 @@ public class SparkHBTParamRecommenderTestRunner implements Runnable {
             && suggestedParameters.get(SparkConfigurationConstants.SPARK_MEMORY_FRACTION_KEY) < 1);
     assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY, 1857L, suggestedParameters
         .get(SparkConfigurationConstants.SPARK_DRIVER_MEMORY_KEY).longValue());
-    assertEquals("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY, 10L,
-        suggestedParameters.get(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY).longValue());
+    assertTrue("Wrong value for " + SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY,
+        suggestedParameters.containsKey(SparkConfigurationConstants.SPARK_EXECUTOR_INSTANCES_KEY) == false);
   }
 
 }

--- a/test/common/TestConstants.java
+++ b/test/common/TestConstants.java
@@ -28,6 +28,7 @@ public class TestConstants {
   public static final String TEST_AUTO_TUNING_DATA_FILE1 = "test/resources/tunein-test1.sql";
   public static final String TEST_FITNESS_CALCULATION_DATA_FILE = "test/resources/test-fitness-calculation-data.sql";
   public static final String TEST_PARAM_GENERATE_DATA_FILE = "test/resources/test-param-generate-data.sql";
+  public static final String TEST_SPARK_HBT_PARAM_RECOMMENDER = "test/resources/test-SparkHBTParamRecommender.sql";
 
   public static final int RESPONSE_TIMEOUT = 3000; // milliseconds
 

--- a/test/resources/test-SparkHBTParamRecommender.sql
+++ b/test/resources/test-SparkHBTParamRecommender.sql
@@ -1,0 +1,300 @@
+INSERT INTO yarn_app_result(id, name, username, queue_name, start_time, finish_time, tracking_url, job_type, severity, score, workflow_depth, scheduler, job_name, job_exec_id, flow_exec_id, job_def_id, flow_def_id, job_exec_url, flow_exec_url, job_def_url, flow_def_url, resource_used, resource_wasted, total_delay)
+  VALUES('application_1547833800460_664575', 'com.linkedin.hello.spark.CountPageView', 'mkumar1', 'sna_default', '1548423066104', '1548423131477', 'http://ltx1-farowp01.grid.linkedin.com:8080/proxy/application_1547833800460_664575/', 'Spark', 4, '553', 0, 'azkaban', 'countPageViewFlow_countPageView', 'https://hostname.com:8443/executor?execid=2136899&job=countPageViewFlow_countPageView&attempt=0', 'https://hostname.com:8443/executor?execid=2136899', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow&job=countPageViewFlow_countPageView', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow', 'https://hostname.com:8443/executor?execid=2136899&job=countPageViewFlow_countPageView&attempt=0', 'https://hostname.com:8443/executor?execid=2136899', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow&job=countPageViewFlow_countPageView', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow', '3095406', '2773917', '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26119, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.ConfigurationHeuristic', 'Spark Configuration', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26120, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.JobsHeuristic', 'Spark Job Metrics', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26121, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.StagesHeuristic', 'Spark Stage Metrics', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26122, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.UnifiedMemoryHeuristic', 'Executor Peak Unified Memory', 4, '200');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26123, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.JvmUsedMemoryHeuristic', 'Executor JVM Used Memory', 4, '200');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26124, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.ExecutorGcHeuristic', 'Executor GC', 3, '150');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26125, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.ExecutorStorageSpillHeuristic', 'Executor spill', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(26126, 'application_1547833800460_664575', 'com.linkedin.drelephant.spark.heuristics.DriverHeuristic', 'Driver Metrics', 3, '3');
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.application.duration', '53 Seconds', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.dynamicAllocation.enabled', 'true', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.dynamicAllocation.maxExecutors', '900', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.dynamicAllocation.minExecutors', '1', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.executor.cores', '2', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.executor.instances', '50', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.executor.memory', '8 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26119, 'spark.yarn.executor.memoryOverhead', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26120, 'Spark completed jobs count', '2', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26120, 'Spark failed jobs count', '0', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26120, 'Spark failed jobs list', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26120, 'Spark job failure rate', '0.000', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26120, 'Spark jobs with high task failure rates', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26121, 'Spark completed stages count', '4', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26121, 'Spark failed stages count', '0', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26121, 'Spark stage failure rate', '0.000', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26121, 'Spark stages with high task failure rates', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26121, 'Spark stages with long average executor runtimes', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26122, 'Max peak unified memory', '540.39 KB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26122, 'Mean peak unified memory', '48.03 KB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26122, 'spark.executor.memory', '8 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26122, 'spark.memory.fraction', '0.6', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26122, 'Unified Memory Space Allocated', '4.09 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26123, 'Executor Memory', 'The allocated memory for the executor (in spark.executor.memory) is much more than the peak JVM used memory by executors.', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26123, 'Max executor peak JVM used memory', '342.68 MB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26123, 'spark.executor.memory', '8 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26123, 'Suggested spark.executor.memory', '412 MB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26124, 'Gc ratio high', 'The job is spending too much time on GC. We recommend increasing the executor memory.', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26124, 'GC time to Executor Run time ratio', '0.1098475625893188', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26124, 'Total Executor Runtime', '6 Minutes', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26124, 'Total GC time', '41 Seconds', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26125, 'Fraction of executors having non zero bytes spilled', '0.0', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26125, 'Max memory spilled', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26125, 'Mean memory spilled', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26125, 'Total memory spilled', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26126, 'Driver Peak JVM used Memory', 'The allocated memory for the driver (in spark.driver.memory) is much more than the peak JVM used memory by the driver.', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26126, 'Max driver peak JVM used memory', '1,002.64 MB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26126, 'spark.driver.cores', '1', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26126, 'spark.driver.memory', '3 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26126, 'spark.yarn.driver.memoryOverhead', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(26126, 'Suggested spark.driver.memory', '2 GB', NULL);
+
+INSERT INTO yarn_app_result(id, name, username, queue_name, start_time, finish_time, tracking_url, job_type, severity, score, workflow_depth, scheduler, job_name, job_exec_id, flow_exec_id, job_def_id, flow_def_id, job_exec_url, flow_exec_url, job_def_url, flow_def_url, resource_used, resource_wasted, total_delay)
+  VALUES('application_1547833800460_664576', 'com.linkedin.hello.spark.CountPageView', 'mkumar1', 'sna_default', '1548423066104', '1548423131477', 'http://ltx1-farowp01.grid.linkedin.com:8080/proxy/application_1547833800460_664576/', 'Spark', 4, '553', 0, 'azkaban', 'countPageViewFlow_countPageView', 'https://hostname.com:8443/executor?execid=2136899&job=countPageViewFlow_countPageView&attempt=0', 'https://hostname.com:8443/executor?execid=2136899', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow&job=countPageViewFlow_countPageView', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow', 'https://hostname.com:8443/executor?execid=2136899&job=countPageViewFlow_countPageView&attempt=0', 'https://hostname.com:8443/executor?execid=2136899', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow&job=countPageViewFlow_countPageView', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow', '3095406', '2773917', '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36119, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.ConfigurationHeuristic', 'Spark Configuration', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36120, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.JobsHeuristic', 'Spark Job Metrics', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36121, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.StagesHeuristic', 'Spark Stage Metrics', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36122, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.UnifiedMemoryHeuristic', 'Executor Peak Unified Memory', 4, '200');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36123, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.JvmUsedMemoryHeuristic', 'Executor JVM Used Memory', 4, '200');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36124, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.ExecutorGcHeuristic', 'Executor GC', 3, '150');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36125, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.ExecutorStorageSpillHeuristic', 'Executor spill', 0, '0');
+
+INSERT INTO yarn_app_heuristic_result(id, yarn_app_result_id, heuristic_class, heuristic_name, severity, score)
+  VALUES(36126, 'application_1547833800460_664576', 'com.linkedin.drelephant.spark.heuristics.DriverHeuristic', 'Driver Metrics', 3, '3');
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.application.duration', '53 Seconds', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.dynamicAllocation.enabled', 'true', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.dynamicAllocation.maxExecutors', '900', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.dynamicAllocation.minExecutors', '9', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.executor.cores', '1', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.executor.instances', '50', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.executor.memory', '8 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36119, 'spark.yarn.executor.memoryOverhead', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36120, 'Spark completed jobs count', '2', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36120, 'Spark failed jobs count', '0', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36120, 'Spark failed jobs list', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36120, 'Spark job failure rate', '0.000', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36120, 'Spark jobs with high task failure rates', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36121, 'Spark completed stages count', '4', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36121, 'Spark failed stages count', '0', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36121, 'Spark stage failure rate', '0.000', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36121, 'Spark stages with high task failure rates', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36121, 'Spark stages with long average executor runtimes', '', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36122, 'Max peak unified memory', '540.39 KB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36122, 'Mean peak unified memory', '48.03 KB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36122, 'spark.executor.memory', '8 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36122, 'spark.memory.fraction', '0.6', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36122, 'Unified Memory Space Allocated', '4.09 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36123, 'Executor Memory', 'The allocated memory for the executor (in spark.executor.memory) is much more than the peak JVM used memory by executors.', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36123, 'Max executor peak JVM used memory', '342.68 MB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36123, 'spark.executor.memory', '8 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36123, 'Suggested spark.executor.memory', '412 MB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36124, 'Gc ratio high', 'The job is spending too much time on GC. We recommend increasing the executor memory.', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36124, 'GC time to Executor Run time ratio', '0.1098475625893188', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36124, 'Total Executor Runtime', '6 Minutes', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36124, 'Total GC time', '41 Seconds', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36125, 'Fraction of executors having non zero bytes spilled', '0.0', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36125, 'Max memory spilled', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36125, 'Mean memory spilled', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36125, 'Total memory spilled', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36126, 'Driver Peak JVM used Memory', 'The allocated memory for the driver (in spark.driver.memory) is much more than the peak JVM used memory by the driver.', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36126, 'Max driver peak JVM used memory', '1,002.64 MB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36126, 'spark.driver.cores', '1', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36126, 'spark.driver.memory', '3 GB', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36126, 'spark.yarn.driver.memoryOverhead', '0 B', NULL);
+
+INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
+  VALUES(36126, 'Suggested spark.driver.memory', '2 GB', NULL);
+

--- a/test/resources/test-SparkHBTParamRecommender.sql
+++ b/test/resources/test-SparkHBTParamRecommender.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 INSERT INTO yarn_app_result(id, name, username, queue_name, start_time, finish_time, tracking_url, job_type, severity, score, workflow_depth, scheduler, job_name, job_exec_id, flow_exec_id, job_def_id, flow_def_id, job_exec_url, flow_exec_url, job_def_url, flow_def_url, resource_used, resource_wasted, total_delay)
   VALUES('application_1547833800460_664575', 'com.linkedin.hello.spark.CountPageView', 'mkumar1', 'sna_default', '1548423066104', '1548423131477', 'http://ltx1-farowp01.grid.linkedin.com:8080/proxy/application_1547833800460_664575/', 'Spark', 4, '553', 0, 'azkaban', 'countPageViewFlow_countPageView', 'https://hostname.com:8443/executor?execid=2136899&job=countPageViewFlow_countPageView&attempt=0', 'https://hostname.com:8443/executor?execid=2136899', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow&job=countPageViewFlow_countPageView', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow', 'https://hostname.com:8443/executor?execid=2136899&job=countPageViewFlow_countPageView&attempt=0', 'https://hostname.com:8443/executor?execid=2136899', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow&job=countPageViewFlow_countPageView', 'https://hostname.com:8443/manager?project=spark_starter_kit&flow=countPageViewFlow', '3095406', '2773917', '0');
 
@@ -182,16 +198,13 @@ INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name
   VALUES(36119, 'spark.dynamicAllocation.enabled', 'true', NULL);
 
 INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
-  VALUES(36119, 'spark.dynamicAllocation.maxExecutors', '900', NULL);
+  VALUES(36119, 'spark.dynamicAllocation.maxExecutors', '30', NULL);
 
 INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
   VALUES(36119, 'spark.dynamicAllocation.minExecutors', '9', NULL);
 
 INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
   VALUES(36119, 'spark.executor.cores', '1', NULL);
-
-INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
-  VALUES(36119, 'spark.executor.instances', '50', NULL);
 
 INSERT INTO yarn_app_heuristic_result_details(yarn_app_heuristic_result_id, name, value, details)
   VALUES(36119, 'spark.executor.memory', '8 GB', NULL);


### PR DESCRIPTION
This request is to improve Spark HBT and add more parameters. With this we would be suggesting three more parameters: spark.dynamicAllocation.minExecutors, spark.dynamicAllocation.maxExecutors, spark.executor.instances. Currently we are changing these parameters only we are making any changes in executor cores. If we are increasing number of cores, that means we would be needing less executors and vice versa. 

Testing Done: 
We have tested following use cases: 

- Suggestion should include previous values if there are no changes. This is to make sure that, if there are no changes in these parameters, we are still carrying forward the last suggested value.    
- If executor cores are decreasing, number of executors are decreasing in same proportion. 
- If executor cores are increasing, number of executors are increasing in same proportion. 
- If there is no value found in previous execution for one of the parameter, do not suggest anything for that parameter. 

Changed debug logging to info level logging. 