### PR TITLE
Fixes for Pig tuning

### DIFF
--- a/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
+++ b/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
@@ -155,7 +155,11 @@ public class SparkHBTParamRecommender {
   private Long getStringToLongParameter(Map<String, String> appHeuristicsResultDetailsMap, String key, Long defaultValue) {
     Long parameterValue = defaultValue;
     if (appHeuristicsResultDetailsMap.containsKey(key)) {
-      parameterValue = Long.parseLong(appHeuristicsResultDetailsMap.get(key));
+      try {
+        parameterValue = Long.parseLong(appHeuristicsResultDetailsMap.get(key));
+      } catch (NumberFormatException e) {
+        //Do Nothing
+      }
     }
     return parameterValue;
   }
@@ -164,7 +168,11 @@ public class SparkHBTParamRecommender {
       Integer defaultValue) {
     Integer parameterValue = defaultValue;
     if (appHeuristicsResultDetailsMap.containsKey(key)) {
-      parameterValue = Integer.parseInt(appHeuristicsResultDetailsMap.get(key));
+      try {
+        parameterValue = Integer.parseInt(appHeuristicsResultDetailsMap.get(key));
+      } catch (NumberFormatException e) {
+        //Do Nothing
+      }
     }
     return parameterValue;
   }

--- a/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
+++ b/app/com/linkedin/drelephant/tuning/engine/SparkHBTParamRecommender.java
@@ -158,7 +158,9 @@ public class SparkHBTParamRecommender {
       try {
         parameterValue = Long.parseLong(appHeuristicsResultDetailsMap.get(key));
       } catch (NumberFormatException e) {
-        //Do Nothing
+        if (logger.isDebugEnabled()) {
+          logger.debug("Number format exception for value " + appHeuristicsResultDetailsMap.get(key), e);
+        }
       }
     }
     return parameterValue;
@@ -171,7 +173,9 @@ public class SparkHBTParamRecommender {
       try {
         parameterValue = Integer.parseInt(appHeuristicsResultDetailsMap.get(key));
       } catch (NumberFormatException e) {
-        //Do Nothing
+        if (logger.isDebugEnabled()) {
+          logger.debug("Number format exception for value " + appHeuristicsResultDetailsMap.get(key), e);
+        }
       }
     }
     return parameterValue;

--- a/app/com/linkedin/drelephant/tuning/obt/ParameterGenerateManagerOBTAlgoPSOIPSOImpl.java
+++ b/app/com/linkedin/drelephant/tuning/obt/ParameterGenerateManagerOBTAlgoPSOIPSOImpl.java
@@ -53,6 +53,7 @@ public class ParameterGenerateManagerOBTAlgoPSOIPSOImpl extends ParameterGenerat
     return _executionEngine.getTuningJobDefinitionsForParameterSuggestion()
         .eq(TuningJobDefinition.TABLE.tuningAlgorithm + "." + TuningAlgorithm.TABLE.optimizationAlgo,
             TuningAlgorithm.OptimizationAlgo.PSO_IPSO.name())
+        .eq(TuningJobDefinition.TABLE.autoApply, 1)
         .findList();
   }
 

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -955,7 +955,7 @@ public class Application extends Controller {
        This logic is for backward compatailbity. Ideally we should remove this logic in next release
        because HBT should be the default optimization algorithm for all the jobs.
        */
-      optimizationAlgo = getAlgoBasedOnVersion(version);
+      optimizationAlgo = getAlgoBasedOnVersion(jobType);
       tuningInput.setFlowDefId(flowDefId);
       tuningInput.setJobDefId(jobDefId);
       tuningInput.setFlowDefUrl(flowDefUrl);
@@ -990,11 +990,12 @@ public class Application extends Controller {
     }
   }
 
-  public static String getAlgoBasedOnVersion(int version){
-    if(version == 1){
+  public static String getAlgoBasedOnVersion(String jobType) {
+    if (jobType.equals(JobType.PIG.name())) {
       return TuningAlgorithm.OptimizationAlgo.PSO_IPSO.name();
-    }
-    else{
+    } else if (jobType.equals(JobType.SPARK.name())) {
+      return TuningAlgorithm.OptimizationAlgo.HBT.name();
+    } else {
       return TuningAlgorithm.OptimizationAlgo.HBT.name();
     }
   }

--- a/test/com/linkedin/drelephant/tuning/TuningManagerTest.java
+++ b/test/com/linkedin/drelephant/tuning/TuningManagerTest.java
@@ -107,11 +107,11 @@ public class TuningManagerTest {
   @Test
   public void testAlgoBasedOnVersion() {
     assertTrue("Alorithm Based on Version Test",
-        controllers.Application.getAlgoBasedOnVersion(1).equals(TuningAlgorithm.OptimizationAlgo.PSO_IPSO.name()));
+        controllers.Application.getAlgoBasedOnVersion("PIG").equals(TuningAlgorithm.OptimizationAlgo.PSO_IPSO.name()));
     assertTrue("Alorithm Based on Version Test",
-        controllers.Application.getAlgoBasedOnVersion(2).equals(TuningAlgorithm.OptimizationAlgo.HBT.name()));
+        controllers.Application.getAlgoBasedOnVersion("SPARK").equals(TuningAlgorithm.OptimizationAlgo.HBT.name()));
     assertTrue("Alorithm Based on Version Test",
-        controllers.Application.getAlgoBasedOnVersion(3).equals(TuningAlgorithm.OptimizationAlgo.HBT.name()));
+        controllers.Application.getAlgoBasedOnVersion("HIVE").equals(TuningAlgorithm.OptimizationAlgo.HBT.name()));
   }
 
   @Test


### PR DESCRIPTION
- Adding try-catch block for reading counters
- Making change for deciding tuning algorithm based on job type
- In case of IPSO PSO, making a change to not generate parameter unless auto_apply=1 for the job 