### PR TITLE
Fix for the MapReduce Exception Fingerprinting

### DIFF
--- a/app/com/linkedin/drelephant/exceptions/azkaban/AzkabanJobLogAnalyzer.java
+++ b/app/com/linkedin/drelephant/exceptions/azkaban/AzkabanJobLogAnalyzer.java
@@ -35,11 +35,11 @@ public class AzkabanJobLogAnalyzer {
 
   private static final Logger logger = Logger.getLogger(AzkabanJobLogAnalyzer.class);
   private Pattern _successfulAzkabanJobPattern =
-      Pattern.compile("Finishing job [^\\s]+ attempt: [0-9]+ at [0-9]+ with status SUCCEEDED");
+      Pattern.compile("Finishing job [^\\s]+ at [0-9]+ with status SUCCEEDED");
   private Pattern _failedAzkabanJobPattern =
-      Pattern.compile("Finishing job [^\\s]+ attempt: [0-9]+ at [0-9]+ with status FAILED");
+      Pattern.compile("Finishing job [^\\s]+ at [0-9]+ with status FAILED");
   private Pattern _killedAzkabanJobPattern =
-      Pattern.compile("Finishing job [^\\s]+ attempt: [0-9]+ at [0-9]+ with status KILLED");
+      Pattern.compile("Finishing job [^\\s]+ at [0-9]+ with status KILLED");
   private Pattern _scriptFailPattern = Pattern.compile("ERROR - Job run failed!");
   // Alternate pattern: (".+\\n(?:.+\\tat.+\\n)+(?:.+Caused by.+\\n(?:.*\\n)?(?:.+\\s+at.+\\n)*)*");
   private Pattern _scriptOrMRFailExceptionPattern = Pattern.compile("(Caused by.+\\n(?:.*\\n)?((?:.+\\s+at.+\\n)*))+");

--- a/app/controllers/api/v1/Web.java
+++ b/app/controllers/api/v1/Web.java
@@ -1777,10 +1777,10 @@ public class Web extends Controller {
     HadoopSecurity _hadoopSeverity = HadoopSecurity.getInstance();
 
 
-    logger.info(String.format("scheduler + ", scheduler));
+    logger.info(String.format("scheduler + %s", scheduler));
     if(scheduler==null) {
       scheduler = "azkaban";
-      logger.info(String.format("Setting scheduler ", scheduler));
+      logger.info(String.format("Setting scheduler %s", scheduler));
     }
     if(!InfoExtractor.getSchedulersConfiguredForException().contains(scheduler)) {
       logger.info("scheduler not found ");


### PR DESCRIPTION
**DESCRIPTION**

Currently, Exception Fingerprinting for MapReduce is not working due to the modified Azkaban logs statements at the end of the job. In this PR, changes are made to update the regex patterns for analyzing Azkaban logs.

**TESTING**

Tested changes in the EI instance.

Before the changes: 
<img width="1391" alt="Screen Shot 2019-05-02 at 4 39 33 PM" src="https://user-images.githubusercontent.com/24277980/57071887-72314980-6cf9-11e9-84d6-6aaf270dbd74.png">

After Changes:
<img width="1265" alt="Screen Shot 2019-05-02 at 4 45 40 PM" src="https://user-images.githubusercontent.com/24277980/57072006-d3591d00-6cf9-11e9-9014-0ee6c1bfeefb.png">

 