### PR TITLE
Persisting the active user's details in HTML local storage

### DIFF
--- a/web/app/routes/job.js
+++ b/web/app/routes/job.js
@@ -121,7 +121,7 @@ export default Ember.Route.extend({
       const cookieName = 'elephant.' + cluster + '.session.id';
       const scheduler = new Scheduler();
       const schedulerUrl = scheduler.getSchedulerUrl(jobDefId, schedulerName);
-      const currentUser = this.get('session').currentUser;
+      const currentUser = this.get('session').getActiveUser();
       if (!Cookies.get(cookieName)) {
         this.doLogin(schedulerUrl, cluster);
       } else {

--- a/web/app/services/session.js
+++ b/web/app/services/session.js
@@ -33,10 +33,23 @@ export default Ember.Service.extend({
     })
   },
   logout(){
-    this.set("currentUser", null)
-    Cookies.remove('userId')
+    this.set("currentUser", null);
   },
   setLoggedInUser(username) {
     this.set("currentUser", username);
+    //saving username to localStorage for persistence even after browser refresh
+    localStorage.setItem('currentUser', username);
+  },
+  getActiveUser(){
+    let activeUser = this.get('currentUser');
+    if (activeUser) {
+      return activeUser;
+    } else {
+      activeUser = localStorage.getItem('currentUser');
+      if (activeUser) {
+        this.set('currentUser', activeUser);
+      }
+      return activeUser;
+    }
   }
 })


### PR DESCRIPTION
**DESCRIPTION**
Currently the username of the active user is saved as an attribute of `Session` service, but the problem is that on the browser refresh the attributes of the service are flushed so on further attempts to update the TuneIn parameters, the username is null. To resolve this we need to persist the username in the HTML local storage which will persist the username even after the page refresh/reload.