### PR TITLE
Implement TonY TaskMemoryHeuristic

### DIFF
--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -361,6 +361,12 @@
     <heuristicname>Task Memory</heuristicname>
     <classname>com.linkedin.drelephant.tony.heuristics.TaskMemoryHeuristic</classname>
     <viewname>views.html.help.tony.helpTaskMemory</viewname>
+    <params>
+      <!-- 2048 is the default set in TaskMemoryHeuristic -->
+      <!--container_memory_default_mb>2048</container_memory_default_mb-->
+      <!-- These are the default max memory limits defiend in TaskMemoryHeuristic -->
+      <!--task_memory_thresholds>0.8, 0.7, 0.6, 0.5</task_memory_thresholds-->
+    </params>
   </heuristic>
   <!-- END TONY HEURISTICS -->
 

--- a/app/com/linkedin/drelephant/analysis/HeuristicResult.java
+++ b/app/com/linkedin/drelephant/analysis/HeuristicResult.java
@@ -73,7 +73,7 @@ public class HeuristicResult {
   /**
    * Returns the heuristic analyser class name
    *
-   * @return the heursitic class name
+   * @return the heuristic class name
    */
   public String getHeuristicClassName() {
     return _heuristicClass;

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -12,16 +12,18 @@ import org.apache.hadoop.conf.Configuration;
 public class TonyApplicationData implements HadoopApplicationData {
   private String _appId;
   private ApplicationType _appType;
+  private Configuration _configuration;
   private Properties _props;
   private Map<String, Map<Integer, List<Metric>>> _metricsMap;
 
-  public TonyApplicationData(String appId, ApplicationType appType, Configuration conf,
+  public TonyApplicationData(String appId, ApplicationType appType, Configuration configuration,
       Map<String, Map<Integer, List<Metric>>> metricsMap) {
     _appId = appId;
     _appType = appType;
 
+    _configuration = configuration;
     _props = new Properties();
-    for (Map.Entry<String, String> entry : conf) {
+    for (Map.Entry<String, String> entry : configuration) {
       _props.setProperty(entry.getKey(), entry.getValue());
     }
 
@@ -31,6 +33,10 @@ public class TonyApplicationData implements HadoopApplicationData {
   @Override
   public String getAppId() {
     return _appId;
+  }
+
+  public Configuration getConfiguration() {
+    return _configuration;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LinkedIn Corp.
+ * Copyright 2019 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,28 +13,103 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.linkedin.drelephant.tony.heuristics;
 
 import com.linkedin.drelephant.analysis.Heuristic;
 import com.linkedin.drelephant.analysis.HeuristicResult;
+import com.linkedin.drelephant.analysis.HeuristicResultDetails;
 import com.linkedin.drelephant.analysis.Severity;
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
 import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.drelephant.util.Utils;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Metric;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 
 
+/**
+ * For each type of task (e.g.: worker, ps), this heuristic checks the max memory used across all tasks of that type
+ * and compares against some thresholds. The final severity is the highest severity across all task types.
+ */
 public class TaskMemoryHeuristic implements Heuristic<TonyApplicationData> {
+  private static final int DEFAULT_CONTAINER_MEMORY_MB = 2048;
+  private static final String CONTAINER_MEMORY_DEFAULT_MB_CONF = "container_memory_default_mb";
+  private static final String TASK_MEMORY_THRESHOLDS_CONF = "task_memory_thresholds";
 
   private HeuristicConfigurationData _heuristicConfData;
+  private long defaultContainerMemoryBytes = DEFAULT_CONTAINER_MEMORY_MB * FileUtils.ONE_MB;
+
+  // Initialized to default max memory thresholds
+  private double[] maxMemoryLimits = {0.8, 0.7, 0.6, 0.5};
 
   public TaskMemoryHeuristic(HeuristicConfigurationData heuristicConfData) {
     this._heuristicConfData = heuristicConfData;
+
+    Map<String, String> params = heuristicConfData.getParamMap();
+    // read default container size
+    if (params.containsKey(CONTAINER_MEMORY_DEFAULT_MB_CONF)) {
+      defaultContainerMemoryBytes = Long.parseLong(params.get(CONTAINER_MEMORY_DEFAULT_MB_CONF)) * FileUtils.ONE_MB;
+    }
+    // read max memory thresholds
+    if (params.containsKey(TASK_MEMORY_THRESHOLDS_CONF)) {
+      maxMemoryLimits = Utils.getParam(params.get(TASK_MEMORY_THRESHOLDS_CONF), maxMemoryLimits.length);
+    }
   }
 
   @Override
   public HeuristicResult apply(TonyApplicationData data) {
-    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
-        0);
+    Map<String, Map<Integer, List<Metric>>> metrics = data.getMetricsMap();
+    Configuration conf = data.getConfiguration();
+
+    Set<String> taskTypes = com.linkedin.tony.util.Utils.getAllJobTypes(conf);
+    Severity finalSeverity = Severity.NONE;
+    List<HeuristicResultDetails> details = new ArrayList<>();
+
+    for (String taskType : taskTypes) {
+      // get per task memory requested
+      String memoryString = conf.get(TonyConfigurationKeys.getResourceKey(taskType, Constants.MEMORY));
+      String memoryStringMB = com.linkedin.tony.util.Utils.parseMemoryString(memoryString);
+      long taskBytesRequested = Long.parseLong(memoryStringMB) * FileUtils.ONE_MB;
+      if (taskBytesRequested <= defaultContainerMemoryBytes) {
+        // If using default container memory, automatic pass
+        continue;
+      }
+
+      // get global max memory per task
+      double maxMemoryBytesUsed = 0;
+      for (List<Metric> taskMetrics : metrics.get(taskType).values()) {
+        for (Metric metric : taskMetrics) {
+          if (metric.getName().equals(Constants.MAX_MEMORY_BYTES)) {
+            if (metric.getValue() > maxMemoryBytesUsed) {
+              maxMemoryBytesUsed = metric.getValue();
+            }
+          }
+        }
+      }
+
+      // compare to threshold and update severity
+      double maxMemoryRatio = maxMemoryBytesUsed / taskBytesRequested;
+      Severity taskMemorySeverity = Severity.getSeverityDescending(maxMemoryRatio, maxMemoryLimits[0],
+          maxMemoryLimits[1], maxMemoryLimits[2], maxMemoryLimits[3]);
+      finalSeverity = Severity.max(finalSeverity, taskMemorySeverity);
+
+      // add heuristic details
+      details.add(new HeuristicResultDetails("Number of " + taskType + " tasks",
+          Integer.toString(metrics.get(taskType).size())));
+      details.add(new HeuristicResultDetails("Requested memory (MB) per " + taskType + " task",
+          Long.toString(taskBytesRequested / FileUtils.ONE_MB)));
+      details.add(new HeuristicResultDetails("Max memory (MB) used in any " + taskType + " task",
+          Long.toString((long) maxMemoryBytesUsed / FileUtils.ONE_MB)));
+    }
+
+    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), finalSeverity,
+        0, details);
   }
 
   @Override

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   lazy val jsoupVersion = "1.7.3"
   lazy val mysqlConnectorVersion = "5.1.36"
   lazy val oozieClientVersion = "4.2.0"
-  lazy val tonyVersion = "0.3.4"
+  lazy val tonyVersion = "0.3.5"
 
   lazy val HADOOP_VERSION = "hadoopversion"
   lazy val SPARK_VERSION = "sparkversion"

--- a/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
+++ b/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
@@ -109,7 +109,7 @@ public class TonyFetcherTest {
     TonyFetcher tonyFetcher = new TonyFetcher(configData);
 
     AnalyticJob job = new AnalyticJob();
-    ApplicationType tonyAppType = new ApplicationType("TONY");
+    ApplicationType tonyAppType = new ApplicationType(Constants.APP_TYPE);
     job.setFinishTime(_endDate.getTime());
     job.setAppId(APPLICATION_ID);
     job.setAppType(tonyAppType);

--- a/test/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristicTest.java
+++ b/test/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristicTest.java
@@ -60,8 +60,8 @@ public class TaskMemoryHeuristicTest {
   public void testSevere() {
     testHelper(
         ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
-            1.2e9,
-            1.1e9,
+            1.5e9,
+            1.6e9,
         }, Constants.PS_JOB_NAME, new double[]{1.84e9}),
         ImmutableMap.of(Constants.WORKER_JOB_NAME, "2g", Constants.PS_JOB_NAME, "3g"),
         Severity.SEVERE

--- a/test/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristicTest.java
+++ b/test/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristicTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.drelephant.tony.heuristics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.analysis.HeuristicResult;
+import com.linkedin.drelephant.analysis.Severity;
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Metric;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TaskMemoryHeuristicTest {
+
+  /**
+   * 3g workers requested, max worker memory < 50%
+   */
+  @Test
+  public void testCritical() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+          1.2e9,
+          1.1e9,
+          1e9,
+          1.3e9
+        }, Constants.PS_JOB_NAME, new double[]{0.5e9}),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g", Constants.PS_JOB_NAME, "2g"),
+        Severity.CRITICAL
+    );
+  }
+
+  /**
+   * 3g ps requested, max ps memory < 60%
+   */
+  @Test
+  public void testSevere() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            1.2e9,
+            1.1e9,
+        }, Constants.PS_JOB_NAME, new double[]{1.84e9}),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "2g", Constants.PS_JOB_NAME, "3g"),
+        Severity.SEVERE
+    );
+  }
+
+  /**
+   * 3g workers requested, max worker memory < 70%
+   */
+  @Test
+  public void testModerate() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            2.14e9,
+            2e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g"),
+        Severity.MODERATE
+    );
+  }
+
+  /**
+   * 3g workers requested, max worker memory < 80%
+   */
+  @Test
+  public void testLow() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            2e9,
+            2.45e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g"),
+        Severity.LOW
+    );
+  }
+
+  /**
+   * 3g workers requested, max worker memory > 80%
+   */
+  @Test
+  public void testNone() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            2.5e9,
+            2.6e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g"),
+        Severity.NONE
+    );
+  }
+
+  /**
+   * Low memory utilization but default container size, so pass.
+   */
+  @Test
+  public void testLowUtilizationDefaultContainerSize() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            0.5e9,
+            0.6e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "2g"),
+        Severity.NONE
+    );
+  }
+
+  public void testHelper(Map<String, double[]> memUsed, Map<String, String> memRequested, Severity expectedSeverity) {
+    Configuration conf = new Configuration(false);
+    Map<String, Map<Integer, List<Metric>>> metricsMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : memRequested.entrySet()) {
+      String taskType = entry.getKey();
+      conf.set(TonyConfigurationKeys.getResourceKey(taskType, Constants.MEMORY), entry.getValue());
+      conf.setInt(TonyConfigurationKeys.getInstancesKey(taskType), memUsed.get(taskType).length);
+      metricsMap.put(taskType, new HashMap<>());
+      for (int i = 0; i < memUsed.get(taskType).length; i++) {
+        metricsMap.get(taskType).put(i,
+            ImmutableList.of(new Metric(Constants.MAX_MEMORY_BYTES, memUsed.get(taskType)[i])));
+      }
+    }
+
+    ApplicationType appType = new ApplicationType(Constants.APP_TYPE);
+    TonyApplicationData data = new TonyApplicationData("application_123_456", appType, conf, metricsMap);
+
+    TaskMemoryHeuristic heuristic = new TaskMemoryHeuristic(new HeuristicConfigurationData("ignored",
+        "ignored", "ignored", appType, Collections.EMPTY_MAP));
+    HeuristicResult result = heuristic.apply(data);
+    Assert.assertEquals(expectedSeverity, result.getSeverity());
+  }
+}


### PR DESCRIPTION
* Added a max memory heuristic that does the following: for each task type, compares the max memory used by any of the tasks and compares it against some thresholds. The severity returned is the highest severity across all task types.
* The heuristic will include number of tasks, requested memory, and max memory for each task type.
* If the requested memory for a task type is <= the default container size, severity is NONE for that task type
* The default container size is 2 GB. The default thresholds are 0.5 for CRITICAL, 0.6 for SEVERE, 0.7 for MODERATE, and 0.8 for LOW. If (max memory / requested memory) > 0.8, severity is NONE.
* Added unit tests.