### PR TITLE
Azkaban Job Whitelisting Blacklisting for Auto Tuning

### DIFF
--- a/app-conf/AutoTuningConf.xml
+++ b/app-conf/AutoTuningConf.xml
@@ -23,6 +23,36 @@
     <description>Enable or disable auto tuning</description>
   </property>
   <property>
+    <name>tuning.whitelisting.enabled</name>
+    <value>true</value>
+    <description>Whether to enable whitelisting/blacklisting for Azkaban daemon</description>
+  </property>
+  <property>
+     <name>tuning.performance.report.enabled</name>
+     <value>true</value>
+     <description>Tuning performance report daemon enabled or not </description>
+  </property>
+  <property>
+    <name>tuning.whitelisting.script</name>
+    <value>path/to/whitelisting/script/azkaban_job_whitelisting_blacklisting.py</value>
+    <description>path for whitelisting script</description>
+  </property>
+  <property>
+    <name>whitelisting.daemon.wait.interval.ms</name>
+    <value>86400000</value>
+    <description>Whitelisting interval daemon wait interval</description>
+  </property>
+  <property>
+    <name>performance.report.script</name>
+    <value>path/to/performancereport/script/tuning_performance_reports.py</value>
+    <description>path for whitelisting script</description>
+  </property>
+  <property>
+    <name>performance.report.daemon.wait.interval.ms</name>
+    <value>86400000</value>
+    <description>Tuning Performance report daemon wait interval</description>
+  </property>
+  <property>
     <name>autotuning.default.allowed_max_resource_usage_percent</name>
     <value>150</value>
     <description>Default value for maximum allowed overheard in resource usage (in percent) as compared to the average

--- a/app/com/linkedin/drelephant/AutoTuner.java
+++ b/app/com/linkedin/drelephant/AutoTuner.java
@@ -35,6 +35,7 @@ import controllers.AutoTuningMetricsController;
  */
 public class AutoTuner implements Runnable {
 
+  public static final long ONE_DAY = 24 * 60 * 60 * 1000;
   public static final long ONE_MIN = 60 * 1000;
   public static final long ONE_SEC = 1000L;
 

--- a/app/com/linkedin/drelephant/DrElephant.java
+++ b/app/com/linkedin/drelephant/DrElephant.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
 import com.linkedin.drelephant.analysis.HDFSContext;
+import com.linkedin.drelephant.tuning.TuningPerformanceReportManager;
+import com.linkedin.drelephant.tuning.TuningWhiteListingManager;
 
 
 /**
@@ -29,23 +31,44 @@ import com.linkedin.drelephant.analysis.HDFSContext;
  */
 public class DrElephant extends Thread {
   public static final String AUTO_TUNING_ENABLED = "autotuning.enabled";
+  public static final String TUNING_WHITELISTING_ENABLED = "tuning.whitelisting.enabled";
+  public static final String TUNING_PERFORMANCE_REPORT_ENABLED = "tuning.performance.report.enabled";
   private static final Logger logger = Logger.getLogger(DrElephant.class);
 
   private ElephantRunner _elephant;
   private AutoTuner _autoTuner;
+  private TuningWhiteListingManager tuningWhiteListingManager;
+  private TuningPerformanceReportManager tuningPerformanceReportManager;
   private Thread _autoTunerThread;
+  private Thread tuningWhitelistingThread;
+  private Thread tuningPerformanceReportThread;
 
   private Boolean autoTuningEnabled;
+  private Boolean tuningWhitelistingEnabled;
+  private Boolean tuningPerformanceReportEnabled;
 
   public DrElephant() throws IOException {
     HDFSContext.load();
     Configuration configuration = ElephantContext.instance().getAutoTuningConf();
     autoTuningEnabled = configuration.getBoolean(AUTO_TUNING_ENABLED, false);
+    tuningWhitelistingEnabled = configuration.getBoolean(TUNING_WHITELISTING_ENABLED, false);
+    tuningPerformanceReportEnabled = configuration.getBoolean(TUNING_PERFORMANCE_REPORT_ENABLED, false);
+
     logger.debug("Auto Tuning Configuration: " + configuration.toString());
+
     _elephant = new ElephantRunner();
     if (autoTuningEnabled) {
       _autoTuner = new AutoTuner();
       _autoTunerThread = new Thread(_autoTuner, "Auto Tuner Thread");
+
+      if (tuningWhitelistingEnabled) {
+        tuningWhiteListingManager = new TuningWhiteListingManager();
+        tuningWhitelistingThread = new Thread(tuningWhiteListingManager, "Tuning Whitelisting Thread");
+      }
+      if (tuningPerformanceReportEnabled) {
+        tuningPerformanceReportManager = new TuningPerformanceReportManager();
+        tuningPerformanceReportThread = new Thread(tuningPerformanceReportManager, "Tuning Performance Report Thread");
+      }
     }
   }
 
@@ -54,6 +77,14 @@ public class DrElephant extends Thread {
     if (_autoTunerThread != null) {
       logger.debug("Starting auto tuner thread ");
       _autoTunerThread.start();
+    }
+    if (tuningWhitelistingThread != null) {
+      logger.info("Starting Tuning Whitelisting Thread");
+      tuningWhitelistingThread.start();
+    }
+    if (tuningPerformanceReportThread != null) {
+      logger.info("Starting Tuning Performance Report Thread");
+      tuningPerformanceReportThread.start();
     }
     _elephant.run();
   }
@@ -64,6 +95,12 @@ public class DrElephant extends Thread {
     }
     if (_autoTunerThread != null) {
       _autoTunerThread.interrupt();
+    }
+    if (tuningWhitelistingThread != null) {
+      tuningWhitelistingThread.interrupt();
+    }
+    if (tuningPerformanceReportThread != null) {
+      tuningPerformanceReportThread.interrupt();
     }
   }
 }

--- a/app/com/linkedin/drelephant/tuning/TuningPerformanceReportManager.java
+++ b/app/com/linkedin/drelephant/tuning/TuningPerformanceReportManager.java
@@ -1,17 +1,11 @@
 package com.linkedin.drelephant.tuning;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-
-import com.linkedin.drelephant.AutoTuner;
-import com.linkedin.drelephant.ElephantContext;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
+import com.linkedin.drelephant.AutoTuner;
+import com.linkedin.drelephant.ElephantContext;
+import com.linkedin.drelephant.util.ProcessUtil;
 import com.linkedin.drelephant.util.Utils;
 
 
