### PR TITLE
Adding a try catch block to make sure thread continue

### DIFF
--- a/app/com/linkedin/drelephant/tuning/AbstractJobStatusManager.java
+++ b/app/com/linkedin/drelephant/tuning/AbstractJobStatusManager.java
@@ -52,12 +52,16 @@ public abstract class AbstractJobStatusManager implements Manager {
       for (TuningJobExecutionParamSet job : jobs) {
         JobSuggestedParamSet jobSuggestedParamSet = job.jobSuggestedParamSet;
         JobExecution jobExecution = job.jobExecution;
-        if (isJobCompleted(jobExecution)) {
-          jobExecution.update();
-          jobSuggestedParamSet.update();
-          logger.info("Execution " + jobExecution.jobExecId + " is completed");
-        } else {
-          logger.info("Execution " + jobExecution.jobExecId + " is still in running state");
+        try{
+          if (isJobCompleted(jobExecution)) {
+            jobExecution.update();
+            jobSuggestedParamSet.update();
+            logger.info("Execution " + jobExecution.jobExecId + " is completed");
+          } else {
+            logger.info("Execution " + jobExecution.jobExecId + " is still in running state");
+          }
+        }catch(Exception e){
+          logger.info("Exception occur while updating database " + e.getMessage());
         }
       }
     } catch (Exception e) {

--- a/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
+++ b/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
@@ -173,7 +173,7 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
       if (disableTuningforUserSpecifiedIterations(jobDefinition, numberOfValidSuggestedParamExecution)
           || disableTuningforHeuristicsPassed(jobDefinition, tuningJobExecutionParamSets,
           numberOfValidSuggestedParamExecution)) {
-        logger.info(" Tuning Disabled for Job " + jobDefinition.id);
+        logger.debug(" Tuning Disabled for Job " + jobDefinition.id);
       }
     }
     Long currentTimeAfter = System.currentTimeMillis();

--- a/test/com/linkedin/drelephant/tuning/JobStatusManagerTestRunner.java
+++ b/test/com/linkedin/drelephant/tuning/JobStatusManagerTestRunner.java
@@ -40,7 +40,7 @@ public class JobStatusManagerTestRunner implements Runnable {
 
     boolean calculateCompletedJobExDone = jobStatusManager.analyzeCompletedJobsExecution(tuningJobExecutionParamSets);
 
-    assertTrue(" Analyize completed job execution ", !calculateCompletedJobExDone);
+    assertTrue(" Analyize completed job execution ", calculateCompletedJobExDone);
 
     boolean updateDatabase = jobStatusManager.updateDataBase(tuningJobExecutionParamSets);
 


### PR DESCRIPTION
Adding a try catch block for database update step, so if there is any failure in database update it should continue updating left over rows. 