### PR TITLE
RM application filter changes

### DIFF
--- a/app-conf/elephant.conf
+++ b/app-conf/elephant.conf
@@ -56,3 +56,8 @@ metrics=true
 # Sample configuration of the agent with additional options.
 # metrics_agent_jar="-javaagent:lib/your_agent.jar=app-name=dr-elephant,app-host=foo"
 
+#
+#Filter for applications to be processed. This filter will be applied in API call to RM for getting 
+#applications finished in last window. Useful to restrict applications to be processed. 
+#
+#rm_application_filter="applicationTags=tag1&user=user1&applicationType=SPARK


### PR DESCRIPTION
This change is to add filter in RM application fetch API call. Now users can configure if they want to apply any filters for processing applications. This need to configured in elephant.conf. 

Example: 
rm_application_filter="applicationTags=tag1&user=user1&applicationType=SPARK

Above filter will process application containing applicationTags "tag1" and from "user1" with application type as "SPARK". 

Done testing with trying different filters and with no filters. 