### PR TITLE
New Spark heuristics, input data size, resource usage computation

### DIFF
--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -349,7 +349,12 @@
     <classname>com.linkedin.drelephant.spark.heuristics.JobsHeuristic</classname>
     <viewname>views.html.help.spark.helpJobsHeuristic</viewname>
   </heuristic>
-
+  <heuristic>
+    <applicationtype>spark</applicationtype>
+    <heuristicname>Spark Application Metrics</heuristicname>
+    <classname>com.linkedin.drelephant.spark.heuristics.SparkApplicationMetricsHeuristics</classname>
+    <viewname>views.html.help.spark.helpApplicationMetricsHeuristic</viewname>
+  </heuristic>
   <heuristic>
     <applicationtype>spark</applicationtype>
     <heuristicname>Spark Stage Metrics</heuristicname>

--- a/app/com/linkedin/drelephant/AutoTuner.java
+++ b/app/com/linkedin/drelephant/AutoTuner.java
@@ -36,6 +36,8 @@ import controllers.AutoTuningMetricsController;
 public class AutoTuner implements Runnable {
 
   public static final long ONE_MIN = 60 * 1000;
+  public static final long ONE_SEC = 1000L;
+
   private static final Logger logger = Logger.getLogger(AutoTuner.class);
   private static final long DEFAULT_METRICS_COMPUTATION_INTERVAL = ONE_MIN / 5;
   public static final String AUTO_TUNING_DAEMON_WAIT_INTERVAL = "autotuning.daemon.wait.interval.ms";

--- a/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
+++ b/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
@@ -16,17 +16,20 @@
 
 package com.linkedin.drelephant.spark
 
-import com.linkedin.drelephant.analysis.{HadoopAggregatedData, HadoopApplicationData, HadoopMetricsAggregator}
+import com.linkedin.drelephant.analysis.{ HadoopAggregatedData, HadoopApplicationData, HadoopMetricsAggregator }
 import com.linkedin.drelephant.configurations.aggregator.AggregatorConfigurationData
 import com.linkedin.drelephant.math.Statistics
-import com.linkedin.drelephant.spark.data.{SparkApplicationData}
+import com.linkedin.drelephant.spark.data.{ SparkApplicationData }
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.ExecutorSummary
 import com.linkedin.drelephant.util.MemoryFormatUtils
 import org.apache.commons.io.FileUtils
 import org.apache.log4j.Logger
 
 import scala.util.Try
-
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageData
+import java.util.Date
+import com.linkedin.drelephant.AutoTuner
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 
 class SparkMetricsAggregator(private val aggregatorConfigurationData: AggregatorConfigurationData)
     extends HadoopMetricsAggregator {
@@ -52,7 +55,7 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
     executorMemoryBytes <- executorMemoryBytesOf(data)
   } {
     val applicationDurationMillis = applicationDurationMillisOf(data)
-    if( applicationDurationMillis < 0) {
+    if (applicationDurationMillis < 0) {
       logger.warn(s"applicationDurationMillis is negative. Skipping Metrics Aggregation:${applicationDurationMillis}")
     } else {
       var (resourcesActuallyUsed, resourcesAllocatedForUse) = calculateResourceUsage(data.executorSummaries, executorMemoryBytes)
@@ -74,31 +77,34 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
         logger.warn(s"allocatedMemoryWasteBufferPercentage:${allocatedMemoryWasteBufferPercentage}")
       }
       hadoopAggregatedData.setResourceWasted(resourcesWastedMBSeconds.toLong)
+      hadoopAggregatedData.setTotalDelay(computeTotalWaitingTime(data.stageDatas))
     }
   }
 
   //calculates the resource usage by summing up the resources used per executor
   private def calculateResourceUsage(executorSummaries: Seq[ExecutorSummary], executorMemoryBytes: Long): (BigInt, BigInt) = {
     var sumResourceUsage: BigInt = 0
-    var sumResourcesAllocatedForUse : BigInt = 0
+    var sumResourcesAllocatedForUse: BigInt = 0
     executorSummaries.foreach(
       executorSummary => {
         var memUsedBytes: Long = executorSummary.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue + MemoryFormatUtils.stringToBytes(SPARK_RESERVED_MEMORY)
         var timeSpent: Long = executorSummary.totalDuration
-        val bytesMillisUsed = BigInt(memUsedBytes) * timeSpent
-        val bytesMillisAllocated = BigInt(executorMemoryBytes) * timeSpent
+        var totalCores: Int = executorSummary.totalCores
+        if(totalCores==0){
+          totalCores=1;
+        }
+        val bytesMillisUsed = BigInt(memUsedBytes) * timeSpent/totalCores
+        val bytesMillisAllocated = BigInt(executorMemoryBytes) * timeSpent/totalCores
         sumResourcesAllocatedForUse += (bytesMillisAllocated / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
         sumResourceUsage += (bytesMillisUsed / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
-      }
-    )
+      })
     (sumResourceUsage, sumResourcesAllocatedForUse)
   }
 
   private def aggregateresourcesAllocatedForUse(
     executorInstances: Int,
     executorMemoryBytes: Long,
-    applicationDurationMillis: Long
-   ): BigInt = {
+    applicationDurationMillis: Long): BigInt = {
     val bytesMillis = BigInt(executorInstances) * BigInt(executorMemoryBytes) * BigInt(applicationDurationMillis)
     (bytesMillis / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
   }
@@ -121,6 +127,111 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
 
   private def totalExecutorTaskTimeMillisOf(data: SparkApplicationData): BigInt = {
     data.executorSummaries.map { executorSummary => BigInt(executorSummary.totalDuration) }.sum
+  }
+
+  /**
+   * This method computes total waiting time by looking at each stage's waiting time and using dependencies between
+   * each stage. Total waiting time is the difference between actual duration of the job and duration of the job
+   * if there was no scheduler delay.
+   */
+  def computeTotalWaitingTime(stageDatas: Seq[StageData]) = {
+    val notSkippedStages = for (stage <- stageDatas if !stage.status.equals(StageStatus.SKIPPED)) yield stage
+    val dependencyMap = getStageDependency(notSkippedStages);
+
+    val sortedStages = notSkippedStages.sortBy { _.submissionTime }
+    var completionTimeWithoutDelayMap: scala.collection.mutable.Map[Int, Long] = scala.collection.mutable.Map[Int, Long]()
+    var completionTimeWithDelayMap: scala.collection.mutable.Map[Int, Long] = scala.collection.mutable.Map[Int, Long]()
+    var finalStageCompletionTimeWithoutDelay = 0L;
+    var finalStageActualCompletionTime = 0L;
+
+    for (i <- 0 until sortedStages.length) {
+      val stage = sortedStages(i)
+      val stageId = stage.stageId
+      var maxCompletionTimeWithoutDelay: Long = 0L;
+      var maxCompletionWithDelay: Long = 0L;
+
+      for (dependeeStageId <- dependencyMap.get(stageId).get) {
+        maxCompletionTimeWithoutDelay = Math.max(maxCompletionTimeWithoutDelay, completionTimeWithoutDelayMap.getOrElse(dependeeStageId, 0L));
+        maxCompletionWithDelay = Math.max(maxCompletionWithDelay, completionTimeWithDelayMap.getOrElse(dependeeStageId, 0L));
+      }
+      if (maxCompletionTimeWithoutDelay == 0) {
+        maxCompletionTimeWithoutDelay = stage.submissionTime.get.getTime;
+        maxCompletionWithDelay = stage.submissionTime.get.getTime
+      }
+      val currentStageDelay = getStageDelay(stage)
+      val completionTimeWithoutDelay = maxCompletionTimeWithoutDelay + (stage.completionTime.get.getTime - stage.submissionTime.get.getTime) - currentStageDelay + (stage.submissionTime.get.getTime - maxCompletionWithDelay)
+
+      logger.debug("currentStageDelay for " + stageId + ":" + currentStageDelay)
+      logger.debug("Delay till this stage " + stageId + ":" + (stage.completionTime.get.getTime - completionTimeWithoutDelay))
+
+      completionTimeWithoutDelayMap.put(stageId, completionTimeWithoutDelay)
+      completionTimeWithDelayMap.put(stageId, stage.completionTime.get.getTime)
+
+      finalStageCompletionTimeWithoutDelay = Math.max(finalStageCompletionTimeWithoutDelay, completionTimeWithoutDelay);
+      finalStageActualCompletionTime = Math.max(finalStageActualCompletionTime, stage.completionTime.get.getTime)
+    }
+
+    logger.debug("Total Delay:" + (finalStageActualCompletionTime - finalStageCompletionTimeWithoutDelay))
+    finalStageActualCompletionTime - finalStageCompletionTimeWithoutDelay
+  }
+
+  /**
+   * Returns scheduler delay for the job, which is max of scheduler delay distribution
+   */
+  def getStageDelay(stage: StageData): Long = {
+    val maxSchedulerDelayIndex = 4
+    var schedulerDelay = 0D
+    val taskSummary = stage.taskSummary.getOrElse(null)
+    if (taskSummary != null) {
+      val schedulerDelays = taskSummary.schedulerDelay
+      if (schedulerDelays != null)
+        schedulerDelay = schedulerDelays(maxSchedulerDelayIndex)
+    }
+    schedulerDelay.longValue()
+  }
+
+  /**
+   * Get approximate dependency between each stages, using submission time and completion time
+   * A stage is dependent on other stage if it is started within 1 second of any stage's completion.
+   */
+  def getStageDependency(stageDatas: Seq[StageData]): scala.collection.mutable.Map[Int, scala.collection.mutable.Set[Int]] = {
+    var dependencyMap: scala.collection.mutable.Map[Int, scala.collection.mutable.Set[Int]] = scala.collection.mutable.Map[Int, scala.collection.mutable.Set[Int]]();
+    for (i <- 0 until stageDatas.length) {
+      var dependentStages = findDependeeStages(i, stageDatas);
+      dependencyMap.put(stageDatas(i).stageId, dependentStages)
+    }
+    logger.debug("Depdendency Map " + dependencyMap)
+    dependencyMap
+  }
+
+  /**
+   * Find dependee stages for the givem stage
+   */
+  def findDependeeStages(dependeeStageIndex: Int, stages: Seq[StageData]): scala.collection.mutable.Set[Int] = {
+    val dependentStage = stages(dependeeStageIndex)
+    val dependentStageStartTime: Date = dependentStage.submissionTime.getOrElse(null)
+    var dependeeStages: scala.collection.mutable.Set[Int] = scala.collection.mutable.Set[Int]()
+    var timeBasedDependentStage = -1
+    var timeBasedDependetStageCompletionTime = new Date(0);
+
+    for (j <- 0 until stages.length if dependeeStageIndex != j) {
+      val possibleDependeeStage = stages(j)
+      val possiblDependeeStageCompletionTime: Date = possibleDependeeStage.completionTime.getOrElse(null)
+      logger.debug("Current dependent Stage " + j + " date " + possiblDependeeStageCompletionTime);
+      if (dependentStageStartTime.before(possiblDependeeStageCompletionTime) == false) {
+        if (possiblDependeeStageCompletionTime.after(timeBasedDependetStageCompletionTime)) {
+          timeBasedDependentStage = j;
+          timeBasedDependetStageCompletionTime = possiblDependeeStageCompletionTime;
+        }
+        if (dependentStageStartTime.getTime <= possiblDependeeStageCompletionTime.getTime + AutoTuner.ONE_SEC) {
+          dependeeStages.add(possibleDependeeStage.stageId)
+        }
+      }
+    }
+    if (dependeeStages.size == 0 && timeBasedDependentStage != -1) {
+      dependeeStages.add(timeBasedDependentStage)
+    }
+    dependeeStages
   }
 }
 

--- a/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
+++ b/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
@@ -30,6 +30,9 @@ import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageData
 import java.util.Date
 import com.linkedin.drelephant.AutoTuner
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
+import com.linkedin.drelephant.ElephantContext
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.conf.Configuration
 
 class SparkMetricsAggregator(private val aggregatorConfigurationData: AggregatorConfigurationData)
     extends HadoopMetricsAggregator {
@@ -58,7 +61,7 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
     if (applicationDurationMillis < 0) {
       logger.warn(s"applicationDurationMillis is negative. Skipping Metrics Aggregation:${applicationDurationMillis}")
     } else {
-      var (resourcesActuallyUsed, resourcesAllocatedForUse) = calculateResourceUsage(data.executorSummaries, executorMemoryBytes)
+      var (resourcesActuallyUsed, resourcesAllocatedForUse) = calculateResourceUsage(data)
       val resourcesActuallyUsedWithBuffer = resourcesActuallyUsed.doubleValue() * (1.0 + allocatedMemoryWasteBufferPercentage)
       val resourcesWastedMBSeconds = (resourcesActuallyUsedWithBuffer < resourcesAllocatedForUse.doubleValue()) match {
         case true => resourcesAllocatedForUse.doubleValue() - resourcesActuallyUsedWithBuffer
@@ -77,24 +80,26 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
         logger.warn(s"allocatedMemoryWasteBufferPercentage:${allocatedMemoryWasteBufferPercentage}")
       }
       hadoopAggregatedData.setResourceWasted(resourcesWastedMBSeconds.toLong)
-      hadoopAggregatedData.setTotalDelay(computeTotalWaitingTime(data.stageDatas))
     }
   }
 
   //calculates the resource usage by summing up the resources used per executor
-  private def calculateResourceUsage(executorSummaries: Seq[ExecutorSummary], executorMemoryBytes: Long): (BigInt, BigInt) = {
+  private def calculateResourceUsage(data: SparkApplicationData): (BigInt, BigInt) = {
+    val executorSummaries = data.executorSummaries
     var sumResourceUsage: BigInt = 0
     var sumResourcesAllocatedForUse: BigInt = 0
     executorSummaries.foreach(
       executorSummary => {
-        var memUsedBytes: Long = executorSummary.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue + MemoryFormatUtils.stringToBytes(SPARK_RESERVED_MEMORY)
+        val memoryOverhead = overheadMemoryBytesOf(data).get
+        val roundedContainerBytes = getRoundedContainerBytes(data).get
+        var memUsedBytes: Long = executorSummary.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue + MemoryFormatUtils.stringToBytes(SPARK_RESERVED_MEMORY) + memoryOverhead
         var timeSpent: Long = executorSummary.totalDuration
         var totalCores: Int = executorSummary.totalCores
-        if(totalCores==0){
-          totalCores=1;
+        if (totalCores == 0) {
+          totalCores = 1;
         }
-        val bytesMillisUsed = BigInt(memUsedBytes) * timeSpent/totalCores
-        val bytesMillisAllocated = BigInt(executorMemoryBytes) * timeSpent/totalCores
+        val bytesMillisUsed = BigInt(memUsedBytes) * timeSpent / totalCores
+        val bytesMillisAllocated = BigInt(roundedContainerBytes) * timeSpent / totalCores
         sumResourcesAllocatedForUse += (bytesMillisAllocated / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
         sumResourceUsage += (bytesMillisUsed / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
       })
@@ -128,119 +133,44 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
   private def totalExecutorTaskTimeMillisOf(data: SparkApplicationData): BigInt = {
     data.executorSummaries.map { executorSummary => BigInt(executorSummary.totalDuration) }.sum
   }
-
-  /**
-   * This method computes total waiting time by looking at each stage's waiting time and using dependencies between
-   * each stage. Total waiting time is the difference between actual duration of the job and duration of the job
-   * if there was no scheduler delay.
-   */
-  def computeTotalWaitingTime(stageDatas: Seq[StageData]) = {
-    val notSkippedStages = for (stage <- stageDatas if !stage.status.equals(StageStatus.SKIPPED)) yield stage
-    val dependencyMap = getStageDependency(notSkippedStages);
-
-    val sortedStages = notSkippedStages.sortBy { _.submissionTime }
-    var completionTimeWithoutDelayMap: scala.collection.mutable.Map[Int, Long] = scala.collection.mutable.Map[Int, Long]()
-    var completionTimeWithDelayMap: scala.collection.mutable.Map[Int, Long] = scala.collection.mutable.Map[Int, Long]()
-    var finalStageCompletionTimeWithoutDelay = 0L;
-    var finalStageActualCompletionTime = 0L;
-
-    for (i <- 0 until sortedStages.length) {
-      val stage = sortedStages(i)
-      val stageId = stage.stageId
-      var maxCompletionTimeWithoutDelay: Long = 0L;
-      var maxCompletionWithDelay: Long = 0L;
-
-      for (dependeeStageId <- dependencyMap.get(stageId).get) {
-        maxCompletionTimeWithoutDelay = Math.max(maxCompletionTimeWithoutDelay, completionTimeWithoutDelayMap.getOrElse(dependeeStageId, 0L));
-        maxCompletionWithDelay = Math.max(maxCompletionWithDelay, completionTimeWithDelayMap.getOrElse(dependeeStageId, 0L));
-      }
-      if (maxCompletionTimeWithoutDelay == 0) {
-        maxCompletionTimeWithoutDelay = stage.submissionTime.get.getTime;
-        maxCompletionWithDelay = stage.submissionTime.get.getTime
-      }
-      val currentStageDelay = getStageDelay(stage)
-      val completionTimeWithoutDelay = maxCompletionTimeWithoutDelay + (stage.completionTime.get.getTime - stage.submissionTime.get.getTime) - currentStageDelay + (stage.submissionTime.get.getTime - maxCompletionWithDelay)
-
-      logger.debug("currentStageDelay for " + stageId + ":" + currentStageDelay)
-      logger.debug("Delay till this stage " + stageId + ":" + (stage.completionTime.get.getTime - completionTimeWithoutDelay))
-
-      completionTimeWithoutDelayMap.put(stageId, completionTimeWithoutDelay)
-      completionTimeWithDelayMap.put(stageId, stage.completionTime.get.getTime)
-
-      finalStageCompletionTimeWithoutDelay = Math.max(finalStageCompletionTimeWithoutDelay, completionTimeWithoutDelay);
-      finalStageActualCompletionTime = Math.max(finalStageActualCompletionTime, stage.completionTime.get.getTime)
+  private def overheadMemoryBytesOf(data: SparkApplicationData): Option[Long] = {
+    val executorMemory = executorMemoryBytesOf(data)
+    val appConfigurationProperties = data.appConfigurationProperties
+    var memoryOverhead = None: Option[Long]
+    if (appConfigurationProperties.get(SPARK_YARN_EXECUTOR_MEMORY_OVERHEAD).isEmpty) {
+      val overheadMemory = executorMemory.get * (appConfigurationProperties.get(SPARK_MEMORY_OVERHEAD_MULTIPLIER_PERCENT).getOrElse(DEFAULT_SPARK_MEMORY_OVERHEAD_MULTIPLIER_PERCENT)).toInt / 100
+      Option(overheadMemory)
+    } else {
+      appConfigurationProperties.get(SPARK_YARN_EXECUTOR_MEMORY_OVERHEAD).map(MemoryFormatUtils.stringToBytes)
     }
-
-    logger.debug("Total Delay:" + (finalStageActualCompletionTime - finalStageCompletionTimeWithoutDelay))
-    finalStageActualCompletionTime - finalStageCompletionTimeWithoutDelay
   }
 
-  /**
-   * Returns scheduler delay for the job, which is max of scheduler delay distribution
-   */
-  def getStageDelay(stage: StageData): Long = {
-    val maxSchedulerDelayIndex = 4
-    var schedulerDelay = 0D
-    val taskSummary = stage.taskSummary.getOrElse(null)
-    if (taskSummary != null) {
-      val schedulerDelays = taskSummary.schedulerDelay
-      if (schedulerDelays != null)
-        schedulerDelay = schedulerDelays(maxSchedulerDelayIndex)
-    }
-    schedulerDelay.longValue()
+  private def getRoundedContainerBytes(data: SparkApplicationData): Option[Long] = {
+    val increment = getIncrementBytes()
+    val executorMemory = executorMemoryBytesOf(data)
+    val memoryOverHead = overheadMemoryBytesOf(data)
+    val totalMemoryRequired = executorMemory.get + memoryOverHead.get
+    val roundedContainerBytes = Math.ceil((totalMemoryRequired * 1.0) / increment.get) * increment.get
+    Option(roundedContainerBytes.longValue())
   }
 
-  /**
-   * Get approximate dependency between each stages, using submission time and completion time
-   * A stage is dependent on other stage if it is started within 1 second of any stage's completion.
-   */
-  def getStageDependency(stageDatas: Seq[StageData]): scala.collection.mutable.Map[Int, scala.collection.mutable.Set[Int]] = {
-    var dependencyMap: scala.collection.mutable.Map[Int, scala.collection.mutable.Set[Int]] = scala.collection.mutable.Map[Int, scala.collection.mutable.Set[Int]]();
-    for (i <- 0 until stageDatas.length) {
-      var dependentStages = findDependeeStages(i, stageDatas);
-      dependencyMap.put(stageDatas(i).stageId, dependentStages)
-    }
-    logger.debug("Depdendency Map " + dependencyMap)
-    dependencyMap
-  }
-
-  /**
-   * Find dependee stages for the givem stage
-   */
-  def findDependeeStages(dependeeStageIndex: Int, stages: Seq[StageData]): scala.collection.mutable.Set[Int] = {
-    val dependentStage = stages(dependeeStageIndex)
-    val dependentStageStartTime: Date = dependentStage.submissionTime.getOrElse(null)
-    var dependeeStages: scala.collection.mutable.Set[Int] = scala.collection.mutable.Set[Int]()
-    var timeBasedDependentStage = -1
-    var timeBasedDependetStageCompletionTime = new Date(0);
-
-    for (j <- 0 until stages.length if dependeeStageIndex != j) {
-      val possibleDependeeStage = stages(j)
-      val possiblDependeeStageCompletionTime: Date = possibleDependeeStage.completionTime.getOrElse(null)
-      logger.debug("Current dependent Stage " + j + " date " + possiblDependeeStageCompletionTime);
-      if (dependentStageStartTime.before(possiblDependeeStageCompletionTime) == false) {
-        if (possiblDependeeStageCompletionTime.after(timeBasedDependetStageCompletionTime)) {
-          timeBasedDependentStage = j;
-          timeBasedDependetStageCompletionTime = possiblDependeeStageCompletionTime;
-        }
-        if (dependentStageStartTime.getTime <= possiblDependeeStageCompletionTime.getTime + AutoTuner.ONE_SEC) {
-          dependeeStages.add(possibleDependeeStage.stageId)
-        }
-      }
-    }
-    if (dependeeStages.size == 0 && timeBasedDependentStage != -1) {
-      dependeeStages.add(timeBasedDependentStage)
-    }
-    dependeeStages
+  private def getIncrementBytes(): Option[Long] = {
+    val config = new Configuration
+    val incrementMB = config.getInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB,
+      YarnConfiguration.DEFAULT_RM_SCHEDULER_MINIMUM_ALLOCATION_MB);
+    Option(incrementMB * 1024 * 1024)
   }
 }
 
 object SparkMetricsAggregator {
   /** The percentage of allocated memory we expect to waste because of overhead. */
+  val DEFAULT_SPARK_MEMORY_OVERHEAD_MULTIPLIER_PERCENT = "10"
   val DEFAULT_ALLOCATED_MEMORY_WASTE_BUFFER_PERCENTAGE = 0.5D
   val ALLOCATED_MEMORY_WASTE_BUFFER_PERCENTAGE_KEY = "allocated_memory_waste_buffer_percentage"
   val SPARK_RESERVED_MEMORY: String = "300M"
   val SPARK_EXECUTOR_INSTANCES_KEY = "spark.executor.instances"
   val SPARK_EXECUTOR_MEMORY_KEY = "spark.executor.memory"
+  val SPARK_YARN_EXECUTOR_MEMORY_OVERHEAD = "spark.yarn.executor.memoryOverhead"
+  val SPARK_MEMORY_OVERHEAD_MULTIPLIER_PERCENT = "spark.memoryOverhead.multiplier.percent"
   val JVM_USED_MEMORY = "jvmUsedMemory"
 }

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
@@ -77,6 +77,7 @@ trait ExecutorSummary{
   def rddBlocks: Int
   def memoryUsed: Long
   def diskUsed: Long
+  def totalCores: Int
   def activeTasks: Int
   def failedTasks: Int
   def completedTasks: Int
@@ -326,6 +327,7 @@ class ExecutorSummaryImpl(
   var rddBlocks: Int,
   var memoryUsed: Long,
   var diskUsed: Long,
+  var totalCores: Int,
   var activeTasks: Int,
   var failedTasks: Int,
   var completedTasks: Int,

--- a/app/com/linkedin/drelephant/spark/heuristics/SparkApplicationMetricsHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/SparkApplicationMetricsHeuristic.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.spark.heuristics
+
+import java.util.Date
+
+import scala.Long
+import scala.collection.JavaConverters
+
+import org.apache.commons.io.FileUtils
+
+import com.linkedin.drelephant.AutoTuner
+import com.linkedin.drelephant.analysis.Heuristic
+import com.linkedin.drelephant.analysis.HeuristicResult
+import com.linkedin.drelephant.analysis.HeuristicResultDetails
+import com.linkedin.drelephant.analysis.Severity
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
+import com.linkedin.drelephant.spark.data.SparkApplicationData
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageData
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
+
+/**
+ * A heuristic based on metrics for a Spark app's stages.
+ * This heuristic reports metrics at application level like total input data size, total input records etc.
+ */
+class SparkApplicationMetricsHeuristics(private val heuristicConfigurationData: HeuristicConfigurationData)
+    extends Heuristic[SparkApplicationData] {
+  import SparkApplicationMetricsHeuristics._
+  import JavaConverters._
+
+  override def getHeuristicConfData(): HeuristicConfigurationData = heuristicConfigurationData
+
+  override def apply(data: SparkApplicationData): HeuristicResult = {
+    val evaluator = new Evaluator(this, data)
+
+    val resultDetails = Seq(
+      new HeuristicResultDetails(TOTAL_INPUT_SIZE_IN_MB, "%.4f".format(evaluator.totalInputBytes * 1.0 / (FileUtils.ONE_MB))),
+      new HeuristicResultDetails(TOTAL_INPUT_RECORDS, evaluator.totalInputRecords.toString()),
+      new HeuristicResultDetails(TOTAL_OUTPUT_SIZE, FileUtils.byteCountToDisplaySize(evaluator.totalOutputBytes)),
+      new HeuristicResultDetails(TOTAL_SHUFFLE_READ_SIZE, FileUtils.byteCountToDisplaySize(evaluator.totalShuffleReadBytes)),
+      new HeuristicResultDetails(TOTAL_SHUFFLE_READ_RECORDS, evaluator.totalShuffleReadRecords.toString()),
+      new HeuristicResultDetails(TOTAL_SHUFFLE_WRITE_SIZE, FileUtils.byteCountToDisplaySize(evaluator.totalShuffleWriteBytes)),
+      new HeuristicResultDetails(TOTAL_SHUFFLE_WRITE_RECORDS, evaluator.totalShuffleWriteRecords.toString()),
+      new HeuristicResultDetails(TOTAL_MEMORY_SPILL_SIZE, FileUtils.byteCountToDisplaySize(evaluator.totalMemoryBytesSpilled)),
+      new HeuristicResultDetails(TOTAL_DISK_SPILL_SIZE, FileUtils.byteCountToDisplaySize(evaluator.totalDiskBytesSpilled)))
+
+    val result = new HeuristicResult(
+      heuristicConfigurationData.getClassName,
+      heuristicConfigurationData.getHeuristicName,
+      Severity.NONE,
+      0,
+      resultDetails.asJava)
+
+    result
+  }
+}
+
+object SparkApplicationMetricsHeuristics {
+  private val maxSchedulerDelayIndex = 4
+  val TOTAL_INPUT_SIZE_IN_MB = "Total Input Size in MB";
+  val TOTAL_INPUT_RECORDS = "Total Input Records";
+  val TOTAL_OUTPUT_SIZE = "Total Output Size"
+  val TOTAL_SHUFFLE_READ_SIZE = "Total Shuffle Read Size";
+  val TOTAL_SHUFFLE_READ_RECORDS = "Total Shuffle Read Records";
+  val TOTAL_SHUFFLE_WRITE_SIZE = "Total Shuffle Write Size";
+  val TOTAL_SHUFFLE_WRITE_RECORDS = "Total Shuffle Write Records";
+  val TOTAL_MEMORY_SPILL_SIZE = "Total Memory Spill Size";
+  val TOTAL_DISK_SPILL_SIZE = "Total Disk Spill Size";
+
+  class Evaluator(sparkApplicationMetricsHeuristics: SparkApplicationMetricsHeuristics, data: SparkApplicationData) {
+    lazy val stageDatas: Seq[StageData] = data.stageDatas
+    lazy val totalInputBytes: Long = stageDatas.map(_.inputBytes).sum
+    lazy val totalInputRecords: Long = stageDatas.map(_.inputRecords).sum
+    lazy val totalOutputBytes: Long = stageDatas.map(_.outputBytes).sum
+    lazy val totalShuffleReadBytes: Long = stageDatas.map(_.shuffleReadBytes).sum
+    lazy val totalShuffleReadRecords: Long = stageDatas.map(_.shuffleReadRecords).sum
+    lazy val totalShuffleWriteBytes: Long = stageDatas.map(_.shuffleWriteBytes).sum
+    lazy val totalShuffleWriteRecords: Long = stageDatas.map(_.shuffleWriteRecords).sum
+    lazy val totalMemoryBytesSpilled: Long = stageDatas.map(_.memoryBytesSpilled).sum
+    lazy val totalDiskBytesSpilled: Long = stageDatas.map(_.diskBytesSpilled).sum
+  }
+}

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -222,6 +222,7 @@ object LegacyDataConverters {
         executorInfo.rddBlocks,
         executorInfo.memUsed,
         executorInfo.diskUsed,
+        executorInfo.totalCores,
         executorInfo.activeTasks,
         executorInfo.failedTasks,
         executorInfo.completedTasks,

--- a/app/com/linkedin/drelephant/spark/legacydata/SparkExecutorData.java
+++ b/app/com/linkedin/drelephant/spark/legacydata/SparkExecutorData.java
@@ -34,7 +34,7 @@ public class SparkExecutorData {
     public long memUsed = 0L;
     public long maxMem = 0L;
     public long diskUsed = 0L;
-
+    public int totalCores = 1;
     public int activeTasks = 0;
     public int completedTasks = 0;
     public int failedTasks = 0;
@@ -50,7 +50,7 @@ public class SparkExecutorData {
 
     public String toString() {
       return "{execId: " + execId + ", hostPort:" + hostPort + " , rddBlocks: " + rddBlocks + ", memUsed: " + memUsed
-          + ", maxMem: " + maxMem + ", diskUsed: " + diskUsed + ", totalTasks" + totalTasks + ", maxTasks" + maxTasks + ", tasksActive: "
+          + ", maxMem: " + maxMem + ", diskUsed: " + diskUsed + ", totalCores: " + totalCores + ", totalTasks" + totalTasks + ", maxTasks" + maxTasks + ", tasksActive: "
           + activeTasks + ", tasksComplete: " + completedTasks + ", tasksFailed: " + failedTasks + ", duration: "
           + duration + ", inputBytes: " + inputBytes + ", outputBytes:" + outputBytes + ", shuffleRead: " + shuffleRead
           + ", shuffleWrite: " + shuffleWrite + ", totalGCTime: " + totalGCTime + ", totalMemoryBytesSpilled: " + totalMemoryBytesSpilled + "}";

--- a/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
+++ b/app/com/linkedin/drelephant/tuning/AbstractFitnessManager.java
@@ -153,29 +153,6 @@ public abstract class AbstractFitnessManager implements Manager {
   }
 
   /**
-   * Returns the total input size
-   * @param appResult appResult
-   * @return total input size
-   */
-  protected Long getTotalInputBytes(AppResult appResult) {
-    Long totalInputBytes = 0L;
-    if (appResult.yarnAppHeuristicResults != null) {
-      for (AppHeuristicResult appHeuristicResult : appResult.yarnAppHeuristicResults) {
-        if (appHeuristicResult.heuristicName.equals(CommonConstantsHeuristic.MAPPER_SPEED)) {
-          if (appHeuristicResult.yarnAppHeuristicResultDetails != null) {
-            for (AppHeuristicResultDetails appHeuristicResultDetails : appHeuristicResult.yarnAppHeuristicResultDetails) {
-              if (appHeuristicResultDetails.name.equals(CommonConstantsHeuristic.TOTAL_INPUT_SIZE_IN_MB)) {
-                totalInputBytes += Math.round(Double.parseDouble(appHeuristicResultDetails.value) * FileUtils.ONE_MB);
-              }
-            }
-          }
-        }
-      }
-    }
-    return totalInputBytes;
-  }
-
-  /**
    * Resets the param set to CREATED state if its fitness is not already computed
    * @param jobSuggestedParamSet Param set which is to be reset
    */

--- a/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBT.java
+++ b/app/com/linkedin/drelephant/tuning/obt/FitnessManagerOBT.java
@@ -68,7 +68,7 @@ public abstract class FitnessManagerOBT extends AbstractFitnessManager {
     Double totalInputBytesInBytes = 0D;
     for (AppResult appResult : results) {
       totalResourceUsed += appResult.resourceUsed;
-      totalInputBytesInBytes += getTotalInputBytes(appResult);
+      totalInputBytesInBytes += appResult.getTotalInputBytes();
     }
 
     Long totalRunTime = Utils.getTotalRuntime(results);

--- a/app/models/AppResult.java
+++ b/app/models/AppResult.java
@@ -27,11 +27,19 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import models.TuningAlgorithm.JobType;
+
+import org.apache.commons.io.FileUtils;
+
 import play.db.ebean.Model;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.linkedin.drelephant.analysis.Severity;
+import com.linkedin.drelephant.mapreduce.heuristics.CommonConstantsHeuristic;
+import com.linkedin.drelephant.mapreduce.heuristics.MapperSpeedHeuristic;
+import com.linkedin.drelephant.spark.heuristics.SparkApplicationMetricsHeuristics;
 import com.linkedin.drelephant.util.Utils;
+import org.apache.log4j.Logger;
 
 
 @Entity
@@ -39,6 +47,7 @@ import com.linkedin.drelephant.util.Utils;
 public class AppResult extends Model {
 
   private static final long serialVersionUID = 1L;
+  private static final Logger logger = Logger.getLogger(AppResult.class);
 
   public static final int ID_LIMIT = 50;
   public static final int USERNAME_LIMIT = 50;
@@ -181,5 +190,38 @@ public class AppResult extends Model {
       }
     }
     return heuristicsDetailsMap;
+  }
+
+  public String getHeuristicValue(String heuristicClass, String heuristicName) {
+    Map<String, String> heuristicsMap = getHeuristicsResultDetailsMap();
+    return heuristicsMap.get(heuristicClass + "_" + heuristicName);
+  }
+
+  /**
+   * Returns the total input size
+   * @param appResult appResult
+   * @return total input size
+   */
+  public Long getTotalInputBytes() {
+    String heursiticValue = null;
+    if (jobType.toLowerCase().equals(JobType.PIG.name().toLowerCase())
+        || jobType.toLowerCase().equals(JobType.HIVE.name().toLowerCase())) {
+      heursiticValue =
+          getHeuristicValue(MapperSpeedHeuristic.class.getCanonicalName(),
+              CommonConstantsHeuristic.TOTAL_INPUT_SIZE_IN_MB);
+    } else if (jobType.toLowerCase().equals(JobType.SPARK.name().toLowerCase())) {
+      heursiticValue =
+          getHeuristicValue(SparkApplicationMetricsHeuristics.class.getCanonicalName(),
+              SparkApplicationMetricsHeuristics.TOTAL_INPUT_SIZE_IN_MB());
+    }
+    Long totalInputBytes = 0L;
+    if (heursiticValue != null) {
+      try {
+        totalInputBytes = Math.round(Double.parseDouble(heursiticValue) * FileUtils.ONE_MB);
+      } catch (NumberFormatException e) {
+        logger.debug("Found wrong input bytes for application ID " + id);
+      }
+    }
+    return totalInputBytes;
   }
 }

--- a/app/views/help/spark/helpApplicationMetricsHeuristic.scala.html
+++ b/app/views/help/spark/helpApplicationMetricsHeuristic.scala.html
@@ -1,0 +1,20 @@
+@*
+* Copyright 2019 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*@
+<p>This heuristic reports Spark application level metrics like Total Input Data Size, Total Input Records,
+Total Output Data Size, Total Shuffle Read and Write Bytes, Total Shuffle Read and Write Records,
+Total Memory Bytes Spilled and Total Disk Bytes Spilled.</p>
+
+<p>This is an informational heuristic.</p>

--- a/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
+++ b/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
@@ -29,6 +29,12 @@ import com.linkedin.drelephant.util.MemoryFormatUtils
 import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
 import org.apache.commons.io.FileUtils
 import org.scalatest.{FunSpec, Matchers}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.TaskMetricDistributionsImpl
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageDataImpl
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
+import java.util.Calendar
+import org.apache.commons.lang3.time.DateUtils
+import com.linkedin.drelephant.AutoTuner
 
 class SparkMetricsAggregatorTest extends FunSpec with Matchers {
   import SparkMetricsAggregatorTest._
@@ -54,11 +60,54 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
       newFakeExecutorSummary(id = "2", totalDuration = 3000000L, Map("jvmUsedMemory" -> 23456834))
 
     )
+
+    val cal = Calendar.getInstance()
+    cal.setTimeInMillis(1550340951000L)
+    val stage1StartTime = cal.getTime
+    val stage1CompletionTime = DateUtils.addMinutes(stage1StartTime, 3)
+
+    val stage2StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 3), 1)
+    val stage2CompletionTime = DateUtils.addMinutes(stage1StartTime, 9)
+
+    val stage3StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 9), 999)
+    val stage3CompletionTime = DateUtils.addMinutes(stage1StartTime, 10)
+
+    val stage4StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 10), 1)
+    val stage4CompletionTime = DateUtils.addMinutes(stage1StartTime, 17)
+
+    val stage5StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 17), 1)
+    val stage5CompletionTime = DateUtils.addMinutes(stage1StartTime, 18)
+
+    val stage6StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 18), 1)
+    val stage6CompletionTime = DateUtils.addMinutes(stage1StartTime, 30)
+
+    val scheduleStage1Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 1);
+    val scheduleStage2Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 0.7);
+    val scheduleStage3Delay = IndexedSeq(0D, 0D, 0D, 0D, 0D);
+    val scheduleStage4Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 3.0);
+    val scheduleStage5Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 1.0);
+    val scheduleStage6Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 0D);
+
+    val taskSummary1 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage1Delay, null, null, null, null, null, null, null);
+    val taskSummary2 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage2Delay, null, null, null, null, null, null, null);
+    val taskSummary3 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage3Delay, null, null, null, null, null, null, null);
+    val taskSummary4 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage4Delay, null, null, null, null, null, null, null);
+    val taskSummary5 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage5Delay, null, null, null, null, null, null, null);
+    val taskSummary6 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage6Delay, null, null, null, null, null, null, null);
+    val stageDatas = Seq(
+      newFakeStageData(StageStatus.COMPLETE, 0, 10, Option(stage1StartTime), Option(stage1CompletionTime), "stage1", 1000990929L, 100000L, 2000990929L, 200000L, 4000990929L, 600000L, 24570990929L, 245990929L, 34570990929L, 34570990929L, Option(taskSummary1)),
+      newFakeStageData(StageStatus.SKIPPED, 1, 11, Option(stage2StartTime), Option(stage2CompletionTime), "stage2", 2000990929L, 200000L, 3000990929L, 300000L, 5000990929L, 700000L, 23570990929L, 345990929L, 44570990929L, 44570990929L, Option(taskSummary2)),
+      newFakeStageData(StageStatus.COMPLETE, 2, 12, Option(stage3StartTime), Option(stage3CompletionTime), "stage3", 3000990929L, 300000L, 4000990929L, 400000L, 6000990929L, 800000L, 22570990929L, 445990929L, 54570990929L, 4570990929L, Option(taskSummary3)),
+      newFakeStageData(StageStatus.COMPLETE, 3, 13, Option(stage4StartTime), Option(stage4CompletionTime), "stage4", 4000990929L, 400000L, 5000990929L, 500000L, 7000990929L, 900000L, 21570990929L, 545990929L, 64570990929L, 64570990929L, Option(taskSummary4)),
+      newFakeStageData(StageStatus.COMPLETE, 4, 14, Option(stage5StartTime), Option(stage5CompletionTime), "stage5", 5000990929L, 500000L, 6000990929L, 600000L, 8000990929L, 2000000L, 20570990929L, 645990929L, 74570990929L, 4570990929L, Option(taskSummary5)),
+      newFakeStageData(StageStatus.COMPLETE, 5, 15, Option(stage6StartTime), Option(stage6CompletionTime), "stage6", 6000990929L, 600000L, 7000990929L, 700000L, 9000990929L, 2100000L, 27570990929L, 845990929L, 84570990929L, 84570990929L, Option(taskSummary6)))
+
+
     val restDerivedData = {
       SparkRestDerivedData(
         applicationInfo,
         jobDatas = Seq.empty,
-        stageDatas = Seq.empty,
+        stageDatas = stageDatas,
         executorSummaries = executorSummaries,
         stagesWithFailedTasks = Seq.empty
       )
@@ -96,8 +145,8 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
         result.getResourceWasted should be(resourceAllocated.toDouble - resourceUsed.toDouble * 1.5)
       }
 
