### PR TITLE
Fix NPE bug and print task information even when no metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tmp
 dump
 .history
 /*.iml
+/dr-elephant-*/
 /out
 
 # Eclipse

--- a/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
@@ -62,6 +62,10 @@ public class TonyMetricsAggregator implements HadoopMetricsAggregator {
         long taskDurationSec = (taskData.getTaskEndTime() - taskData.getTaskStartTime()) / Statistics.SECOND_IN_MS;
         mbSecUsed += mbRequested * taskDurationSec;
 
+        if (maxMemoryMBUsed <= 0) {
+          // If we don't have max memory metrics, don't calculate wasted memory.
+          continue;
+        }
         long wastedMemory = (long) (mbRequested - maxMemoryMBUsed * MEMORY_BUFFER);
         if (wastedMemory > 0) {
           mbSecWasted += wastedMemory * taskDurationSec;

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -29,9 +29,11 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
 
 
 public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
+  private static final Logger _LOGGER = Logger.getLogger(TonyFetcher.class);
   private final Path _finishedDir;
   private final FileSystem _fs;
 
@@ -42,16 +44,16 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
     if (fetcherConfig.getParamMap().containsKey(Constants.TONY_CONF_DIR)) {
       tonyConfDir = fetcherConfig.getParamMap().get(Constants.TONY_CONF_DIR);
     }
+    _LOGGER.info("Using TonY conf dir: " + tonyConfDir);
 
     conf.addResource(new Path(tonyConfDir + Path.SEPARATOR + Constants.TONY_SITE_CONF));
     _finishedDir = new Path(conf.get(TonyConfigurationKeys.TONY_HISTORY_FINISHED));
     _fs = _finishedDir.getFileSystem(conf);
   }
 
-
-
   @Override
   public TonyApplicationData fetchData(AnalyticJob job) throws Exception {
+    _LOGGER.debug("Fetching data for job " + job.getAppId());
     long finishTime = job.getFinishTime();
     Date date = new Date(finishTime);
 
@@ -62,6 +64,7 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
     // In case we don't find the history files in yyyy/MM/dd, we should check the previous day as well.
     String yearMonthDay = ParserUtils.getYearMonthDayDirectory(date);
     Path jobDir = new Path(_finishedDir, yearMonthDay + Path.SEPARATOR + job.getAppId());
+    _LOGGER.debug("Job directory for " + job.getAppId() + ": " + jobDir);
 
     // parse config
     Path confFile = new Path(jobDir, Constants.TONY_FINAL_XML);

--- a/app/com/linkedin/drelephant/tony/util/TonyUtils.java
+++ b/app/com/linkedin/drelephant/tony/util/TonyUtils.java
@@ -3,6 +3,7 @@ package com.linkedin.drelephant.tony.util;
 import com.linkedin.drelephant.tony.data.TonyTaskData;
 import com.linkedin.tony.Constants;
 import com.linkedin.tony.events.Metric;
+import java.util.List;
 import java.util.Map;
 
 
@@ -10,7 +11,11 @@ public class TonyUtils {
   public static double getMaxMemoryBytesUsedForTaskType(Map<String, Map<Integer, TonyTaskData>> taskMap, String taskType) {
     double maxMemoryBytesUsed = 0;
     for (TonyTaskData taskData : taskMap.get(taskType).values()) {
-      for (Metric metric : taskData.getMetrics()) {
+      List<Metric> metrics = taskData.getMetrics();
+      if (metrics == null) {
+        return -1;
+      }
+      for (Metric metric : metrics) {
         if (metric.getName().equals(Constants.MAX_MEMORY_BYTES)) {
           if (metric.getValue() > maxMemoryBytesUsed) {
             maxMemoryBytesUsed = metric.getValue();

--- a/compile.sh
+++ b/compile.sh
@@ -427,7 +427,7 @@ if [ $run_StyleChecks = "y" ]; then
 fi
 
 set -v
-set -x
+set -ex
 # Echo the value of pwd in the script so that it is clear what is being removed.
 rm -rf ${project_root}/dist
 mkdir dist
@@ -436,8 +436,8 @@ play_command $OPTS dist
 
 cd target/universal
 
-ZIP_NAME=`/bin/ls *.zip`
-unzip -of ${ZIP_NAME}
+ZIP_NAME=`ls *.zip`
+unzip -o ${ZIP_NAME}
 rm ${ZIP_NAME}
 DIST_NAME=${ZIP_NAME%.zip}
 
@@ -452,7 +452,7 @@ cp $stop_script ${DIST_NAME}/bin/
 
 cp -r $app_conf ${DIST_NAME}
 
-mkdir ${DIST_NAME}/scripts/
+mkdir -p ${DIST_NAME}/scripts/
 
 cp -r $pso_dir ${DIST_NAME}/scripts/
 


### PR DESCRIPTION
* Fixed NPE when no metrics (The `ProcfsBasedProcessTree` that TonY uses only works on Mac but not Linux, so when running TonY on Mac, there are no memory metrics.)
* Updated logic so even when there are no metrics, we still print info like number of worker tasks and memory requested per worker task.

<img width="924" alt="tony-job" src="https://user-images.githubusercontent.com/544734/57483285-5549c880-725b-11e9-88d0-a84ea568c035.png">
