### PR TITLE
Skeleton code for TonY jobtype support in Dr. Elephant #553

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ public/assets/ember/
 public/assets/fonts/
 web/bower_components/
 web/node_modules/
+web/package-lock.json

--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -358,7 +358,7 @@
   <!-- TONY HEURISTICS -->
   <heuristic>
     <applicationtype>tony</applicationtype>
-    <heuristicname>TonY Task Memory</heuristicname>
+    <heuristicname>Task Memory</heuristicname>
     <classname>com.linkedin.drelephant.tony.heuristics.TaskMemoryHeuristic</classname>
     <viewname>views.html.help.tony.helpTaskMemory</viewname>
   </heuristic>

--- a/app-conf/JobTypeConf.xml
+++ b/app-conf/JobTypeConf.xml
@@ -90,5 +90,6 @@
     <name>TonY</name>
     <applicationtype>TONY</applicationtype>
     <conf>tony.application.name</conf>
+    <isDefault/>
   </jobType>
 </jobTypes>

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -21,7 +21,9 @@ public class TonyApplicationData implements HadoopApplicationData {
 
   @Override
   public Properties getConf() {
-    return null;
+    Properties props = new Properties();
+    props.put("tony.application.name", "My Awesome Application");
+    return props;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -11,14 +11,9 @@ import org.apache.hadoop.fs.Path;
 public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
   public static final String TONY_CONF_LOCATION = "tony_conf_location";
 
-//  private final Path finishedDir;
-
 
   public TonyFetcher(FetcherConfigurationData fetcherConfData) {
-//    String tonyConfLoc = fetcherConfData.getParamMap().get(TONY_CONF_LOCATION);
-//    Configuration conf = new Configuration();
-//    conf.addResource(new Path(tonyConfLoc));
-//    finishedDir = conf.get("tony.history")
+    // TODO
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -9,15 +9,15 @@ import org.apache.hadoop.fs.Path;
 
 
 public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
-  public static final String TONY_CONF_LOCATION = "tony.conf.location";
+  public static final String TONY_CONF_LOCATION = "tony_conf_location";
 
 //  private final Path finishedDir;
 
 
   public TonyFetcher(FetcherConfigurationData fetcherConfData) {
-    String tonyConfLoc = fetcherConfData.getParamMap().get(TONY_CONF_LOCATION);
-    Configuration conf = new Configuration();
-    conf.addResource(new Path(tonyConfLoc));
+//    String tonyConfLoc = fetcherConfData.getParamMap().get(TONY_CONF_LOCATION);
+//    Configuration conf = new Configuration();
+//    conf.addResource(new Path(tonyConfLoc));
 //    finishedDir = conf.get("tony.history")
   }
 

--- a/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
@@ -20,10 +20,10 @@ import com.linkedin.drelephant.analysis.Heuristic;
 import com.linkedin.drelephant.analysis.HeuristicResult;
 import com.linkedin.drelephant.analysis.Severity;
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
-import com.linkedin.drelephant.mapreduce.data.MapReduceApplicationData;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
 
 
-public class TaskMemoryHeuristic implements Heuristic<MapReduceApplicationData> {
+public class TaskMemoryHeuristic implements Heuristic<TonyApplicationData> {
 
   private HeuristicConfigurationData _heuristicConfData;
 
@@ -32,13 +32,13 @@ public class TaskMemoryHeuristic implements Heuristic<MapReduceApplicationData> 
   }
 
   @Override
-  public HeuristicConfigurationData getHeuristicConfData() {
-    return _heuristicConfData;
+  public HeuristicResult apply(TonyApplicationData data) {
+    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
+        0);
   }
 
   @Override
-  public HeuristicResult apply(MapReduceApplicationData data) {
-    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
-        0);
+  public HeuristicConfigurationData getHeuristicConfData() {
+    return _heuristicConfData;
   }
 }

--- a/compile.sh
+++ b/compile.sh
@@ -437,7 +437,7 @@ play_command $OPTS dist
 cd target/universal
 
 ZIP_NAME=`/bin/ls *.zip`
-unzip ${ZIP_NAME}
+unzip -f ${ZIP_NAME}
 rm ${ZIP_NAME}
 DIST_NAME=${ZIP_NAME%.zip}
 

--- a/test/resources/JobTypeConf.xml
+++ b/test/resources/JobTypeConf.xml
@@ -74,4 +74,9 @@
     <conf>mapred.child.java.opts</conf>
     <isDefault/>
   </jobType>
+  <jobType>
+    <name>TonY</name>
+    <applicationtype>TONY</applicationtype>
+    <conf>tony.application.name</conf>
+  </jobType>
 </jobTypes>


### PR DESCRIPTION
This is just skeleton code with hardcoded values just to plumb through support for TonY jobtype. I now see it in my local Dr. Elephant instance:

<img width="921" alt="tony-support" src="https://user-images.githubusercontent.com/544734/56938943-02814b80-6aba-11e9-9f41-0be1c6cff23d.png">

In follow-up PRs, I will add a proper implementation.

Please ignore commented-out code for now.

I plan to do incremental PRs and merge them into the `tony-fetcher` branch and once support for TonY jobtype is complete, I will send a PR for merging `tony-fetcher` into `master`.