@@ -46,7 +40,7 @@ public class TuningPerformanceReportManager implements Runnable {
       while (!Thread.currentThread().isInterrupted()) {
         try {
           logger.info("Start: Executing TuningPerformanceReportManager ");
-          executeScript();
+          ProcessUtil.executeScript(pythonPath + " " + tuningPerformanceReportScriptPath);
           logger.info("End: Executing TuningPerformanceReportManager ");
         } catch (Exception e) {
           logger.error("Error in TuningPerformanceReportManager thread ", e);
@@ -56,27 +50,5 @@ public class TuningPerformanceReportManager implements Runnable {
     } catch (Exception e) {
       logger.error("Error in TuningPerformanceReportManager thread ", e);
     }
-  }
-
-  public boolean executeScript() {
-    List<String> error = new ArrayList<String>();
-    try {
-      Process p = Runtime.getRuntime().exec(pythonPath + " " + tuningPerformanceReportScriptPath);
-      logger.info(pythonPath + " " + tuningPerformanceReportScriptPath);
-
-      BufferedReader errorStream = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-      String errorLine;
-      while ((errorLine = errorStream.readLine()) != null) {
-        error.add(errorLine);
-      }
-      if (error.size() != 0) {
-        logger.error("Error in python script running TuningPerformanceReportManager: " + error.toString());
-      } else {
-        return true;
-      }
-    } catch (IOException e) {
-      logger.error("Error in executeScript()", e);
-    }
-    return false;
   }
 }

--- a/app/com/linkedin/drelephant/tuning/TuningPerformanceReportManager.java
+++ b/app/com/linkedin/drelephant/tuning/TuningPerformanceReportManager.java
@@ -1,0 +1,82 @@
+package com.linkedin.drelephant.tuning;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.linkedin.drelephant.AutoTuner;
+import com.linkedin.drelephant.ElephantContext;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.log4j.Logger;
+
+import com.linkedin.drelephant.util.Utils;
+
+
+public class TuningPerformanceReportManager implements Runnable {
+
+  private final Logger logger = Logger.getLogger(getClass());
+
+  private static final String PYTHON27_PATH_CONF = "python27.path";
+  private static final String DEFAULT_PYTHON27_PATH = "python2.7";
+  private static final String DEFAULT_PERFORMANCE_REPORT_SCRIPT_PATH = "./scripts/tuning_performance_reports.py";
+  private static final String PERFORMANCE_REPORT_SCRIPT_PATH = "performance.report.script";
+  public static final String PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL = "performance.report.daemon.wait.interval.ms";
+  public static final long DEFAULT_PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL = AutoTuner.ONE_DAY;
+
+  private String pythonPath = null;
+  private String tuningPerformanceReportScriptPath = null;
+  private Long tuningPerformanceReportInterval;
+
+  public TuningPerformanceReportManager() {
+    Configuration configuration = ElephantContext.instance().getAutoTuningConf();
+    pythonPath = configuration.get(PYTHON27_PATH_CONF, DEFAULT_PYTHON27_PATH);
+    tuningPerformanceReportScriptPath =
+        configuration.get(PERFORMANCE_REPORT_SCRIPT_PATH, DEFAULT_PERFORMANCE_REPORT_SCRIPT_PATH);
+    tuningPerformanceReportInterval =
+        Utils.getNonNegativeLong(configuration, PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL,
+            DEFAULT_PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL);
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (!Thread.currentThread().isInterrupted()) {
+        try {
+          logger.info("Start: Executing TuningPerformanceReportManager ");
+          executeScript();
+          logger.info("End: Executing TuningPerformanceReportManager ");
+        } catch (Exception e) {
+          logger.error("Error in TuningPerformanceReportManager thread ", e);
+        }
+        Thread.sleep(tuningPerformanceReportInterval);
+      }
+    } catch (Exception e) {
+      logger.error("Error in TuningPerformanceReportManager thread ", e);
+    }
+  }
+
+  public boolean executeScript() {
+    List<String> error = new ArrayList<String>();
+    try {
+      Process p = Runtime.getRuntime().exec(pythonPath + " " + tuningPerformanceReportScriptPath);
+      logger.info(pythonPath + " " + tuningPerformanceReportScriptPath);
+
+      BufferedReader errorStream = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+      String errorLine;
+      while ((errorLine = errorStream.readLine()) != null) {
+        error.add(errorLine);
+      }
+      if (error.size() != 0) {
+        logger.error("Error in python script running TuningPerformanceReportManager: " + error.toString());
+      } else {
+        return true;
+      }
+    } catch (IOException e) {
+      logger.error("Error in executeScript()", e);
+    }
+    return false;
+  }
+}