-      it("doesn't calculate total delay") {
-        result.getTotalDelay should be(0L)
+      it("calculate total delay") {
+        result.getTotalDelay should be(300000L)
       }
       it("sets resource used as 0 when duration is negative") {
         //make the duration negative
@@ -181,6 +230,7 @@ object SparkMetricsAggregatorTest {
     rddBlocks = 0,
     memoryUsed = 0,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,
@@ -197,4 +247,58 @@ object SparkMetricsAggregatorTest {
     peakJvmUsedMemory,
     peakUnifiedMemory = Map.empty
   )
+
+  def newFakeStageData(
+    status: StageStatus,
+    stageId: Int,
+    numCompleteTasks: Int,
+    submissionTime: Option[Date],
+    completionTime: Option[Date],
+    name: String,
+    inputBytes: Long,
+    inputRecords: Long,
+    outputBytes: Long,
+    outputRecords: Long,
+    shuffleReadBytes: Long,
+    shuffleReadRecords: Long,
+    shuffleWriteBytes: Long,
+    shuffleWriteRecords: Long,
+    memoryBytesSpilled: Long,
+    diskBytesSpilled: Long,
+    taskSummary: Option[TaskMetricDistributionsImpl]): StageDataImpl = new StageDataImpl(
+    status,
+    stageId,
+    attemptId = 0,
+    numTasks = numCompleteTasks + 0,
+    numActiveTasks = numCompleteTasks + 0,
+    numCompleteTasks,
+    numFailedTasks = 0,
+    executorRunTime = 0L,
+    executorCpuTime = 0,
+    submissionTime,
+    firstTaskLaunchedTime = None,
+    completionTime,
+    failureReason = None,
+    inputBytes,
+    inputRecords,
+    outputBytes,
+    outputRecords,
+    shuffleReadBytes,
+    shuffleReadRecords,
+    shuffleWriteBytes,
+    shuffleWriteRecords,
+    memoryBytesSpilled,
+    diskBytesSpilled,
+    name,
+    details = "",
+    schedulingPool = "",
+    accumulatorUpdates = Seq.empty,
+    tasks = None,
+    executorSummary = None,
+    peakJvmUsedMemory = None,
+    peakExecutionMemory = None,
+    peakStorageMemory = None,
+    peakUnifiedMemory = None,
+    taskSummary,
+    executorMetricsSummary = None)
 }

--- a/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
+++ b/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
@@ -56,58 +56,16 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
     }
 
     val executorSummaries = Seq(
-      newFakeExecutorSummary(id = "1", totalDuration = 1000000L, Map("jvmUsedMemory" -> 394567123)),
-      newFakeExecutorSummary(id = "2", totalDuration = 3000000L, Map("jvmUsedMemory" -> 23456834))
+      newFakeExecutorSummary(id = "1", totalDuration = 1000000L, totalCores=3,  Map("jvmUsedMemory" -> 394567123)),
+      newFakeExecutorSummary(id = "2", totalDuration = 3000000L, totalCores=3,  Map("jvmUsedMemory" -> 23456834))
 
     )
-
-    val cal = Calendar.getInstance()
-    cal.setTimeInMillis(1550340951000L)
-    val stage1StartTime = cal.getTime
-    val stage1CompletionTime = DateUtils.addMinutes(stage1StartTime, 3)
-
-    val stage2StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 3), 1)
-    val stage2CompletionTime = DateUtils.addMinutes(stage1StartTime, 9)
-
-    val stage3StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 9), 999)
-    val stage3CompletionTime = DateUtils.addMinutes(stage1StartTime, 10)
-
-    val stage4StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 10), 1)
-    val stage4CompletionTime = DateUtils.addMinutes(stage1StartTime, 17)
-
-    val stage5StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 17), 1)
-    val stage5CompletionTime = DateUtils.addMinutes(stage1StartTime, 18)
-
-    val stage6StartTime = DateUtils.addMilliseconds(DateUtils.addMinutes(stage1StartTime, 18), 1)
-    val stage6CompletionTime = DateUtils.addMinutes(stage1StartTime, 30)
-
-    val scheduleStage1Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 1);
-    val scheduleStage2Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 0.7);
-    val scheduleStage3Delay = IndexedSeq(0D, 0D, 0D, 0D, 0D);
-    val scheduleStage4Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 3.0);
-    val scheduleStage5Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 1.0);
-    val scheduleStage6Delay = IndexedSeq(0D, 0D, 0D, 0D, AutoTuner.ONE_MIN * 0D);
-
-    val taskSummary1 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage1Delay, null, null, null, null, null, null, null);
-    val taskSummary2 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage2Delay, null, null, null, null, null, null, null);
-    val taskSummary3 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage3Delay, null, null, null, null, null, null, null);
-    val taskSummary4 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage4Delay, null, null, null, null, null, null, null);
-    val taskSummary5 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage5Delay, null, null, null, null, null, null, null);
-    val taskSummary6 = new TaskMetricDistributionsImpl(null, null, null, null, null, null, null, null, null, scheduleStage6Delay, null, null, null, null, null, null, null);
-    val stageDatas = Seq(
-      newFakeStageData(StageStatus.COMPLETE, 0, 10, Option(stage1StartTime), Option(stage1CompletionTime), "stage1", 1000990929L, 100000L, 2000990929L, 200000L, 4000990929L, 600000L, 24570990929L, 245990929L, 34570990929L, 34570990929L, Option(taskSummary1)),
-      newFakeStageData(StageStatus.SKIPPED, 1, 11, Option(stage2StartTime), Option(stage2CompletionTime), "stage2", 2000990929L, 200000L, 3000990929L, 300000L, 5000990929L, 700000L, 23570990929L, 345990929L, 44570990929L, 44570990929L, Option(taskSummary2)),
-      newFakeStageData(StageStatus.COMPLETE, 2, 12, Option(stage3StartTime), Option(stage3CompletionTime), "stage3", 3000990929L, 300000L, 4000990929L, 400000L, 6000990929L, 800000L, 22570990929L, 445990929L, 54570990929L, 4570990929L, Option(taskSummary3)),
-      newFakeStageData(StageStatus.COMPLETE, 3, 13, Option(stage4StartTime), Option(stage4CompletionTime), "stage4", 4000990929L, 400000L, 5000990929L, 500000L, 7000990929L, 900000L, 21570990929L, 545990929L, 64570990929L, 64570990929L, Option(taskSummary4)),
-      newFakeStageData(StageStatus.COMPLETE, 4, 14, Option(stage5StartTime), Option(stage5CompletionTime), "stage5", 5000990929L, 500000L, 6000990929L, 600000L, 8000990929L, 2000000L, 20570990929L, 645990929L, 74570990929L, 4570990929L, Option(taskSummary5)),
-      newFakeStageData(StageStatus.COMPLETE, 5, 15, Option(stage6StartTime), Option(stage6CompletionTime), "stage6", 6000990929L, 600000L, 7000990929L, 700000L, 9000990929L, 2100000L, 27570990929L, 845990929L, 84570990929L, 84570990929L, Option(taskSummary6)))
-
 
     val restDerivedData = {
       SparkRestDerivedData(
         applicationInfo,
         jobDatas = Seq.empty,
-        stageDatas = stageDatas,
+        stageDatas = Seq.empty,
         executorSummaries = executorSummaries,
         stagesWithFailedTasks = Seq.empty
       )
@@ -122,7 +80,8 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
             "spark.driver.memory" -> "2G",
             "spark.executor.instances" -> "2",
             "spark.executor.memory" -> "4g",
-            "spark.shuffle.memoryFraction" -> "0.5"
+            "spark.shuffle.memoryFraction" -> "0.5",
+            "spark.memoryOverhead.multiplier.percent" -> "15"
           )
         )
         SparkLogDerivedData(environmentUpdate)
