### PR TITLE
Using a separate component for TuneIn details

### DIFF
--- a/web/app/components/tunein-info.js
+++ b/web/app/components/tunein-info.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  showTuneinRecommendations: false,
+  actions: {
+    showTuneinDetails() {
+      this.set("showTuneinRecommendations", true),
+      this.sendAction('action', this.get('param'));
+    }
+  }
+});

--- a/web/app/helpers/or.js
+++ b/web/app/helpers/or.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Ember from 'ember';
+
+/**
+ * This helper takes boolean array and returns true if one or more elements are true else returns false
+ * @param params The boolean array for the helper
+ * @returns {boolean}
+ */
+
+export function or(params) {
+  if (params.length < 2)
+    throw new Error("Handlerbars Helper 'or' needs atleast 2 Boolean parameters");
+  var result = false;
+  for (var i = 0; i < params.length; i++) {
+    result = result || !!params[i];
+  }
+  return result;
+}
+export default Ember.Helper.helper(or);

--- a/web/app/routes/job.js
+++ b/web/app/routes/job.js
@@ -17,10 +17,10 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  ajax: Ember.inject.service(),
   beforeModel: function (transition) {
     this.jobid = transition.queryParams.jobid;
   },
-  ajax: Ember.inject.service(),
 
   model(){
     return Ember.RSVP.hash({
@@ -29,7 +29,7 @@ export default Ember.Route.extend({
     });
   },
   actions: {
-    showRecommendations(jobDefinitionId) {
+    updateShowRecommendationCount(jobDefinitionId) {
       return this.get('ajax').post('/rest/showTuneinParams', {
         contentType: 'application/json; charset=UTF-8',
         data: JSON.stringify({

--- a/web/app/templates/components/tunein-info.hbs
+++ b/web/app/templates/components/tunein-info.hbs
@@ -1,0 +1,89 @@
+{{!--
+
+ Copyright 2016 LinkedIn Corp.
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+
+--}}
+
+ <!--If the jobSuggestedParamSetId is null then we won't show the TuneIn param div
+  as TuneIn params are not present for the job-->
+{{#unless (eq tunein.jobSuggestedParamSetId "null")}}
+  <div class="shadow details-container box">
+    <h4>TuneIn Recommended Parameters</h4>
+    {{#if showTuneinRecommendations}}
+      <hr class="bold-horizontal-line">
+      <table class="table info borderless">
+        <tbody>
+        <tr class="heading">
+          <th>Parameter Name </th>
+          <th>Suggested Value</th>
+          <th>Manual Override</th>
+        </tr>
+        {{#each tunein.tuningParameters as |param|}}
+          <tr>
+            <td class="bold">{{param.name}}</td>
+            <td>{{param.jobSuggestedParamValue}}</td>
+            <td>
+              {{input type="text" class="param-value" value=param.userSuggestedParamValue disabled=true}}
+            </td>
+          </tr>
+        {{/each}}
+        </tbody>
+      </table>
+      <div class="severity-None">*These parameter suggestions are based on latest job execution</div>
+      <hr class="bold-horizontal-line">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-3 heading bold">Auto Tuning</div>
+          <div class="col-sm-3 heading bold">Tuning Algorithm</div>
+          <div class="col-sm-3 heading bold">Number of Iterations</div>
+        </div>
+        <div class="row">
+          <div class="col-sm-3">
+            <label class="switch">
+              {{input type="checkbox" checked=tunein.autoApply disabled=true}}
+              <div class="slider round"></div>
+            </label>
+          </div>
+          <div class="col-sm-3">
+            <select id='soflow' disabled>
+              {{#each tunein.tuningAlgorithmList as |algorithm|}}
+                <option value={{algorithm.name}} selected={{eq algorithm.name tunein.tuningAlgorithm}}>{{algorithm.name}}</option>
+              {{/each}}
+            </select>
+          </div>
+          <div class="col-sm-3">
+            {{input type="text" class="iteration-count" id="form-workflow-id" name="iterationCount" value=tunein.iterationCount disabled=true}}
+          </div>
+
+          <div class="col-sm-3">
+            <button type="submit" class="btn wf-button" disabled title="This funtionality will be available in the next release"> Submit</button>
+          </div>
+        </div>
+      </div>
+      <div class="severity-Critical">Above shown features will be enabled in the next release</div>
+      {{#if (or (eq jobs.severity "None") (eq jobs.severity "Low"))}}
+        <div class="severity-None">All Heuristics Passed with the above mentioned parameters</div>
+      {{/if}}
+      {{#unless (eq tunein.reasonForTuningDisable "NONE")}}
+        <div class="text info-text">Disabling TuneIn for this application as {{tunein.reasonForTuningDisable}}</div>
+      {{/unless}}
+    {{else}}
+      <div class="wrapper">
+        <button class="recommendation-button" {{action "showTuneinDetails"}}>Show TuneIn Recommended Parameters</button>
+      </div>
+    {{/if}}
+    <div class="info-text text-right">For any queries, contact <b>ask_tunein</b></div>
+  </div>
+{{/unless}}

--- a/web/app/templates/job.hbs
+++ b/web/app/templates/job.hbs
@@ -92,75 +92,8 @@
       </tbody>
     </table>
   </div>
-  {{#unless (eq model.tunein.jobSuggestedParamSetId "null")}}
-    <div class="shadow details-container box">
-      <h4>TuneIn Recommended Parameters</h4>
-      {{#if showTuneinRecommendations}}
-        <hr class="bold-horizontal-line">
-        <table class="table info borderless">
-          <tbody>
-          <tr class="heading">
-            <th>Parameter Name</th>
-            <th>Suggested Value</th>
-            <th>Manual Override</th>
-          </tr>
-          {{#each model.tunein.tuningParameters as |tuningParam|}}
-            <tr>
-              <td class="bold">{{tuningParam.name}}</td>
-              <td>{{tuningParam.jobSuggestedParamValue}}</td>
-              <td>
-                {{input type="text" class="param-value" value=tuningParam.userSuggestedParamValue disabled=true}}
-              </td>
-            </tr>
-          {{/each}}
-          </tbody>
-        </table>
-        <div class="severity-None">*These parameter suggestions are based on latest job execution</div>
-        <hr class="bold-horizontal-line">
-        <div class="container">
-          <div class="row">
-            <div class="col-sm-3 heading bold">Auto Tuning</div>
-            <div class="col-sm-3 heading bold">Tuning Algorithm</div>
-            <div class="col-sm-3 heading bold">Number of Iterations</div>
-          </div>
-          <div class="row">
-            <div class="col-sm-3">
-              <label class="switch">
-                {{input type="checkbox" checked=model.tunein.autoApply disabled=true}}
-                <div class="slider round"></div>
-              </label>
-            </div>
-            <div class="col-sm-3">
-              <select id='soflow' disabled>
-                {{#each model.tunein.tuningAlgorithmList as |algorithm|}}
-                  <option value={{algorithm.name}} selected={{eq algorithm.name model.tunein.tuningAlgorithm}}>{{algorithm.name}}</option>
-                {{/each}}
-              </select>
-            </div>
-            <div class="col-sm-3">
-              {{input type="text" class="iteration-count" id="form-workflow-id" name="iterationCount" value=model.tunein.iterationCount disabled=true}}
-            </div>
 
-            <div class="col-sm-3">
-              <button type="submit" class="btn wf-button" disabled title="This will be available in the next release"> Submit</button>
-            </div>
-          </div>
-        </div>
-        <div class="severity-Critical">Above shown features will be enabled in the next release</div>
-        {{#if (eq model.jobs.severity "None")}}
-          <div class="severity-None">All Heuristics Passed with the above mentioned parameters</div>
-        {{/if}}
-        {{#unless (eq model.tunein.reasonForTuningDisable "NONE")}}
-          <div class="text info-text">Disabling TuneIn for this application as {{model.tunein.reasonForTuningDisable}}</div>
-        {{/unless}}
-      {{else}}
-        <div class="wrapper">
-          <button class="recommendation-button" {{action "showRecommendation" model.tunein.jobDefinitionId}}>Show TuneIn Recommended Parameters</button>
-        </div>
-      {{/if}}
-      <div class="info-text text-right">For any queries, contact <b>ask_tunein</b></div>
-    </div>
-  {{/unless}}
+  {{tunein-info tunein=model.tunein action="updateShowRecommendationCount" param=model.tunein.jobDefinitionId}}
 
   <div class="shadow summary-list-container">
     <div class="summary-list-header">Applications</div>

--- a/web/tests/unit/helpers/or-test.js
+++ b/web/tests/unit/helpers/or-test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { or } from 'dr-elephant/helpers/or';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | or');
+
+test('Test for or helper', function(assert) {
+  let result = or([true,false]);
+  assert.ok(result);
+  result = or([false, false])
+  assert.ok(!result);
+  result = or([false, false, false, false, true, false])
+  assert.ok(result);
+  result = or([false, false, false, false, false, false])
+  assert.ok(!result);
+});


### PR DESCRIPTION
**DESCRIPTION**

In this PR the changes are made to the TuneIn's current UI structure. As of now, TuneIn's UI template is part of the Dr.Elephant job page template. Since TuneIn details have their own variables which need to be refreshed on any transition, so it required for TuneIn UI to have their own component. This will help in better management of the variables and also makes it easier to reuse the template for TuneIn in the future if required.