--- a/app/com/linkedin/drelephant/tuning/TuningPerformanceReportManager.java
+++ b/app/com/linkedin/drelephant/tuning/TuningPerformanceReportManager.java
@@ -23,8 +23,8 @@ public class TuningPerformanceReportManager implements Runnable {
   private static final String DEFAULT_PYTHON27_PATH = "python2.7";
   private static final String DEFAULT_PERFORMANCE_REPORT_SCRIPT_PATH = "./scripts/tuning_performance_reports.py";
   private static final String PERFORMANCE_REPORT_SCRIPT_PATH = "performance.report.script";
-  public static final String PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL = "performance.report.daemon.wait.interval.ms";
-  public static final long DEFAULT_PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL = AutoTuner.ONE_DAY;
+  private static final String PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL = "performance.report.daemon.wait.interval.ms";
+  private static final long DEFAULT_PERFORMANCE_REPORT_DAEMON_WAIT_INTERVAL = AutoTuner.ONE_DAY;
 
   private String pythonPath = null;
   private String tuningPerformanceReportScriptPath = null;

--- a/app/com/linkedin/drelephant/tuning/TuningWhiteListingManager.java
+++ b/app/com/linkedin/drelephant/tuning/TuningWhiteListingManager.java
@@ -23,8 +23,8 @@ public class TuningWhiteListingManager implements Runnable {
   private static final String DEFAULT_PYTHON_PATH = "python";
   private static final String DEFAULT_WHITELISTING_SCRIPT_PATH = "./scripts/azkaban_job_whitelisting_blacklisting.py";
   private static final String WHITELISTING_SCRIPT_PATH = "tuning.whitelisting.script";
-  public static final String WHITELISTING_DAEMON_WAIT_INTERVAL = "whitelisting.daemon.wait.interval.ms";
-  public static final long DEFAULT_WHITELISTING_DAEMON_WAIT_INTERVAL = AutoTuner.ONE_DAY;
+  private static final String WHITELISTING_DAEMON_WAIT_INTERVAL = "whitelisting.daemon.wait.interval.ms";
+  private static final long DEFAULT_WHITELISTING_DAEMON_WAIT_INTERVAL = AutoTuner.ONE_DAY;
 
   private String pythonPath = null;
   private String whitelistingScriptPath = null;

--- a/app/com/linkedin/drelephant/tuning/TuningWhiteListingManager.java
+++ b/app/com/linkedin/drelephant/tuning/TuningWhiteListingManager.java
@@ -1,0 +1,81 @@
+package com.linkedin.drelephant.tuning;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.linkedin.drelephant.AutoTuner;
+import com.linkedin.drelephant.ElephantContext;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.log4j.Logger;
+
+import com.linkedin.drelephant.util.Utils;
+
+
+public class TuningWhiteListingManager implements Runnable {
+
+  private final Logger logger = Logger.getLogger(getClass());
+
+  private static final String PYTHON_PATH_CONF = "python.path";
+  private static final String DEFAULT_PYTHON_PATH = "python";
+  private static final String DEFAULT_WHITELISTING_SCRIPT_PATH = "./scripts/azkaban_job_whitelisting_blacklisting.py";
+  private static final String WHITELISTING_SCRIPT_PATH = "tuning.whitelisting.script";
+  public static final String WHITELISTING_DAEMON_WAIT_INTERVAL = "whitelisting.daemon.wait.interval.ms";
+  public static final long DEFAULT_WHITELISTING_DAEMON_WAIT_INTERVAL = AutoTuner.ONE_DAY;
+
+  private String pythonPath = null;
+  private String whitelistingScriptPath = null;
+  private Long whiteListingInterval;
+
+  public TuningWhiteListingManager() {
+    Configuration configuration = ElephantContext.instance().getAutoTuningConf();
+    pythonPath = configuration.get(PYTHON_PATH_CONF, DEFAULT_PYTHON_PATH);
+    whitelistingScriptPath = configuration.get(WHITELISTING_SCRIPT_PATH, DEFAULT_WHITELISTING_SCRIPT_PATH);
+    whiteListingInterval =
+        Utils.getNonNegativeLong(configuration, WHITELISTING_DAEMON_WAIT_INTERVAL,
+            DEFAULT_WHITELISTING_DAEMON_WAIT_INTERVAL);
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (!Thread.currentThread().isInterrupted()) {
+        try {
+          logger.info("Start: Executing TuningWhitelistingManager ");
+          executeScript();
+          logger.info("End: Executing TuningWhitelistingManager ");
+        } catch (Exception e) {
+          logger.error("Error in TuningWhiteListingManager thread ", e);
+        }
+        Thread.sleep(whiteListingInterval);
+      }
+    } catch (Exception e) {
+      logger.error("Error in TuningWhiteListingManager thread ", e);
+    }
+  }
+
+  public boolean executeScript() {
+    List<String> error = new ArrayList<String>();
+    try {
+      Process p = Runtime.getRuntime().exec(pythonPath + " " + whitelistingScriptPath);
+      logger.info(pythonPath + " " + whitelistingScriptPath);
+
+      BufferedReader errorStream = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+      String errorLine;
+      while ((errorLine = errorStream.readLine()) != null) {
+        error.add(errorLine);
+      }
+      if (error.size() != 0) {
+        logger.error("Error in python script running whitelist manager: " + error.toString());
+      } else {
+        return true;
+      }
+    } catch (IOException e) {
+      logger.error("Error in executeScript()", e);
+    }
+    return false;
+  }
+}

--- a/app/com/linkedin/drelephant/tuning/TuningWhiteListingManager.java
+++ b/app/com/linkedin/drelephant/tuning/TuningWhiteListingManager.java
@@ -1,17 +1,11 @@
 package com.linkedin.drelephant.tuning;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-
-import com.linkedin.drelephant.AutoTuner;
-import com.linkedin.drelephant.ElephantContext;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
+import com.linkedin.drelephant.AutoTuner;
+import com.linkedin.drelephant.ElephantContext;
+import com.linkedin.drelephant.util.ProcessUtil;
 import com.linkedin.drelephant.util.Utils;
 
 
@@ -45,7 +39,7 @@ public class TuningWhiteListingManager implements Runnable {
       while (!Thread.currentThread().isInterrupted()) {
         try {
           logger.info("Start: Executing TuningWhitelistingManager ");
-          executeScript();
+          ProcessUtil.executeScript(pythonPath + " " + whitelistingScriptPath);
           logger.info("End: Executing TuningWhitelistingManager ");
         } catch (Exception e) {
           logger.error("Error in TuningWhiteListingManager thread ", e);
@@ -57,25 +51,4 @@ public class TuningWhiteListingManager implements Runnable {
     }
   }
 
-  public boolean executeScript() {
-    List<String> error = new ArrayList<String>();
-    try {
-      Process p = Runtime.getRuntime().exec(pythonPath + " " + whitelistingScriptPath);
-      logger.info(pythonPath + " " + whitelistingScriptPath);
-
-      BufferedReader errorStream = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-      String errorLine;
-      while ((errorLine = errorStream.readLine()) != null) {
-        error.add(errorLine);
-      }
-      if (error.size() != 0) {
-        logger.error("Error in python script running whitelist manager: " + error.toString());
-      } else {
-        return true;
-      }
-    } catch (IOException e) {
-      logger.error("Error in executeScript()", e);
-    }
-    return false;
-  }
 }

--- a/app/com/linkedin/drelephant/util/ProcessUtil.java
+++ b/app/com/linkedin/drelephant/util/ProcessUtil.java
@@ -1,0 +1,38 @@
+package com.linkedin.drelephant.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+
+public class ProcessUtil {
+
+  private static final Logger logger = Logger.getLogger(ProcessUtil.class);
+
+  public static boolean executeScript(String command) {
+    List<String> error = new ArrayList<String>();
+    try {
+      Process p = Runtime.getRuntime().exec(command);
+      logger.info(command);
+
+      BufferedReader errorStream = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+      String errorLine;
+      while ((errorLine = errorStream.readLine()) != null) {
+        error.add(errorLine);
+      }
+      if (error.size() != 0) {
+        logger.error("Error in python script running whitelist manager: " + error.toString());
+      } else {
+        return true;
+      }
+    } catch (IOException e) {
+      logger.error("Error in executeScript()", e);
+    }
+    return false;
+  }
+
+}

--- a/compile.sh
+++ b/compile.sh
@@ -142,12 +142,15 @@ start_script=${project_root}/scripts/start.sh
 stop_script=${project_root}/scripts/stop.sh
 app_conf=${project_root}/app-conf
 pso_dir=${project_root}/scripts/pso
-
+mysql_dir=${project_root}/scripts/mysql
+whitelisting_script=${project_root}/scripts/azkaban_job_whitelisting_blacklisting.py
+tuning_performance_report_script=${project_root}/scripts/tuning_performance_reports.py
 # Echo the value of pwd in the script so that it is clear what is being removed.
 rm -rf ${project_root}/dist
 mkdir dist
 
 play_command $OPTS clean test compile dist
+
 
 cd target/universal
 
@@ -170,6 +173,9 @@ cp -r $app_conf ${DIST_NAME}
 mkdir ${DIST_NAME}/scripts/
 
 cp -r $pso_dir ${DIST_NAME}/scripts/
+cp -r $mysql_dir ${DIST_NAME}/scripts/
+cp $whitelisting_script ${DIST_NAME}/scripts/
+cp $tuning_performance_report_script ${DIST_NAME}/scripts/
 
 zip -r ${DIST_NAME}.zip ${DIST_NAME}
 

--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -10,8 +10,53 @@ CREATE TABLE `tuning_auto_apply_azkaban_rules` (
   `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10000 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=10000;
+
+CREATE TABLE `job_execution_performance` (
+  `job_definition_id` int(10) unsigned NOT NULL COMMENT 'foreign key from job_definition table',
+  `job_suggested_param_set_id` int(10) unsigned NOT NULL,
+  `tuning_algorithm_id` int(10) unsigned NOT NULL COMMENT 'foreign key from tuning_algorithm table. algorithm to be used for tuning this job',
+  `tuning_enabled` tinyint(4) NOT NULL COMMENT 'auto tuning is enabled or not ',
+  `is_param_set_default` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'Is parameter set default',
+  `is_param_set_best` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'Is parameter set best',
+  `is_param_set_suggested` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'Is parameter set suggested',
+  `is_manually_overriden_parameter` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'Is parameter set is manually overriden',
+  `job_execution_id` int(10) unsigned NOT NULL,
+  `execution_state` enum('SUCCEEDED','FAILED','NOT_STARTED','IN_PROGRESS','CANCELLED') NOT NULL COMMENT 'current state of execution of the job ',
+  `fitness` double DEFAULT NULL COMMENT 'fitness of this parameter set',
+  `fitness_type` enum('RU_PER_GB','HEURISTIC_SCORE') DEFAULT NULL,
+  `resource_usage` double DEFAULT NULL COMMENT 'resource usage in GB Hours for this execution of the job',
+  `execution_time` double DEFAULT NULL COMMENT 'execution time excluding delay for this execution of the job',
+  `input_size_in_bytes` bigint(20) DEFAULT NULL COMMENT 'input size in bytes for this execution of the job',
+  `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`job_execution_id`,`job_suggested_param_set_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `job_aggregate_performance` (
+  `job_definition_id` int(10) unsigned NOT NULL COMMENT 'foreign key from job_definition table',
+  `tuning_algorithm_id` int(10) unsigned NOT NULL COMMENT 'foreign key from tuning_algorithm table. algorithm to be used for tuning this job',
+  `default_job_suggested_param_set_id` int(10) unsigned NOT NULL,
+  `best_job_suggested_param_set_id` int(10) unsigned NOT NULL,
+  `default_job_execution_id` int(10) unsigned NOT NULL,
+  `best_job_execution_id` int(10) unsigned NOT NULL,
+  `default_param_fitness` double DEFAULT NULL COMMENT 'fitness before tuning started, fitness for default parameter',
+  `best_param_fitness` double DEFAULT NULL COMMENT 'fitness after tuning ',
+  `fitness_type` enum('RU_PER_GB','HEURISTIC_SCORE') DEFAULT NULL,
+  `default_param_resource_usage` double DEFAULT NULL COMMENT 'resource usage in GB Hours for this execution of the job',
+  `best_param_resource_usage` double DEFAULT NULL COMMENT 'resource usage in GB Hours for this execution of the job',
+  `default_param_execution_time` double DEFAULT NULL COMMENT 'execution time excluding delay for this execution of the job',
+  `best_param_execution_time` double DEFAULT NULL COMMENT 'execution time excluding delay for this execution of the job',
+  `default_param_ru_per_gb_input` double DEFAULT NULL COMMENT 'resource usage in GB Hours for this execution of the job',
+  `best_param_ru_per_gb_input` double DEFAULT NULL COMMENT 'resource usage in GB Hours for this execution of the job',
+  `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`job_definition_id`,`tuning_algorithm_id`)
+) ENGINE=InnoDB;
+
 
 
 # --- !Downs
 DROP TABLE tuning_auto_apply_azkaban_rules;
+DROP TABLE job_execution_performance;
+DROP TABLE job_aggregate_performance;

--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE `tuning_auto_apply_azkaban_rules` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Auto increment unique id',
-  `rule_type` enum('WHITELIST','BLACKLIST') NOT NULL COMMENT 'optimization algorithm name e.g. PSO',
+  `rule_type` enum('WHITELIST','BLACKLIST') NOT NULL COMMENT 'type of the rule, whitelist for enabling, blacklist for disabling auto tuning',
   `project_name` varchar(700) NOT NULL COMMENT 'Azkaban Project Name to be whitelisted',
   `flow_name_expr` varchar(700) NOT NULL COMMENT 'flow name regular expression for whitelist/blacklist',
   `job_name_expr` varchar(700) NOT NULL COMMENT 'job name regular expression for whitelist/blacklist',

--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -10,7 +10,7 @@ CREATE TABLE `tuning_auto_apply_azkaban_rules` (
   `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=100161 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=10000 DEFAULT CHARSET=latin1;
 
 
 # --- !Downs

--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -1,0 +1,17 @@
+# --- !Ups
+
+CREATE TABLE `tuning_auto_apply_azkaban_rules` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Auto increment unique id',
+  `rule_type` enum('WHITELIST','BLACKLIST') NOT NULL COMMENT 'optimization algorithm name e.g. PSO',
+  `project_name` varchar(700) NOT NULL COMMENT 'Azkaban Project Name to be whitelisted',
+  `flow_name_expr` varchar(700) NOT NULL COMMENT 'flow name regular expression for whitelist/blacklist',
+  `job_name_expr` varchar(700) NOT NULL COMMENT 'job name regular expression for whitelist/blacklist',
+  `job_type` enum('PIG','HIVE','SPARK') NOT NULL COMMENT 'Job type e.g. pig, hive, spark',
+  `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=100161 DEFAULT CHARSET=latin1;
+
+
+# --- !Downs
+DROP TABLE tuning_auto_apply_azkaban_rules;

--- a/scripts/azkaban_job_whitelisting_blacklisting.py
+++ b/scripts/azkaban_job_whitelisting_blacklisting.py
@@ -1,0 +1,169 @@
+import mysql.connector
+import json
+import re
+import smtplib
+import logging
+import logging.handlers as handlers
+import sys
+
+
+if len (sys.argv) != 2 :
+    print "Usage: python azkaban_job_whitelisting_blacklisting.py config_file_name "
+    sys.exit (1)
+config_file_name = sys.argv[1]
+
+get_all_tuning_auto_apply_azkaban_rules_query="select rule_type, project_name, flow_name_expr, job_name_expr, job_type from tuning_auto_apply_azkaban_rules"
+get_all_jobs_for_a_project_query = "select jd.id, job_def_id, tjd.auto_apply, ta.job_type from job_definition jd inner join tuning_job_definition tjd on jd.id=tjd.job_definition_id inner join tuning_algorithm ta on tjd.tuning_algorithm_id=ta.id where job_def_id rlike %s"
+update_auto_apply_flag_query="""update tuning_job_definition set auto_apply=%s, updated_ts=current_timestamp where job_definition_id=%s"""
+db_config = None
+conn = None
+updated_job_definition_ids = {}
+updated_job_definition_ids[0]=[]
+updated_job_definition_ids[1]=[]
+BATCH_SIZE = 100
+
+logger=logging.getLogger() 
+logHandler = handlers.RotatingFileHandler('azkaban_job_whitelist.log', maxBytes=1073741824, backupCount=10)
+formatter = logging.Formatter('%(asctime)-12s [%(levelname)s] %(message)s')  
+logHandler.setFormatter(formatter)
+logger.setLevel(logging.INFO) 
+logger.addHandler(logHandler)
+
+logger.info("========================================================================")
+
+def get_mysql_connection():
+	db_config = json.load(open(config_file_name))
+	logger.info(db_config)
+	return mysql.connector.connect(**db_config)
+
+def get_project_name_expr(project_name):
+	return "project=" + project_name + "&"
+
+def get_all_jobs_for_a_project(project_name):
+	jobList = []
+	cursor=conn.cursor(dictionary=True)
+	args = (get_project_name_expr(project_name), )
+	cursor.execute(get_all_jobs_for_a_project_query, args)
+	row=cursor.fetchone()
+	while row is not None: 
+		job_definition_id = row["id"]
+		job_def_id = row["job_def_id"]
+		auto_apply = row["auto_apply"]
+		job_type = row["job_type"]
+		job = Job(job_definition_id, job_def_id, auto_apply, job_type)
+		jobList.append(job)
+		row = cursor.fetchone()
+	return jobList
+
+def get_all_tuning_auto_apply_azkaban_rules():
+	ruleList = {}
+	projectRuleList = None
+	cursor=conn.cursor(dictionary=True)
+	cursor.execute(get_all_tuning_auto_apply_azkaban_rules_query)
+	row=cursor.fetchone()
+	while row is not None: 
+		rule_type = row["rule_type"]
+		project_name = row["project_name"]
+		flow_name_expr = row["flow_name_expr"]
+		job_name_expr = row["job_name_expr"]
+		job_type = row["job_type"]
+		rule=Rule(rule_type, project_name, flow_name_expr, job_name_expr, job_type)
+		if(ruleList.has_key(project_name)):
+			projectRuleList=ruleList[project_name]
+		else : 
+			projectRuleList=[]
+			ruleList[project_name] = projectRuleList
+		projectRuleList.append(rule)
+		row = cursor.fetchone()
+	return ruleList
+
+def update_auto_apply_flag(records_to_update): 
+    try:
+    	conn.autocommit = True 
+    	cursor = conn.cursor()
+    	cursor.executemany(update_auto_apply_flag_query, records_to_update)
+
+    except Exception as e:
+    	conn.rollback()
+    	logger.error(e)
+
+    finally:
+    	cursor.close()
+
+def update_auto_apply_flag_for_jobs(jobs):
+	records_to_update = []
+	for job in jobs : 
+		if job.auto_apply!=job.new_auto_appply:
+			if len(records_to_update) >= BATCH_SIZE : 
+				update_auto_apply_flag(records_to_update)
+				records_to_update = []
+			batch_element = (job.new_auto_appply, job.job_definition_id)
+			updated_job_definition_ids[job.new_auto_appply].append(job.job_definition_id)
+			records_to_update.append(batch_element)
+
+	if len(records_to_update)>0 : 
+		update_auto_apply_flag(records_to_update)
+
+class Job:
+	def __init__(self, _job_definition_id, _job_def_id, _auto_apply, _job_type):
+		self.job_definition_id = _job_definition_id
+		self.job_def_id = _job_def_id
+		self.auto_apply = _auto_apply
+		self.job_type = _job_type
+
+	def set_new_auto_apply_value(self, auto_apply):
+		self.new_auto_appply=auto_apply
+
+	def apply_rules(self, rules):
+		auto_apply=False
+		for rule in rules :
+			if self.job_type == rule.job_type : 
+				pattern = self.get_flow_job_expr(rule)
+				if re.match(pattern, self.job_def_id) :
+					if rule.rule_type=="WHITELIST" : 
+						auto_apply=True 
+					elif rule.rule_type=="BLACKLIST" : 
+						auto_apply=False
+						break
+		return auto_apply
+
+	def get_flow_job_expr(self, rule):
+		pattern=".*flow=" + rule.flow_name_expr + "&job=" + rule.job_name_expr + "$" 
+		return pattern
+
+class Rule:
+	def __init__(self, _rule_type, _project_name, _flow_name_expr, _job_name_expr, _job_type):
+		self.rule_type = _rule_type
+		self.project_name = _project_name
+		self.flow_name_expr = _flow_name_expr
+		self.job_name_expr = _job_name_expr
+		self.job_type = _job_type
+
+	def print_rule(self):
+		logger.info("Rule Type: " + self.rule_type + ", Project Name: " + self.project_name + ", Flow Name Expr: " + self.flow_name_expr + ", Job Name Expr: " + self.job_name_expr + ", Job Type: " + self.job_type)
+
+
+def print_rules(rules):
+	for rule in rules:
+		rule.print_rule()
+
+conn=get_mysql_connection()
+logger.info("mysql connection established")
+
+rulesMap = get_all_tuning_auto_apply_azkaban_rules()
+for project_name, rules in rulesMap.items():
+	jobs=get_all_jobs_for_a_project(project_name)
+	print_rules(rules)
+	for job in jobs:
+		auto_apply=job.apply_rules(rules)
+		job.set_new_auto_apply_value(auto_apply)
+		logger.debug("Auto Apply " + str(auto_apply) + " for job " + str(job.job_definition_id) + " for job ID " + str(job.job_def_id))
+	update_auto_apply_flag_for_jobs(jobs)
+
+conn.close()
+logger.info("Following job definition IDs disabled for auto tuning ")
+logger.info(updated_job_definition_ids[0])
+logger.info("")
+logger.info("Following job definition IDs enabled for auto tuning ")
+logger.info(updated_job_definition_ids[1])
+logger.info("========================================================================")

--- a/scripts/mysql_config.json
+++ b/scripts/mysql_config.json
@@ -1,0 +1,6 @@
+{
+    "database": "db_name",
+    "user":     "user_name",
+    "password": "password",
+    "host":     "hostname"
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -79,7 +79,9 @@ else
   exit 1
 fi
 
+set -a
 source $CONFIG_FILE
+set +a
 
 # db_url, db_name ad db_user must be present in the config file
 check=1

--- a/scripts/tuning_performance_reports.py
+++ b/scripts/tuning_performance_reports.py
@@ -1,0 +1,325 @@
+import mysql.connector
+import json
+import re
+import smtplib
+import logging
+import logging.handlers as handlers
+import sys
+import csv
+import os
+
+get_max_execution_id_query="select coalesce(max(job_execution_id), 0) as max_job_execution_id from job_execution_performance"
+
+update_job_execution_performance_query="""INSERT INTO job_execution_performance 
+            ( 
+                        job_definition_id, 
+                        job_suggested_param_set_id, 
+                        tuning_algorithm_id, 
+                        tuning_enabled, 
+                        is_param_set_default, 
+                        is_param_set_best, 
+                        is_param_set_suggested, 
+                        is_manually_overriden_parameter, 
+                        job_execution_id, 
+                        execution_state, 
+                        fitness, 
+                        fitness_type, 
+                        resource_usage, 
+                        execution_time, 
+                        input_size_in_bytes 
+            ) 
+SELECT     je.job_definition_id, 
+           jsps.id, 
+           jsps.tuning_algorithm_id, 
+           tjeps.tuning_enabled, 
+           jsps.is_param_set_default, 
+           jsps.is_param_set_best, 
+           jsps.is_param_set_suggested, 
+           jsps.is_manually_overriden_parameter, 
+           je.id, 
+           je.execution_state, 
+           jsps.fitness, ( 
+           CASE 
+                      WHEN ( tuning_algorithm_id = 1 
+                             OR tuning_algorithm_id = 3 ) THEN "RU_PER_GB" 
+                      ELSE "HEURISTIC_SCORE" 
+           end) AS fitness_type, 
+           je.resource_usage, 
+           je.execution_time, 
+           je.input_size_in_bytes 
+FROM       tuning_job_execution_param_set tjeps 
+INNER JOIN job_execution je 
+ON         tjeps.job_execution_id=je.id 
+INNER JOIN job_suggested_param_set jsps 
+ON         tjeps.job_suggested_param_set_id = jsps.id 
+WHERE      je.execution_state IN ('SUCCEEDED' , 'FAILED') 
+AND        je.id>%s 
+AND        tjeps.tuning_enabled=1 
+AND		   je.input_size_in_bytes>1
+ON duplicate KEY 
+UPDATE job_definition_id=je.job_definition_id, 
+       job_suggested_param_set_id=jsps.id, 
+       tuning_algorithm_id=jsps.tuning_algorithm_id, 
+       tuning_enabled=tjeps.tuning_enabled, 
+       is_param_set_default=jsps.is_param_set_default, 
+       is_param_set_best=jsps.is_param_set_best, 
+       is_param_set_suggested=jsps.is_param_set_suggested, 
+       is_manually_overriden_parameter=jsps.is_manually_overriden_parameter, 
+       job_execution_id=je.id, 
+       execution_state=je.execution_state, 
+       fitness=jsps.fitness, 
+       fitness_type=VALUES(fitness_type), 
+       resource_usage=je.resource_usage, 
+       execution_time=je.execution_time, 
+       input_size_in_bytes=je.input_size_in_bytes"""
+
+
+get_default_param_job_execution_performance_query="""SELECT jp.job_definition_id,
+       jp.job_suggested_param_set_id,
+       tuning_algorithm_id,
+       tuning_enabled,
+       is_param_set_default,
+       is_param_set_best,
+       is_param_set_suggested,
+       is_manually_overriden_parameter,
+       jp.job_execution_id,
+       execution_state,
+       fitness, 
+	   fitness_type, 
+	   resource_usage, 
+	   execution_time, 
+       input_size_in_bytes
+FROM job_execution_performance jp
+INNER JOIN
+  (SELECT jep.job_definition_id,
+          max(job_execution_id) AS job_execution_id
+   FROM job_execution_performance jep
+   INNER JOIN tuning_job_definition tjd ON jep.job_definition_id=tjd.job_definition_id
+   WHERE tjd.auto_apply=1
+     AND is_param_set_suggested=0
+     AND execution_state="SUCCEEDED"
+   GROUP BY job_definition_id) ids ON jp.job_execution_id=ids.job_execution_id
+ORDER BY job_definition_id"""
+
+
+get_best_param_job_execution_performance_query="""SELECT jp.job_definition_id,
+       jp.job_suggested_param_set_id,
+       tuning_algorithm_id,
+       tuning_enabled,
+       is_param_set_default,
+       is_param_set_best,
+       is_param_set_suggested,
+       is_manually_overriden_parameter,
+       jp.job_execution_id,
+       execution_state,
+       fitness, 
+	   fitness_type, 
+	   resource_usage, 
+	   execution_time, 
+       input_size_in_bytes
+FROM job_execution_performance jp
+INNER JOIN
+  (SELECT jep.job_definition_id,
+          max(job_execution_id) AS job_execution_id
+   FROM job_execution_performance jep
+   INNER JOIN tuning_job_definition tjd ON jep.job_definition_id=tjd.job_definition_id
+   WHERE tjd.auto_apply=1
+     AND is_param_set_suggested=1
+     AND is_param_set_best=1
+     AND execution_state="SUCCEEDED"
+   GROUP BY job_definition_id) ids ON jp.job_execution_id=ids.job_execution_id
+ORDER BY job_definition_id"""
+
+update_job_aggregate_performance_query="""INSERT INTO job_aggregate_performance (job_definition_id, tuning_algorithm_id, default_job_suggested_param_set_id, best_job_suggested_param_set_id, default_job_execution_id, best_job_execution_id, default_param_fitness, best_param_fitness, fitness_type, default_param_resource_usage, best_param_resource_usage, default_param_execution_time, best_param_execution_time, default_param_ru_per_gb_input, best_param_ru_per_gb_input)
+VALUES (%s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s,
+        %s) ON duplicate KEY
+UPDATE job_definition_id =
+VALUES(job_definition_id), tuning_algorithm_id =
+VALUES(tuning_algorithm_id), default_job_suggested_param_set_id =
+VALUES(default_job_suggested_param_set_id), best_job_suggested_param_set_id =
+VALUES(best_job_suggested_param_set_id), default_job_execution_id =
+VALUES(default_job_execution_id), best_job_execution_id =
+VALUES(best_job_execution_id), default_param_fitness =
+VALUES(default_param_fitness), best_param_fitness =
+VALUES(best_param_fitness), fitness_type =
+VALUES(fitness_type), default_param_resource_usage =
+VALUES(default_param_resource_usage), best_param_resource_usage =
+VALUES(best_param_resource_usage), default_param_execution_time =
+VALUES(default_param_execution_time), best_param_execution_time =
+VALUES(best_param_execution_time), default_param_ru_per_gb_input =
+VALUES(default_param_ru_per_gb_input), best_param_ru_per_gb_input =
+VALUES(best_param_ru_per_gb_input)"""
+
+db_config = None
+conn = None
+
+logger=logging.getLogger() 
+logHandler = handlers.RotatingFileHandler('tuning_performance_reports.log', maxBytes=1073741824, backupCount=10)
+formatter = logging.Formatter('%(asctime)-12s [%(levelname)s] %(message)s')  
+logHandler.setFormatter(formatter)
+logger.setLevel(logging.INFO) 
+logger.addHandler(logHandler)
+
+logger.info("========================================================================")
+
+db_url=os.environ['db_url']
+db_name=os.environ['db_name']
+db_user=os.environ['db_user']
+db_password=os.environ['db_password']
+
+def get_mysql_connection():
+        return mysql.connector.connect(user=db_user, password=db_password, host=db_url, database=db_name)
+
+#Get max execution ID of already processed execution 
+def get_max_execution_id():
+	cursor=conn.cursor(dictionary=True)
+	cursor.execute(get_max_execution_id_query)
+	row=cursor.fetchone()
+	max_job_execution_id=0
+	if row is not None: 
+		max_job_execution_id = row["max_job_execution_id"]
+	return max_job_execution_id
+
+# job execution performance records 
+def update_job_execution_performance(max_job_execution_id): 
+    try:
+    	conn.autocommit = True 
+    	cursor = conn.cursor()
+    	args = (max_job_execution_id, )
+    	logger.info("Max Job Execution ID " + str(max_job_execution_id))
+    	cursor.execute(update_job_execution_performance_query, args)
+    	logger.info("Number of records updated " + str(cursor.rowcount))
+
+    except Exception as e:
+    	conn.rollback()
+    	logger.error(e)
+
+    finally:
+	   	cursor.close()
+
+# get job execution performance data
+def get_job_execution_performance(query):
+	jobExecutionMap = {}
+	cursor=conn.cursor(dictionary=True)
+	cursor.execute(query)
+	row=cursor.fetchone()
+	while row is not None: 
+		job_definition_id = row["job_definition_id"]
+		job_suggested_param_set_id = row["job_suggested_param_set_id"]
+		tuning_algorithm_id = row["tuning_algorithm_id"]
+		tuning_enabled = row["tuning_enabled"]
+		is_param_set_default = row["is_param_set_default"]
+		is_param_set_best = row["is_param_set_best"]
+		is_param_set_suggested = row["is_param_set_suggested"]
+		is_manually_overriden_parameter = row["is_manually_overriden_parameter"]
+		job_execution_id = row["job_execution_id"]
+		execution_state = row["execution_state"]
+		fitness = row["fitness"]
+		fitness_type = row["fitness_type"]
+		resource_usage = row["resource_usage"]
+		execution_time = row["execution_time"]
+		input_size_in_bytes = row["input_size_in_bytes"]
+		job_execution_performance = JobExecutionPerformance(job_definition_id, job_suggested_param_set_id, tuning_algorithm_id, tuning_enabled, 
+is_param_set_default, is_param_set_best, is_param_set_suggested, is_manually_overriden_parameter, job_execution_id, execution_state, fitness, fitness_type, resource_usage,execution_time, input_size_in_bytes)
+		jobExecutionMap[job_definition_id] = job_execution_performance
+		row = cursor.fetchone()
+	return jobExecutionMap
+
+#Aggregate performance data 
+def update_job_aggregate_performance(default_param_job_exec_perf_map, best_param_job_exec_perf_map): 
+	job_agg_perf_list=[]
+	for job_definition_id, dpjep in default_param_job_exec_perf_map.items():
+		if best_param_job_exec_perf_map.has_key(job_definition_id):
+			bpjep = best_param_job_exec_perf_map[job_definition_id]
+		else:
+			bpjep = dpjep
+
+		job_aggregate_performance =  (dpjep.job_definition_id, dpjep.tuning_algorithm_id, dpjep.job_suggested_param_set_id, bpjep.job_suggested_param_set_id, dpjep.job_execution_id, bpjep.job_execution_id, dpjep.fitness, bpjep.fitness, dpjep.fitness_type, dpjep.resource_usage, bpjep.resource_usage, 
+dpjep.execution_time, bpjep.execution_time, dpjep.get_ru_per_gb_input(), bpjep.get_ru_per_gb_input())
+		job_agg_perf_list.append(job_aggregate_performance)
+	update_job_aggregate_performance_table(job_agg_perf_list)
+
+# update job aggregate performance table 
+def update_job_aggregate_performance_table(records_to_update): 
+    try:
+    	conn.autocommit = True 
+    	cursor = conn.cursor()
+    	cursor.executemany(update_job_aggregate_performance_query, records_to_update)
+
+    except Exception as e:
+    	conn.rollback()
+    	logger.error(e)
+
+    finally:
+    	cursor.close()
+
+class JobExecutionPerformance:
+	def __init__(self, _job_definition_id, _job_suggested_param_set_id, _tuning_algorithm_id, _tuning_enabled, 
+_is_param_set_default, _is_param_set_best, _is_param_set_suggested, _is_manually_overriden_parameter, _job_execution_id, _execution_state, _fitness, _fitness_type, _resource_usage, _execution_time, _input_size_in_bytes):
+		self.job_definition_id = _job_definition_id
+		self.job_suggested_param_set_id = _job_suggested_param_set_id
+		self.tuning_algorithm_id = _tuning_algorithm_id
+		self.tuning_enabled = _tuning_enabled
+		self.is_param_set_default = _is_param_set_default
+		self.is_param_set_best = _is_param_set_best
+		self.is_param_set_suggested = _is_param_set_suggested
+		self.is_manually_overriden_parameter = _is_manually_overriden_parameter 
+		self.job_execution_id = _job_execution_id
+		self.execution_state = _execution_state
+		self.fitness = _fitness
+		self.fitness_type = _fitness_type
+		self.resource_usage = _resource_usage
+		self.execution_time = _execution_time
+		self.input_size_in_bytes = _input_size_in_bytes
+
+	def get_ru_per_gb_input(self): 
+		if self.input_size_in_bytes != 0:
+			return self.resource_usage / (self.input_size_in_bytes * 1.0 / (1024 * 1024 * 1024))
+		else:
+			return 0
+
+class JobAggregatePerformance: 
+	def __init__(self, _job_definition_id, _tuning_algorithm_id, _default_job_suggested_param_set_id, _best_job_suggested_param_set_id, _default_job_execution_id, _best_job_execution_id, _default_param_fitness, _best_param_fitness, _fitness_type, _default_param_resource_usage, _best_param_resource_usage, 
+_default_param_execution_time, _best_param_execution_time, _default_param_ru_per_gb_input, _best_param_ru_per_gb_input):
+		self.job_definition_id = _job_definition_id
+		self.tuning_algorithm_id = _tuning_algorithm_id
+		self.default_job_suggested_param_set_id = _default_job_suggested_param_set_id
+		self.best_job_suggested_param_set_id = _best_job_suggested_param_set_id
+		self.default_job_execution_id = _default_job_execution_id
+		self.best_job_execution_id = _best_job_execution_id
+		self.default_param_fitness = _default_param_fitness
+		self.best_param_fitness = _best_param_fitness
+		self.fitness_type = _fitness_type
+		self.default_param_resource_usage = _default_param_resource_usage
+		self.best_param_resource_usage = _best_param_resource_usage
+		self.default_param_execution_time = _default_param_execution_time
+		self.best_param_execution_time = _best_param_execution_time
+		self.default_param_ru_per_gb_input = _default_param_ru_per_gb_input
+		self.best_param_ru_per_gb_input = _best_param_ru_per_gb_input
+
+
+conn=get_mysql_connection()
+logger.info("mysql connection established")
+
+max_execution_id = get_max_execution_id()
+update_job_execution_performance(max_execution_id)
+default_param_job_exec_perf_map=get_job_execution_performance(get_default_param_job_execution_performance_query)
+best_param_job_exec_perf_map=get_job_execution_performance(get_best_param_job_execution_performance_query)
+update_job_aggregate_performance(default_param_job_exec_perf_map, best_param_job_exec_perf_map)
+
+conn.close()
+logger.info("========================================================================")
+


### PR DESCRIPTION
This change contains script for whitelisting and blacklisting Azkaban projects for auto tuning. With this user can whitelist or blacklist few projects, flows and jobs using expressions. Once a project is whitelisted, then all jobs for that project which matches expressions given in flow_name_expr and job_name_expr will be enabled for auto tuning. (auto_apply flag enabled). Same way blacklisted jobs will be disabled for auto tuning. 

We can configure rules, which will contain following information:

-   `rule_type` enum('WHITELIST','BLACKLIST') - 'Type of the rule, whitelist or blacklist',
-   `project_name`-  'Azkaban Project Name to be whitelisted',
-   `flow_name_expr` -  'flow name regular expression for whitelist/blacklist',
-   `job_name_expr` -  'job name regular expression for whitelist/blacklist',
-   `job_type` enum('PIG','HIVE','SPARK') - 'Job type e.g. pig, hive, spark',

Any job for which there is a matching rule for blacklist, will be disabled for auto tuning. 
Any job which have matching rule for whitelist and no rule for blacklist, will be enabled for auto tuning. 

Information for rules will be stored in database. This script will run once a day to enable/disable any new jobs or process any new rule. 