@@ -136,18 +95,20 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
       val result = aggregator.getResult
 
       it("calculates resources used (allocated)") {
-        result.getResourceUsed should be(4096000+12288000)
+        result.getResourceUsed should be(6826666)
       }
 
       it("calculates resources wasted") {
-        val resourceAllocated = 4096000+12288000
-        val resourceUsed = 676288+967110
-        result.getResourceWasted should be(resourceAllocated.toDouble - resourceUsed.toDouble * 1.5)
+        val resourceAllocated = 6826666
+        val resourceUsed = 1366999
+        val resourceWasted: Long = (resourceAllocated.toDouble - resourceUsed.toDouble * 1.5).longValue()
+        result.getResourceWasted should be(resourceWasted)
       }
 
-      it("calculate total delay") {
-        result.getTotalDelay should be(300000L)
+      it("doesn't calculate total delay") {
+        result.getTotalDelay should be(0L)
       }
+
       it("sets resource used as 0 when duration is negative") {
         //make the duration negative
         val applicationInfo = {
@@ -223,6 +184,7 @@ object SparkMetricsAggregatorTest {
   def newFakeExecutorSummary(
     id: String,
     totalDuration: Long,
+    totalCores: Int,
     peakJvmUsedMemory: Map[String, Long]
   ): ExecutorSummaryImpl = new ExecutorSummaryImpl(
     id,
@@ -230,7 +192,7 @@ object SparkMetricsAggregatorTest {
     rddBlocks = 0,
     memoryUsed = 0,
     diskUsed = 0,
-    totalCores = 1,
+    totalCores = totalCores,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,
@@ -247,58 +209,4 @@ object SparkMetricsAggregatorTest {
     peakJvmUsedMemory,
     peakUnifiedMemory = Map.empty
   )
-
-  def newFakeStageData(
-    status: StageStatus,
-    stageId: Int,
-    numCompleteTasks: Int,
-    submissionTime: Option[Date],
-    completionTime: Option[Date],
-    name: String,
-    inputBytes: Long,
-    inputRecords: Long,
-    outputBytes: Long,
-    outputRecords: Long,
-    shuffleReadBytes: Long,
-    shuffleReadRecords: Long,
-    shuffleWriteBytes: Long,
-    shuffleWriteRecords: Long,
-    memoryBytesSpilled: Long,
-    diskBytesSpilled: Long,
-    taskSummary: Option[TaskMetricDistributionsImpl]): StageDataImpl = new StageDataImpl(
-    status,
-    stageId,
-    attemptId = 0,
-    numTasks = numCompleteTasks + 0,
-    numActiveTasks = numCompleteTasks + 0,
-    numCompleteTasks,
-    numFailedTasks = 0,
-    executorRunTime = 0L,
-    executorCpuTime = 0,
-    submissionTime,
-    firstTaskLaunchedTime = None,
-    completionTime,
-    failureReason = None,
-    inputBytes,
-    inputRecords,
-    outputBytes,
-    outputRecords,
-    shuffleReadBytes,
-    shuffleReadRecords,
-    shuffleWriteBytes,
-    shuffleWriteRecords,
-    memoryBytesSpilled,
-    diskBytesSpilled,
-    name,
-    details = "",
-    schedulingPool = "",
-    accumulatorUpdates = Seq.empty,
-    tasks = None,
-    executorSummary = None,
-    peakJvmUsedMemory = None,
-    peakExecutionMemory = None,
-    peakStorageMemory = None,
-    peakUnifiedMemory = None,
-    taskSummary,
-    executorMetricsSummary = None)
 }

--- a/test/com/linkedin/drelephant/spark/heuristics/DriverHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/DriverHeuristicTest.scala
@@ -75,6 +75,7 @@ object DriverHeuristicTest {
     rddBlocks = 0,
     memoryUsed = 0,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
@@ -176,6 +176,7 @@ object ExecutorGcHeuristicTest {
     rddBlocks = 0,
     memoryUsed=0,
     diskUsed = 0,
+    totalCores=1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorStorageSpillHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorStorageSpillHeuristicTest.scala
@@ -112,6 +112,7 @@ object ExecutorStorageSpillHeuristicTest {
     rddBlocks = 0,
     memoryUsed=0,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
@@ -242,6 +242,7 @@ object ExecutorsHeuristicTest {
     rddBlocks = 0,
     memoryUsed,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -88,6 +88,7 @@ object JvmUsedMemoryHeuristicTest {
     rddBlocks = 0,
     memoryUsed = 0,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,

--- a/test/com/linkedin/drelephant/spark/heuristics/SparkApplicationMetricsHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/SparkApplicationMetricsHeuristicTest.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.spark.heuristics
+
+import scala.collection.JavaConverters
+import scala.concurrent.duration.Duration
+
+import com.linkedin.drelephant.analysis.{ ApplicationType, Severity }
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
+import com.linkedin.drelephant.spark.data.{ SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData }
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ ApplicationInfoImpl, StageDataImpl }
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
+import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
+import org.scalatest.{ FunSpec, Matchers }
+import java.util.Date
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.TaskMetricDistributions
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.TaskMetricDistributionsImpl
+import java.util.Calendar
+import org.apache.commons.lang3.time.DateUtils
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.TaskMetricDistributionsImpl
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.TaskMetricDistributionsImpl
+import com.linkedin.drelephant.AutoTuner
+
+/**
+ * Test class for Stages Heuristic. It checks whether all the values used in the heuristic are calculated correctly.
+ */
+class SparkApplicationMetricsHeuristicsTest extends FunSpec with Matchers {
+  import SparkApplicationMetricsHeuristicsTest._
+
+  describe("SparkApplicationMetricsHeuristics") {
+    val heuristicConfigurationData = newFakeHeuristicConfigurationData(
+      Map())
+    val sparkApplicationMetricsHeuristics = new SparkApplicationMetricsHeuristics(heuristicConfigurationData)
+
+    val stageDatas = Seq(
+      newFakeStageData(StageStatus.COMPLETE, 0, 10, "stage1", 1000990929L, 100000L, 2000990929L,
+        200000L, 4000990929L, 600000L, 24570990929L, 245990929L, 34570990929L, 34570990929L),
+      newFakeStageData(StageStatus.COMPLETE, 1, 11, "stage2", 2000990929L, 200000L, 3000990929L,
+        300000L, 5000990929L, 700000L, 23570990929L, 345990929L, 44570990929L, 44570990929L),
+      newFakeStageData(StageStatus.COMPLETE, 2, 12, "stage3", 3000990929L, 300000L, 4000990929L,
+        400000L, 6000990929L, 800000L, 22570990929L, 445990929L, 54570990929L, 4570990929L),
+      newFakeStageData(StageStatus.COMPLETE, 3, 13, "stage4", 4000990929L, 400000L, 5000990929L,
+        500000L, 7000990929L, 900000L, 21570990929L, 545990929L, 64570990929L, 64570990929L),
+      newFakeStageData(StageStatus.COMPLETE, 4, 14, "stage5", 5000990929L, 500000L, 6000990929L,
+        600000L, 8000990929L, 2000000L, 20570990929L, 645990929L, 74570990929L, 4570990929L),
+      newFakeStageData(StageStatus.COMPLETE, 5, 15, "stage6", 6000990929L, 600000L, 7000990929L,
+        700000L, 9000990929L, 2100000L, 27570990929L, 845990929L, 84570990929L, 84570990929L))
+
+    val appConfigurationProperties = Map("spark.executor.instances" -> "2")
+
+    describe(".apply") {
+      val data = newFakeSparkApplicationData(stageDatas, appConfigurationProperties)
+      val heuristicResult = sparkApplicationMetricsHeuristics.apply(data)
+      val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
+
+      it("returns the severity") {
+        heuristicResult.getSeverity should be(Severity.NONE)
+      }
+      it("returns the Total Input Size") {
+        heuristicResultDetails.get(0).getValue should be("20032.8308")
+      }
+      it("returns the Total Input Records") {
+        heuristicResultDetails.get(1).getValue should be("2100000")
+      }
+      it("returns the Total Output Size") {
+        heuristicResultDetails.get(2).getValue should be("25 GB")
+      }
+      it("returns the Total Shuffle Read Size") {
+        heuristicResultDetails.get(3).getValue should be("36 GB")
+      }
+      it("returns the Total Shuffle Read Records") {
+        heuristicResultDetails.get(4).getValue should be("7100000")
+      }
+      it("returns the Total Shuffle Write Size") {
+        heuristicResultDetails.get(5).getValue should be("130 GB")
+      }
+      it("returns the Total Shuffle Write Records") {
+        heuristicResultDetails.get(6).getValue should be("3075945574")
+      }
+      it("returns the Total Memory Spill Size") {
+        heuristicResultDetails.get(7).getValue should be("332 GB")
+      }
+      it("returns the Total Disk Spill Size") {
+        heuristicResultDetails.get(8).getValue should be("221 GB")
+      }
+    }
+
+  }
+}
+
+object SparkApplicationMetricsHeuristicsTest {
+  import JavaConverters._
+
+  def newFakeHeuristicConfigurationData(params: Map[String, String] = Map.empty): HeuristicConfigurationData =
+    new HeuristicConfigurationData("heuristic", "class", "view", new ApplicationType("type"), params.asJava)
+
+  def newFakeStageData(
+    status: StageStatus,
+    stageId: Int,
+    numCompleteTasks: Int,
+    name: String,
+    inputBytes: Long,
+    inputRecords: Long,
+    outputBytes: Long,
+    outputRecords: Long,
+    shuffleReadBytes: Long,
+    shuffleReadRecords: Long,
+    shuffleWriteBytes: Long,
+    shuffleWriteRecords: Long,
+    memoryBytesSpilled: Long,
+    diskBytesSpilled: Long): StageDataImpl = new StageDataImpl(
+    status,
+    stageId,
+    attemptId = 0,
+    numTasks = numCompleteTasks + 0,
+    numActiveTasks = numCompleteTasks + 0,
+    numCompleteTasks,
+    numFailedTasks = 0,
+    executorRunTime = 0L,
+    executorCpuTime = 0,
+    submissionTime = None,
+    firstTaskLaunchedTime = None,
+    completionTime = None,
+    failureReason = None,
+    inputBytes,
+    inputRecords,
+    outputBytes,
+    outputRecords,
+    shuffleReadBytes,
+    shuffleReadRecords,
+    shuffleWriteBytes,
+    shuffleWriteRecords,
+    memoryBytesSpilled,
+    diskBytesSpilled,
+    name,
+    details = "",
+    schedulingPool = "",
+    accumulatorUpdates = Seq.empty,
+    tasks = None,
+    executorSummary = None,
+    peakJvmUsedMemory = None,
+    peakExecutionMemory = None,
+    peakStorageMemory = None,
+    peakUnifiedMemory = None,
+    taskSummary = None,
+    executorMetricsSummary = None)
+
+  def newFakeSparkApplicationData(
+    stageDatas: Seq[StageDataImpl],
+    appConfigurationProperties: Map[String, String]): SparkApplicationData = {
+    val appId = "application_1"
+
+    val restDerivedData = SparkRestDerivedData(
+      new ApplicationInfoImpl(appId, name = "app", Seq.empty),
+      jobDatas = Seq.empty,
+      stageDatas = stageDatas,
+      executorSummaries = Seq.empty,
+      stagesWithFailedTasks = Seq.empty)
+
+    val logDerivedData = SparkLogDerivedData(
+      SparkListenerEnvironmentUpdate(Map("Spark Properties" -> appConfigurationProperties.toSeq)))
+
+    SparkApplicationData(appId, restDerivedData, Some(logDerivedData))
+  }
+}

--- a/test/com/linkedin/drelephant/spark/heuristics/SparkTestUtilities.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/SparkTestUtilities.scala
@@ -509,6 +509,7 @@ private [heuristics] object SparkTestUtilities {
     rddBlocks = 0,
     memoryUsed=0,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -138,6 +138,7 @@ object UnifiedMemoryHeuristicTest {
     rddBlocks = 0,
     memoryUsed = 0,
     diskUsed = 0,
+    totalCores = 1,
     activeTasks = 0,
     failedTasks = 0,
     completedTasks = 0,


### PR DESCRIPTION
Changes in this PR:

**Adding a new Heuristic Spark Application Heuristic** 
This heuristic is an informational heuristic. and contains following metrics. 
- Total Input Data Size
- Total Input Records,
- Total Output Data Size
- Total Shuffle Read and Write Bytes
- Total Shuffle Read and Write Records,
- Total Memory Bytes Spilled
- Total Disk Bytes Spilled

**Making changes to use total input data size available for fitness computation of Spark jobs**
Using total input data size from above heuristic in fitness computation of Spark jobs. 

**Making changes to add total delay for Spark jobs**
This features uses stage level schedulerDelay and stage dependencies to come up with total delay. 

**Change in computation for resource usage and resource wastage**
Currently we use total_duration from executor metrics and executor memory to compute resource usage. Total duration is actually based on total core. If for an executor, number of core is 2 and it runs for 10 min, then total duration would be 20 min. This actually inflates the resource usage. In this PR we are dividing the total duration with total cores. 

Testing Done: 
- Analyzed many Spark applications for the heuristics and compared numbers with API numbers. 
- For using input data size for fitness computation tried following test cases:

|Test Case  | Passed|
|------------- | -------------|
|current parameter having fitness greater than existing best parameter | True|
|current parameter having fitness less than existing best parameter|True|
|current parameter zero input size and resource usage less than existing best parameter| True|
|current parameter zero input size and resource usage more than existing best parameter| True|
|existing best parameter zero input size and resource usage more than current parameter| True|
|existing best parameter zero input size and resource usage less than current parameter| True|

- Analyzed resource usage for many Spark application having executors more than one
- Analyzed resource usage for many Spark application having one executor
- Analyzed total delay for many Spark application and matched given numbers from API






