### PR TITLE
Updating the location for fetching all dtd config files

### DIFF
--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Source Forge//DTD Check Configuration 1.3//EN" "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <!-- *********************** Configurations *********************** -->
   <!-- Filter out non Java files -->

--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <!-- *********************** Configurations *********************** -->
   <!-- Filter out non Java files -->


### PR DESCRIPTION
**DESCRIPTION**
According to https://github.com/checkstyle/checkstyle/issues/1571 the location to fetch **dtds** configs is shifted to SourceForge site and the present path is giving Not Found exception as the file is unavailable at the mentioned location. Updating the file location to the appropriate path.