### PR TITLE
Fix #553: Add support for TonY jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ public/assets/ember/
 public/assets/fonts/
 web/bower_components/
 web/node_modules/
+web/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # general
 *~
 *.log
+dr_elephant.log.*
 tmp
 dump
 .history

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tmp
 dump
 .history
 /*.iml
+/dr-elephant-*/
 /out
 
 # Eclipse

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 sudo: true
 jdk:
   - oraclejdk8
-  - openjdk7
 python: "2.6"
 install:
   - sudo pip install inspyred

--- a/app-conf/AggregatorConf.xml
+++ b/app-conf/AggregatorConf.xml
@@ -44,4 +44,8 @@
       <allocated_memory_waste_buffer_percentage>0.5</allocated_memory_waste_buffer_percentage>
     </params>
   </aggregator>
+  <aggregator>
+    <applicationtype>tony</applicationtype>
+    <classname>com.linkedin.drelephant.tony.TonyMetricsAggregator</classname>
+  </aggregator>
 </aggregators>

--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -116,4 +116,8 @@
     </params>
   </fetcher>
   -->
+  <fetcher>
+    <applicationtype>tony</applicationtype>
+    <classname>com.linkedin.drelephant.tony.fetchers.TonyFetcher</classname>
+  </fetcher>
 </fetchers>

--- a/app-conf/FetcherConf.xml
+++ b/app-conf/FetcherConf.xml
@@ -116,8 +116,13 @@
     </params>
   </fetcher>
   -->
-  <fetcher>
+
+  <!--
+    Fetcher for TonY jobs. To use this, you must set the TONY_CONF_DIR environment variable to the directory
+    containing the tony-site.xml file.
+  -->
+  <!--fetcher>
     <applicationtype>tony</applicationtype>
     <classname>com.linkedin.drelephant.tony.fetchers.TonyFetcher</classname>
-  </fetcher>
+  </fetcher-->
 </fetchers>

--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -358,7 +358,7 @@
   <!-- TONY HEURISTICS -->
   <heuristic>
     <applicationtype>tony</applicationtype>
-    <heuristicname>TonY Task Memory</heuristicname>
+    <heuristicname>Task Memory</heuristicname>
     <classname>com.linkedin.drelephant.tony.heuristics.TaskMemoryHeuristic</classname>
     <viewname>views.html.help.tony.helpTaskMemory</viewname>
   </heuristic>

--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -361,6 +361,12 @@
     <heuristicname>Task Memory</heuristicname>
     <classname>com.linkedin.drelephant.tony.heuristics.TaskMemoryHeuristic</classname>
     <viewname>views.html.help.tony.helpTaskMemory</viewname>
+    <params>
+      <!-- 2048 is the default set in TaskMemoryHeuristic -->
+      <!--container_memory_default_mb>2048</container_memory_default_mb-->
+      <!-- These are the default max memory limits defiend in TaskMemoryHeuristic -->
+      <!--task_memory_thresholds>0.8, 0.7, 0.6, 0.5</task_memory_thresholds-->
+    </params>
   </heuristic>
   <!-- END TONY HEURISTICS -->
 

--- a/app-conf/HeuristicConf.xml
+++ b/app-conf/HeuristicConf.xml
@@ -354,4 +354,14 @@
     <viewname>views.html.help.spark.helpExecutorGcHeuristic</viewname>
   </heuristic>
 
+
+  <!-- TONY HEURISTICS -->
+  <heuristic>
+    <applicationtype>tony</applicationtype>
+    <heuristicname>TonY Task Memory</heuristicname>
+    <classname>com.linkedin.drelephant.tony.heuristics.TaskMemoryHeuristic</classname>
+    <viewname>views.html.help.tony.helpTaskMemory</viewname>
+  </heuristic>
+  <!-- END TONY HEURISTICS -->
+
 </heuristics>

--- a/app-conf/JobTypeConf.xml
+++ b/app-conf/JobTypeConf.xml
@@ -90,5 +90,6 @@
     <name>TonY</name>
     <applicationtype>TONY</applicationtype>
     <conf>tony.application.name</conf>
+    <isDefault/>
   </jobType>
 </jobTypes>

--- a/app-conf/JobTypeConf.xml
+++ b/app-conf/JobTypeConf.xml
@@ -86,4 +86,9 @@
     <conf>mapred.child.java.opts</conf>
     <isDefault/>
   </jobType>
+  <jobType>
+    <name>TonY</name>
+    <applicationtype>TONY</applicationtype>
+    <conf>tony.application.name</conf>
+  </jobType>
 </jobTypes>

--- a/app/com/linkedin/drelephant/analysis/HeuristicResult.java
+++ b/app/com/linkedin/drelephant/analysis/HeuristicResult.java
@@ -73,7 +73,7 @@ public class HeuristicResult {
   /**
    * Returns the heuristic analyser class name
    *
-   * @return the heursitic class name
+   * @return the heuristic class name
    */
   public String getHeuristicClassName() {
     return _heuristicClass;

--- a/app/com/linkedin/drelephant/analysis/HeuristicResult.java
+++ b/app/com/linkedin/drelephant/analysis/HeuristicResult.java
@@ -40,7 +40,7 @@ public class HeuristicResult {
    * Heuristic Result Constructor
    *
    * @param heuristicClass The Heuristic class
-   * @param heuristicName The name of the Heursitic
+   * @param heuristicName The name of the Heuristic
    * @param severity The severity of the result
    * @param score The computed score
    */

--- a/app/com/linkedin/drelephant/mapreduce/TaskLevelAggregatedMetrics.java
+++ b/app/com/linkedin/drelephant/mapreduce/TaskLevelAggregatedMetrics.java
@@ -142,7 +142,7 @@ public class TaskLevelAggregatedMetrics {
     }
 
     // wastedResources
-    long wastedMemory = containerSize -  (long) (peakMemoryNeed * MEMORY_BUFFER); // give a 50% buffer
+    long wastedMemory = containerSize - (long) (peakMemoryNeed * MEMORY_BUFFER); // give a 50% buffer
     if(wastedMemory > 0) {
       for (long duration : durations) {
         _resourceWasted += (wastedMemory) * (duration / Statistics.SECOND_IN_MS); // MB Seconds

--- a/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
@@ -37,6 +37,10 @@ public class TonyMetricsAggregator implements HadoopMetricsAggregator {
 
   private HadoopAggregatedData _hadoopAggregatedData;
 
+  /**
+   * Creates a new {@code TonyMetricsAggregator}.
+   * @param unused  Dr. Elephant expects a constructor of this form but {@code TonyMetricsAggregator} does not need this
+   */
   public TonyMetricsAggregator(AggregatorConfigurationData unused) { }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
@@ -1,26 +1,81 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.linkedin.drelephant.tony;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.drelephant.analysis.HadoopAggregatedData;
 import com.linkedin.drelephant.analysis.HadoopApplicationData;
 import com.linkedin.drelephant.analysis.HadoopMetricsAggregator;
 import com.linkedin.drelephant.configurations.aggregator.AggregatorConfigurationData;
+import com.linkedin.drelephant.math.Statistics;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.drelephant.tony.data.TonyTaskData;
+import com.linkedin.drelephant.tony.util.TonyUtils;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 
 
 public class TonyMetricsAggregator implements HadoopMetricsAggregator {
-  public TonyMetricsAggregator(AggregatorConfigurationData _aggregatorConfigurationData) {
-  }
+  @VisibleForTesting
+  static final double MEMORY_BUFFER = 1.5;
+
+  private HadoopAggregatedData _hadoopAggregatedData;
+
+  public TonyMetricsAggregator(AggregatorConfigurationData unused) { }
 
   @Override
   public void aggregate(HadoopApplicationData data) {
-    // TODO
+    _hadoopAggregatedData = new HadoopAggregatedData();
+
+    TonyApplicationData tonyData = (TonyApplicationData) data;
+    Configuration tonyConf = tonyData.getConfiguration();
+
+    long mbSecUsed = 0;
+    long mbSecWasted = 0;
+
+    Map<String, Map<Integer, TonyTaskData>> taskMap = tonyData.getTaskMap();
+    for (Map.Entry<String, Map<Integer, TonyTaskData>> entry : taskMap.entrySet()) {
+      String taskType = entry.getKey();
+
+      String memoryString = tonyConf.get(TonyConfigurationKeys.getResourceKey(taskType, Constants.MEMORY));
+      String memoryStringMB = com.linkedin.tony.util.Utils.parseMemoryString(memoryString);
+      long mbRequested = Long.parseLong(memoryStringMB);
+      double maxMemoryMBUsed = TonyUtils.getMaxMemoryBytesUsedForTaskType(taskMap, taskType) / FileUtils.ONE_MB;
+
+      for (TonyTaskData taskData : entry.getValue().values()) {
+        long taskDurationSec = (taskData.getTaskEndTime() - taskData.getTaskStartTime()) / Statistics.SECOND_IN_MS;
+        mbSecUsed += mbRequested * taskDurationSec;
+
+        long wastedMemory = (long) (mbRequested - maxMemoryMBUsed * MEMORY_BUFFER);
+        if (wastedMemory > 0) {
+          mbSecWasted += wastedMemory * taskDurationSec;
+        }
+      }
+    }
+
+    _hadoopAggregatedData.setResourceUsed(mbSecUsed);
+    _hadoopAggregatedData.setResourceWasted(mbSecWasted);
+    // TODO: Calculate and set delay
   }
 
   @Override
   public HadoopAggregatedData getResult() {
-    HadoopAggregatedData data = new HadoopAggregatedData();
-    data.setResourceUsed(1);
-    data.setResourceWasted(1);
-    data.setTotalDelay(1);
-    return data;
+    return _hadoopAggregatedData;
   }
 }

--- a/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
@@ -62,6 +62,10 @@ public class TonyMetricsAggregator implements HadoopMetricsAggregator {
         long taskDurationSec = (taskData.getTaskEndTime() - taskData.getTaskStartTime()) / Statistics.SECOND_IN_MS;
         mbSecUsed += mbRequested * taskDurationSec;
 
+        if (maxMemoryMBUsed <= 0) {
+          // If we don't have max memory metrics, don't calculate wasted memory.
+          continue;
+        }
         long wastedMemory = (long) (mbRequested - maxMemoryMBUsed * MEMORY_BUFFER);
         if (wastedMemory > 0) {
           mbSecWasted += wastedMemory * taskDurationSec;

--- a/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
+++ b/app/com/linkedin/drelephant/tony/TonyMetricsAggregator.java
@@ -1,0 +1,26 @@
+package com.linkedin.drelephant.tony;
+
+import com.linkedin.drelephant.analysis.HadoopAggregatedData;
+import com.linkedin.drelephant.analysis.HadoopApplicationData;
+import com.linkedin.drelephant.analysis.HadoopMetricsAggregator;
+import com.linkedin.drelephant.configurations.aggregator.AggregatorConfigurationData;
+
+
+public class TonyMetricsAggregator implements HadoopMetricsAggregator {
+  public TonyMetricsAggregator(AggregatorConfigurationData _aggregatorConfigurationData) {
+  }
+
+  @Override
+  public void aggregate(HadoopApplicationData data) {
+    // TODO
+  }
+
+  @Override
+  public HadoopAggregatedData getResult() {
+    HadoopAggregatedData data = new HadoopAggregatedData();
+    data.setResourceUsed(1);
+    data.setResourceWasted(1);
+    data.setTotalDelay(1);
+    return data;
+  }
+}

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -1,0 +1,36 @@
+package com.linkedin.drelephant.tony.data;
+
+import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.analysis.HadoopApplicationData;
+import java.util.Properties;
+
+
+public class TonyApplicationData implements HadoopApplicationData {
+  private String _appId;
+  private ApplicationType _appType;
+
+  public TonyApplicationData(String appId, ApplicationType appType) {
+    _appId = appId;
+    _appType = appType;
+  }
+
+  @Override
+  public String getAppId() {
+    return _appId;
+  }
+
+  @Override
+  public Properties getConf() {
+    return null;
+  }
+
+  @Override
+  public ApplicationType getApplicationType() {
+    return _appType;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+}

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -35,6 +35,13 @@ public class TonyApplicationData implements HadoopApplicationData {
   private Properties _props;
   private Map<String, Map<Integer, TonyTaskData>> _taskMap;
 
+  /**
+   * Constructor for {@code TonyApplicationData}.
+   * @param appId  application id
+   * @param appType  application type (should be TONY)
+   * @param configuration  the configuration for this application
+   * @param events  the events emitted by this application
+   */
   public TonyApplicationData(String appId, ApplicationType appType, Configuration configuration, List<Event> events) {
     _appId = appId;
     _appType = appType;
@@ -54,6 +61,10 @@ public class TonyApplicationData implements HadoopApplicationData {
     return _appId;
   }
 
+  /**
+   * Returns the {@link Configuration} for this application.
+   * @return  the configuration for this application
+   */
   public Configuration getConfiguration() {
     return _configuration;
   }
@@ -68,6 +79,10 @@ public class TonyApplicationData implements HadoopApplicationData {
     return _appType;
   }
 
+  /**
+   * Returns a map of task data.
+   * @return  a map from task type to a map of task index to task data
+   */
   public Map<String, Map<Integer, TonyTaskData>> getTaskMap() {
     return _taskMap;
   }

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.linkedin.drelephant.tony.data;
 
 import com.linkedin.drelephant.analysis.ApplicationType;

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -2,16 +2,30 @@ package com.linkedin.drelephant.tony.data;
 
 import com.linkedin.drelephant.analysis.ApplicationType;
 import com.linkedin.drelephant.analysis.HadoopApplicationData;
+import com.linkedin.tony.events.Metric;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
 
 
 public class TonyApplicationData implements HadoopApplicationData {
   private String _appId;
   private ApplicationType _appType;
+  private Properties _props;
+  private Map<String, Map<Integer, List<Metric>>> _metricsMap;
 
-  public TonyApplicationData(String appId, ApplicationType appType) {
+  public TonyApplicationData(String appId, ApplicationType appType, Configuration conf,
+      Map<String, Map<Integer, List<Metric>>> metricsMap) {
     _appId = appId;
     _appType = appType;
+
+    _props = new Properties();
+    for (Map.Entry<String, String> entry : conf) {
+      _props.setProperty(entry.getKey(), entry.getValue());
+    }
+
+    _metricsMap = metricsMap;
   }
 
   @Override
@@ -21,14 +35,16 @@ public class TonyApplicationData implements HadoopApplicationData {
 
   @Override
   public Properties getConf() {
-    Properties props = new Properties();
-    props.put("tony.application.name", "My Awesome Application");
-    return props;
+    return _props;
   }
 
   @Override
   public ApplicationType getApplicationType() {
     return _appType;
+  }
+
+  public Map<String, Map<Integer, List<Metric>>> getMetricsMap() {
+    return _metricsMap;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -12,16 +12,18 @@ import org.apache.hadoop.conf.Configuration;
 public class TonyApplicationData implements HadoopApplicationData {
   private String _appId;
   private ApplicationType _appType;
+  private Configuration _configuration;
   private Properties _props;
   private Map<String, Map<Integer, List<Metric>>> _metricsMap;
 
-  public TonyApplicationData(String appId, ApplicationType appType, Configuration conf,
+  public TonyApplicationData(String appId, ApplicationType appType, Configuration configuration,
       Map<String, Map<Integer, List<Metric>>> metricsMap) {
     _appId = appId;
     _appType = appType;
 
+    _configuration = configuration;
     _props = new Properties();
-    for (Map.Entry<String, String> entry : conf) {
+    for (Map.Entry<String, String> entry : configuration) {
       _props.setProperty(entry.getKey(), entry.getValue());
     }
 
@@ -31,6 +33,10 @@ public class TonyApplicationData implements HadoopApplicationData {
   @Override
   public String getAppId() {
     return _appId;
+  }
+
+  public Configuration getConfiguration() {
+    return _configuration;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyApplicationData.java
@@ -21,7 +21,9 @@ public class TonyApplicationData implements HadoopApplicationData {
 
   @Override
   public Properties getConf() {
-    return null;
+    Properties props = new Properties();
+    props.put("tony.application.name", "My Awesome Application");
+    return props;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/data/TonyTaskData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyTaskData.java
@@ -27,31 +27,61 @@ public class TonyTaskData {
   private long _taskEndTime;
   private List<Metric> _metrics;
 
+  /**
+   * Creates a new {@code TonyTaskData} encapsulating a task's data, such as task type, index, start time,
+   * end time, and metrics.
+   * @param taskType  the task type
+   * @param taskIndex  the task index
+   */
   public TonyTaskData(String taskType, int taskIndex) {
     _taskType = taskType;
     _taskIndex = taskIndex;
   }
 
+  /**
+   * Get task start time.
+   * @return  the task start time
+   */
   public long getTaskStartTime() {
     return _taskStartTime;
   }
 
+  /**
+   * Set task start time.
+   * @param taskStartTime  the task start time
+   */
   public void setTaskStartTime(long taskStartTime) {
     _taskStartTime = taskStartTime;
   }
 
+  /**
+   * Get task end time.
+   * @return  the task end time
+   */
   public long getTaskEndTime() {
     return _taskEndTime;
   }
 
+  /**
+   * Set task end time.
+   * @param taskEndTime  the end time
+   */
   public void setTaskEndTime(long taskEndTime) {
     _taskEndTime = taskEndTime;
   }
 
+  /**
+   * Get the metrics for this task.
+   * @return  the metrics
+   */
   public List<Metric> getMetrics() {
     return _metrics;
   }
 
+  /**
+   * Sets the metrics for this task.
+   * @param metrics  the metrics
+   */
   public void setMetrics(List<Metric> metrics) {
     _metrics = metrics;
   }

--- a/app/com/linkedin/drelephant/tony/data/TonyTaskData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyTaskData.java
@@ -1,0 +1,43 @@
+package com.linkedin.drelephant.tony.data;
+
+import com.linkedin.tony.events.Metric;
+import java.util.List;
+
+
+public class TonyTaskData {
+  private final String _taskType;
+  private final int _taskIndex;
+
+  private long _taskStartTime;
+  private long _taskEndTime;
+  private List<Metric> _metrics;
+
+  public TonyTaskData(String taskType, int taskIndex) {
+    _taskType = taskType;
+    _taskIndex = taskIndex;
+  }
+
+  public long getTaskStartTime() {
+    return _taskStartTime;
+  }
+
+  public void setTaskStartTime(long taskStartTime) {
+    _taskStartTime = taskStartTime;
+  }
+
+  public long getTaskEndTime() {
+    return _taskEndTime;
+  }
+
+  public void setTaskEndTime(long taskEndTime) {
+    _taskEndTime = taskEndTime;
+  }
+
+  public List<Metric> getMetrics() {
+    return _metrics;
+  }
+
+  public void setMetrics(List<Metric> metrics) {
+    _metrics = metrics;
+  }
+}

--- a/app/com/linkedin/drelephant/tony/data/TonyTaskData.java
+++ b/app/com/linkedin/drelephant/tony/data/TonyTaskData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.linkedin.drelephant.tony.data;
 
 import com.linkedin.tony.events.Metric;

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -37,6 +37,11 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
   private final Path _finishedDir;
   private final FileSystem _fs;
 
+  /**
+   * Constructor for {@link TonyFetcher}.
+   * @param fetcherConfig  the fetcher configuration
+   * @throws IOException
+   */
   public TonyFetcher(FetcherConfigurationData fetcherConfig) throws IOException {
     Configuration conf = new Configuration();
 

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -22,15 +22,10 @@ import com.linkedin.drelephant.tony.data.TonyApplicationData;
 import com.linkedin.tony.Constants;
 import com.linkedin.tony.TonyConfigurationKeys;
 import com.linkedin.tony.events.Event;
-import com.linkedin.tony.events.EventType;
-import com.linkedin.tony.events.Metric;
-import com.linkedin.tony.events.TaskFinished;
 import com.linkedin.tony.util.ParserUtils;
 import java.io.IOException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -53,20 +48,7 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
     _fs = _finishedDir.getFileSystem(conf);
   }
 
-  private static Map<String, Map<Integer, List<Metric>>> parseMetricsMap(List<Event> events) {
-    Map<String, Map<Integer, List<Metric>>> metricsMap = new HashMap<>();
-    for (Event e : events) {
-      if (e.getType().equals(EventType.TASK_FINISHED)) {
-        TaskFinished taskFinishedEvent = (TaskFinished) e.getEvent();
-        if (!metricsMap.containsKey(taskFinishedEvent.getTaskType())) {
-          metricsMap.put(taskFinishedEvent.getTaskType(), new HashMap<>());
-        }
-        metricsMap.get(taskFinishedEvent.getTaskType()).put(taskFinishedEvent.getTaskIndex(),
-            taskFinishedEvent.getMetrics());
-      }
-    }
-    return metricsMap;
-  }
+
 
   @Override
   public TonyApplicationData fetchData(AnalyticJob job) throws Exception {
@@ -81,14 +63,20 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
     String yearMonthDay = ParserUtils.getYearMonthDayDirectory(date);
     Path jobDir = new Path(_finishedDir, yearMonthDay + Path.SEPARATOR + job.getAppId());
 
-    Map<String, Map<Integer, List<Metric>>> metricsMap = parseMetricsMap(ParserUtils.parseEvents(_fs, jobDir));
-
+    // parse config
     Path confFile = new Path(jobDir, Constants.TONY_FINAL_XML);
+    if (!_fs.exists(confFile)) {
+      // for backward compatibility, see https://github.com/linkedin/TonY/issues/271
+      confFile = new Path(jobDir, "config.xml");
+    }
     Configuration conf = new Configuration(false);
     if (_fs.exists(confFile)) {
       conf.addResource(_fs.open(confFile));
     }
 
-    return new TonyApplicationData(job.getAppId(), job.getAppType(), conf, metricsMap);
+    // parse events
+    List<Event> events = ParserUtils.parseEvents(_fs, jobDir);
+
+    return new TonyApplicationData(job.getAppId(), job.getAppType(), conf, events);
   }
 }

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -1,31 +1,94 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.linkedin.drelephant.tony.fetchers;
 
 import com.linkedin.drelephant.analysis.AnalyticJob;
 import com.linkedin.drelephant.analysis.ElephantFetcher;
 import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData;
 import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Event;
+import com.linkedin.tony.events.EventType;
+import com.linkedin.tony.events.Metric;
+import com.linkedin.tony.events.TaskFinished;
+import com.linkedin.tony.util.ParserUtils;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 
 public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
-  public static final String TONY_CONF_LOCATION = "tony_conf_location";
+  private final Path _finishedDir;
+  private final FileSystem _fs;
 
+  public TonyFetcher(FetcherConfigurationData fetcherConfig) throws IOException {
+    Configuration conf = new Configuration();
 
-  public TonyFetcher(FetcherConfigurationData fetcherConfData) {
-    // TODO
+    String tonyConfDir = System.getenv(Constants.TONY_CONF_DIR);
+    if (fetcherConfig.getParamMap().containsKey(Constants.TONY_CONF_DIR)) {
+      tonyConfDir = fetcherConfig.getParamMap().get(Constants.TONY_CONF_DIR);
+    }
+
+    conf.addResource(new Path(tonyConfDir + Path.SEPARATOR + Constants.TONY_SITE_CONF));
+    _finishedDir = new Path(conf.get(TonyConfigurationKeys.TONY_HISTORY_FINISHED));
+    _fs = _finishedDir.getFileSystem(conf);
+  }
+
+  private static Map<String, Map<Integer, List<Metric>>> parseMetricsMap(List<Event> events) {
+    Map<String, Map<Integer, List<Metric>>> metricsMap = new HashMap<>();
+    for (Event e : events) {
+      if (e.getType().equals(EventType.TASK_FINISHED)) {
+        TaskFinished taskFinishedEvent = (TaskFinished) e.getEvent();
+        if (!metricsMap.containsKey(taskFinishedEvent.getTaskType())) {
+          metricsMap.put(taskFinishedEvent.getTaskType(), new HashMap<>());
+        }
+        metricsMap.get(taskFinishedEvent.getTaskType()).put(taskFinishedEvent.getTaskIndex(),
+            taskFinishedEvent.getMetrics());
+      }
+    }
+    return metricsMap;
   }
 
   @Override
   public TonyApplicationData fetchData(AnalyticJob job) throws Exception {
-    TonyApplicationData jobData = new TonyApplicationData(job.getAppId(),
-        job.getAppType());
-    // get history files
-    // create in-memory parsed representation of file
-    // create TonyApplicationData object
-    // set stuff in it
-    // return it
+    long finishTime = job.getFinishTime();
+    Date date = new Date(finishTime);
 
-    return jobData;
+    // TODO: We are deriving yyyy/MM/dd from the RM's application finish time, but the TonY Portal actually creates the
+    // yyyy/MM/dd directory based off the end time embedded in the jhist file name. This end time is taken before the
+    // application finishes and thus is slightly before the RM's application finish time. So it's possible that the
+    // yyyy/MM/dd derived from the RM's application finish time is a day later and we may not find the history files.
+    // In case we don't find the history files in yyyy/MM/dd, we should check the previous day as well.
+    String yearMonthDay = ParserUtils.getYearMonthDayDirectory(date);
+    Path jobDir = new Path(_finishedDir, yearMonthDay + Path.SEPARATOR + job.getAppId());
+
+    Map<String, Map<Integer, List<Metric>>> metricsMap = parseMetricsMap(ParserUtils.parseEvents(_fs, jobDir));
+
+    Path confFile = new Path(jobDir, Constants.TONY_FINAL_XML);
+    Configuration conf = new Configuration(false);
+    if (_fs.exists(confFile)) {
+      conf.addResource(_fs.open(confFile));
+    }
+
+    return new TonyApplicationData(job.getAppId(), job.getAppType(), conf, metricsMap);
   }
 }

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -9,16 +9,11 @@ import org.apache.hadoop.fs.Path;
 
 
 public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
-  public static final String TONY_CONF_LOCATION = "tony.conf.location";
-
-//  private final Path finishedDir;
+  public static final String TONY_CONF_LOCATION = "tony_conf_location";
 
 
   public TonyFetcher(FetcherConfigurationData fetcherConfData) {
-    String tonyConfLoc = fetcherConfData.getParamMap().get(TONY_CONF_LOCATION);
-    Configuration conf = new Configuration();
-    conf.addResource(new Path(tonyConfLoc));
-//    finishedDir = conf.get("tony.history")
+    // TODO
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -29,9 +29,11 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
 
 
 public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
+  private static final Logger _LOGGER = Logger.getLogger(TonyFetcher.class);
   private final Path _finishedDir;
   private final FileSystem _fs;
 
@@ -42,16 +44,16 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
     if (fetcherConfig.getParamMap().containsKey(Constants.TONY_CONF_DIR)) {
       tonyConfDir = fetcherConfig.getParamMap().get(Constants.TONY_CONF_DIR);
     }
+    _LOGGER.info("Using TonY conf dir: " + tonyConfDir);
 
     conf.addResource(new Path(tonyConfDir + Path.SEPARATOR + Constants.TONY_SITE_CONF));
     _finishedDir = new Path(conf.get(TonyConfigurationKeys.TONY_HISTORY_FINISHED));
     _fs = _finishedDir.getFileSystem(conf);
   }
 
-
-
   @Override
   public TonyApplicationData fetchData(AnalyticJob job) throws Exception {
+    _LOGGER.debug("Fetching data for job " + job.getAppId());
     long finishTime = job.getFinishTime();
     Date date = new Date(finishTime);
 
@@ -62,6 +64,7 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
     // In case we don't find the history files in yyyy/MM/dd, we should check the previous day as well.
     String yearMonthDay = ParserUtils.getYearMonthDayDirectory(date);
     Path jobDir = new Path(_finishedDir, yearMonthDay + Path.SEPARATOR + job.getAppId());
+    _LOGGER.debug("Job directory for " + job.getAppId() + ": " + jobDir);
 
     // parse config
     Path confFile = new Path(jobDir, Constants.TONY_FINAL_XML);

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -82,7 +82,10 @@ public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
       conf.addResource(_fs.open(confFile));
     }
 
-    // parse events
+    // Parse events. For a list of event types, see
+    // https://github.com/linkedin/TonY/blob/master/tony-core/src/main/avro/EventType.avsc.
+    // We get the task start time from the TASK_STARTED event and the finish time and metrics from the TASK_FINISHED
+    // event.
     List<Event> events = ParserUtils.parseEvents(_fs, jobDir);
 
     return new TonyApplicationData(job.getAppId(), job.getAppType(), conf, events);

--- a/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
+++ b/app/com/linkedin/drelephant/tony/fetchers/TonyFetcher.java
@@ -1,0 +1,36 @@
+package com.linkedin.drelephant.tony.fetchers;
+
+import com.linkedin.drelephant.analysis.AnalyticJob;
+import com.linkedin.drelephant.analysis.ElephantFetcher;
+import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+
+public class TonyFetcher implements ElephantFetcher<TonyApplicationData> {
+  public static final String TONY_CONF_LOCATION = "tony.conf.location";
+
+//  private final Path finishedDir;
+
+
+  public TonyFetcher(FetcherConfigurationData fetcherConfData) {
+    String tonyConfLoc = fetcherConfData.getParamMap().get(TONY_CONF_LOCATION);
+    Configuration conf = new Configuration();
+    conf.addResource(new Path(tonyConfLoc));
+//    finishedDir = conf.get("tony.history")
+  }
+
+  @Override
+  public TonyApplicationData fetchData(AnalyticJob job) throws Exception {
+    TonyApplicationData jobData = new TonyApplicationData(job.getAppId(),
+        job.getAppType());
+    // get history files
+    // create in-memory parsed representation of file
+    // create TonyApplicationData object
+    // set stuff in it
+    // return it
+
+    return jobData;
+  }
+}

--- a/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
@@ -20,10 +20,10 @@ import com.linkedin.drelephant.analysis.Heuristic;
 import com.linkedin.drelephant.analysis.HeuristicResult;
 import com.linkedin.drelephant.analysis.Severity;
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
-import com.linkedin.drelephant.mapreduce.data.MapReduceApplicationData;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
 
 
-public class TaskMemoryHeuristic implements Heuristic<MapReduceApplicationData> {
+public class TaskMemoryHeuristic implements Heuristic<TonyApplicationData> {
 
   private HeuristicConfigurationData _heuristicConfData;
 
@@ -32,13 +32,13 @@ public class TaskMemoryHeuristic implements Heuristic<MapReduceApplicationData> 
   }
 
   @Override
-  public HeuristicConfigurationData getHeuristicConfData() {
-    return _heuristicConfData;
+  public HeuristicResult apply(TonyApplicationData data) {
+    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
+        0);
   }
 
   @Override
-  public HeuristicResult apply(MapReduceApplicationData data) {
-    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
-        0);
+  public HeuristicConfigurationData getHeuristicConfData() {
+    return _heuristicConfData;
   }
 }

--- a/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.tony.heuristics;
+
+import com.linkedin.drelephant.analysis.Heuristic;
+import com.linkedin.drelephant.analysis.HeuristicResult;
+import com.linkedin.drelephant.analysis.Severity;
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
+import com.linkedin.drelephant.mapreduce.data.MapReduceApplicationData;
+
+
+public class TaskMemoryHeuristic implements Heuristic<MapReduceApplicationData> {
+
+  private HeuristicConfigurationData _heuristicConfData;
+
+  public TaskMemoryHeuristic(HeuristicConfigurationData heuristicConfData) {
+    this._heuristicConfData = heuristicConfData;
+  }
+
+  @Override
+  public HeuristicConfigurationData getHeuristicConfData() {
+    return _heuristicConfData;
+  }
+
+  @Override
+  public HeuristicResult apply(MapReduceApplicationData data) {
+    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
+        0);
+  }
+}

--- a/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LinkedIn Corp.
+ * Copyright 2019 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,28 +13,103 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.linkedin.drelephant.tony.heuristics;
 
 import com.linkedin.drelephant.analysis.Heuristic;
 import com.linkedin.drelephant.analysis.HeuristicResult;
+import com.linkedin.drelephant.analysis.HeuristicResultDetails;
 import com.linkedin.drelephant.analysis.Severity;
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
 import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.drelephant.util.Utils;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Metric;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 
 
+/**
+ * For each type of task (e.g.: worker, ps), this heuristic checks the max memory used across all tasks of that type
+ * and compares against some thresholds. The final severity is the highest severity across all task types.
+ */
 public class TaskMemoryHeuristic implements Heuristic<TonyApplicationData> {
+  private static final int DEFAULT_CONTAINER_MEMORY_MB = 2048;
+  private static final String CONTAINER_MEMORY_DEFAULT_MB_CONF = "container_memory_default_mb";
+  private static final String TASK_MEMORY_THRESHOLDS_CONF = "task_memory_thresholds";
 
   private HeuristicConfigurationData _heuristicConfData;
+  private long defaultContainerMemoryBytes = DEFAULT_CONTAINER_MEMORY_MB * FileUtils.ONE_MB;
+
+  // Initialized to default max memory thresholds
+  private double[] maxMemoryLimits = {0.8, 0.7, 0.6, 0.5};
 
   public TaskMemoryHeuristic(HeuristicConfigurationData heuristicConfData) {
     this._heuristicConfData = heuristicConfData;
+
+    Map<String, String> params = heuristicConfData.getParamMap();
+    // read default container size
+    if (params.containsKey(CONTAINER_MEMORY_DEFAULT_MB_CONF)) {
+      defaultContainerMemoryBytes = Long.parseLong(params.get(CONTAINER_MEMORY_DEFAULT_MB_CONF)) * FileUtils.ONE_MB;
+    }
+    // read max memory thresholds
+    if (params.containsKey(TASK_MEMORY_THRESHOLDS_CONF)) {
+      maxMemoryLimits = Utils.getParam(params.get(TASK_MEMORY_THRESHOLDS_CONF), maxMemoryLimits.length);
+    }
   }
 
   @Override
   public HeuristicResult apply(TonyApplicationData data) {
-    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), Severity.NONE,
-        0);
+    Map<String, Map<Integer, List<Metric>>> metrics = data.getMetricsMap();
+    Configuration conf = data.getConfiguration();
+
+    Set<String> taskTypes = com.linkedin.tony.util.Utils.getAllJobTypes(conf);
+    Severity finalSeverity = Severity.NONE;
+    List<HeuristicResultDetails> details = new ArrayList<>();
+
+    for (String taskType : taskTypes) {
+      // get per task memory requested
+      String memoryString = conf.get(TonyConfigurationKeys.getResourceKey(taskType, Constants.MEMORY));
+      String memoryStringMB = com.linkedin.tony.util.Utils.parseMemoryString(memoryString);
+      long taskBytesRequested = Long.parseLong(memoryStringMB) * FileUtils.ONE_MB;
+      if (taskBytesRequested <= defaultContainerMemoryBytes) {
+        // If using default container memory, automatic pass
+        continue;
+      }
+
+      // get global max memory per task
+      double maxMemoryBytesUsed = 0;
+      for (List<Metric> taskMetrics : metrics.get(taskType).values()) {
+        for (Metric metric : taskMetrics) {
+          if (metric.getName().equals(Constants.MAX_MEMORY_BYTES)) {
+            if (metric.getValue() > maxMemoryBytesUsed) {
+              maxMemoryBytesUsed = metric.getValue();
+            }
+          }
+        }
+      }
+
+      // compare to threshold and update severity
+      double maxMemoryRatio = maxMemoryBytesUsed / taskBytesRequested;
+      Severity taskMemorySeverity = Severity.getSeverityDescending(maxMemoryRatio, maxMemoryLimits[0],
+          maxMemoryLimits[1], maxMemoryLimits[2], maxMemoryLimits[3]);
+      finalSeverity = Severity.max(finalSeverity, taskMemorySeverity);
+
+      // add heuristic details
+      details.add(new HeuristicResultDetails("Number of " + taskType + " tasks",
+          Integer.toString(metrics.get(taskType).size())));
+      details.add(new HeuristicResultDetails("Requested memory (MB) per " + taskType + " task",
+          Long.toString(taskBytesRequested / FileUtils.ONE_MB)));
+      details.add(new HeuristicResultDetails("Max memory (MB) used in any " + taskType + " task",
+          Long.toString((long) maxMemoryBytesUsed / FileUtils.ONE_MB)));
+    }
+
+    return new HeuristicResult(_heuristicConfData.getClassName(), _heuristicConfData.getHeuristicName(), finalSeverity,
+        0, details);
   }
 
   @Override

--- a/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristic.java
@@ -51,6 +51,10 @@ public class TaskMemoryHeuristic implements Heuristic<TonyApplicationData> {
   // Initialized to default max memory thresholds
   private double[] maxMemoryLimits = {0.8, 0.7, 0.6, 0.5};
 
+  /**
+   * Constructor for {@link TaskMemoryHeuristic}.
+   * @param heuristicConfData  the configuration for this heuristic
+   */
   public TaskMemoryHeuristic(HeuristicConfigurationData heuristicConfData) {
     this._heuristicConfData = heuristicConfData;
 

--- a/app/com/linkedin/drelephant/tony/util/TonyUtils.java
+++ b/app/com/linkedin/drelephant/tony/util/TonyUtils.java
@@ -1,0 +1,23 @@
+package com.linkedin.drelephant.tony.util;
+
+import com.linkedin.drelephant.tony.data.TonyTaskData;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.events.Metric;
+import java.util.Map;
+
+
+public class TonyUtils {
+  public static double getMaxMemoryBytesUsedForTaskType(Map<String, Map<Integer, TonyTaskData>> taskMap, String taskType) {
+    double maxMemoryBytesUsed = 0;
+    for (TonyTaskData taskData : taskMap.get(taskType).values()) {
+      for (Metric metric : taskData.getMetrics()) {
+        if (metric.getName().equals(Constants.MAX_MEMORY_BYTES)) {
+          if (metric.getValue() > maxMemoryBytesUsed) {
+            maxMemoryBytesUsed = metric.getValue();
+          }
+        }
+      }
+    }
+    return maxMemoryBytesUsed;
+  }
+}

--- a/app/com/linkedin/drelephant/tony/util/TonyUtils.java
+++ b/app/com/linkedin/drelephant/tony/util/TonyUtils.java
@@ -3,6 +3,7 @@ package com.linkedin.drelephant.tony.util;
 import com.linkedin.drelephant.tony.data.TonyTaskData;
 import com.linkedin.tony.Constants;
 import com.linkedin.tony.events.Metric;
+import java.util.List;
 import java.util.Map;
 
 
@@ -10,7 +11,11 @@ public class TonyUtils {
   public static double getMaxMemoryBytesUsedForTaskType(Map<String, Map<Integer, TonyTaskData>> taskMap, String taskType) {
     double maxMemoryBytesUsed = 0;
     for (TonyTaskData taskData : taskMap.get(taskType).values()) {
-      for (Metric metric : taskData.getMetrics()) {
+      List<Metric> metrics = taskData.getMetrics();
+      if (metrics == null) {
+        return -1;
+      }
+      for (Metric metric : metrics) {
         if (metric.getName().equals(Constants.MAX_MEMORY_BYTES)) {
           if (metric.getValue() > maxMemoryBytesUsed) {
             maxMemoryBytesUsed = metric.getValue();

--- a/app/com/linkedin/drelephant/tony/util/TonyUtils.java
+++ b/app/com/linkedin/drelephant/tony/util/TonyUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.linkedin.drelephant.tony.util;
 
 import com.linkedin.drelephant.tony.data.TonyTaskData;
@@ -8,7 +23,14 @@ import java.util.Map;
 
 
 public class TonyUtils {
-  public static double getMaxMemoryBytesUsedForTaskType(Map<String, Map<Integer, TonyTaskData>> taskMap, String taskType) {
+  /**
+   * Returns the max memory in bytes used by any task of the specified type.
+   * @param taskMap  a map containing data for all tasks
+   * @param taskType  the task type
+   * @return  the max memory in bytes used by any task of the specified type
+   */
+  public static double getMaxMemoryBytesUsedForTaskType(Map<String, Map<Integer, TonyTaskData>> taskMap,
+      String taskType) {
     double maxMemoryBytesUsed = 0;
     for (TonyTaskData taskData : taskMap.get(taskType).values()) {
       List<Metric> metrics = taskData.getMetrics();

--- a/app/models/AppResult.java
+++ b/app/models/AppResult.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.linkedin.drelephant.analysis.Severity;
 
 import com.linkedin.drelephant.util.Utils;
-import java.util.Date;
 import play.db.ebean.Model;
 
 import java.util.List;

--- a/app/views/help/tony/helpTaskMemory.scala.html
+++ b/app/views/help/tony/helpTaskMemory.scala.html
@@ -1,0 +1,18 @@
+@*
+* Copyright 2019 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*@
+<p>
+  Don't use so much memory!
+</p>

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ organization := "com.linkedin.drelephant"
 // Enable CPD SBT plugin
 lazy val root = (project in file(".")).enablePlugins(CopyPasteDetector)
 
-javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+javacOptions in Compile ++= Seq("-source", "1.8", "-target", "1.8")
 
 libraryDependencies ++= dependencies map { _.excludeAll(exclusionRules: _*) }
 

--- a/compile.sh
+++ b/compile.sh
@@ -437,7 +437,7 @@ play_command $OPTS dist
 cd target/universal
 
 ZIP_NAME=`/bin/ls *.zip`
-unzip -f ${ZIP_NAME}
+unzip -of ${ZIP_NAME}
 rm ${ZIP_NAME}
 DIST_NAME=${ZIP_NAME%.zip}
 

--- a/compile.sh
+++ b/compile.sh
@@ -437,7 +437,7 @@ play_command $OPTS dist
 cd target/universal
 
 ZIP_NAME=`/bin/ls *.zip`
-unzip ${ZIP_NAME}
+unzip -f ${ZIP_NAME}
 rm ${ZIP_NAME}
 DIST_NAME=${ZIP_NAME%.zip}
 

--- a/compile.sh
+++ b/compile.sh
@@ -427,7 +427,7 @@ if [ $run_StyleChecks = "y" ]; then
 fi
 
 set -v
-set -x
+set -ex
 # Echo the value of pwd in the script so that it is clear what is being removed.
 rm -rf ${project_root}/dist
 mkdir dist
@@ -436,8 +436,8 @@ play_command $OPTS dist
 
 cd target/universal
 
-ZIP_NAME=`/bin/ls *.zip`
-unzip -of ${ZIP_NAME}
+ZIP_NAME=`ls *.zip`
+unzip -o ${ZIP_NAME}
 rm ${ZIP_NAME}
 DIST_NAME=${ZIP_NAME%.zip}
 
@@ -452,7 +452,7 @@ cp $stop_script ${DIST_NAME}/bin/
 
 cp -r $app_conf ${DIST_NAME}
 
-mkdir ${DIST_NAME}/scripts/
+mkdir -p ${DIST_NAME}/scripts/
 
 cp -r $pso_dir ${DIST_NAME}/scripts/
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   lazy val jsoupVersion = "1.7.3"
   lazy val mysqlConnectorVersion = "5.1.36"
   lazy val oozieClientVersion = "4.2.0"
-  lazy val tonyVersion = "0.3.5"
+  lazy val tonyVersion = "0.3.6"
 
   lazy val HADOOP_VERSION = "hadoopversion"
   lazy val SPARK_VERSION = "sparkversion"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   lazy val jsoupVersion = "1.7.3"
   lazy val mysqlConnectorVersion = "5.1.36"
   lazy val oozieClientVersion = "4.2.0"
-  lazy val tonyVersion = "0.3.4"
+  lazy val tonyVersion = "0.3.5"
 
   lazy val HADOOP_VERSION = "hadoopversion"
   lazy val SPARK_VERSION = "sparkversion"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,13 +23,14 @@ object Dependencies {
   lazy val commonsCodecVersion = "1.10"
   lazy val commonsIoVersion = "2.4"
   lazy val gsonVersion = "2.2.4"
-  lazy val guavaVersion = "18.0"          // Hadoop defaultly are using guava 11.0, might raise NoSuchMethodException
+  lazy val guavaVersion = "18.0"          // Hadoop by default uses Guava 11.0, might raise NoSuchMethodException
   lazy val jacksonMapperAslVersion = "1.7.3"
   lazy val jacksonVersion = "2.5.3"
   lazy val jerseyVersion = "2.24"
   lazy val jsoupVersion = "1.7.3"
   lazy val mysqlConnectorVersion = "5.1.36"
   lazy val oozieClientVersion = "4.2.0"
+  lazy val tonyVersion = "0.3.4"
 
   lazy val HADOOP_VERSION = "hadoopversion"
   lazy val SPARK_VERSION = "sparkversion"
@@ -95,8 +96,11 @@ object Dependencies {
     "org.apache.httpcomponents" % "httpclient" % "4.5.2",
     "org.apache.httpcomponents" % "httpcore" % "4.4.4",
     "org.scalatest" %% "scalatest" % "3.0.0" % Test,
-    "com.h2database" % "h2" % "1.4.196" % Test
-
+    "com.h2database" % "h2" % "1.4.196" % Test,
+    "com.linkedin.tony" % "tony-core" % tonyVersion excludeAll(
+      ExclusionRule(organization = "com.fasterxml.jackson.core"),
+      ExclusionRule(organization = "org.apache.hadoop")
+    )
   ) :+ sparkExclusion
 
   var dependencies = Seq(javaJdbc, javaEbean, cache)

--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -32,7 +32,7 @@
 
   <!-- *********************** Issues which will be treated as errors hence enforced *********************** -->
   <!-- FILE HEADER as per format given in the header file configured below -->
-  <module name="Header">
+  <module name="RegexpHeader">
     <property name="headerFile" value="project/checkstyle-java.header"/>
     <property name="fileExtensions" value="java"/>
   </module>

--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<!DOCTYPE module PUBLIC "-//Source Forge//DTD Check Configuration 1.3//EN" "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Source Forge//DTD Check Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <!-- *********************** Configurations *********************** -->
   <!-- Filter out non Java files -->

--- a/project/checkstyle-java.header
+++ b/project/checkstyle-java.header
@@ -1,15 +1,15 @@
-/*
- * Copyright 2016 LinkedIn Corp.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
+^/\*$
+^ \* Copyright \d{4} LinkedIn Corp.$
+^ \*$
+^ \* Licensed under the Apache License, Version 2.0 \(the "License"\); you may not$
+^ \* use this file except in compliance with the License. You may obtain a copy of$
+^ \* the License at$
+^ \*$
+^ \* http://www.apache.org/licenses/LICENSE-2.0$
+^ \*$
+^ \* Unless required by applicable law or agreed to in writing, software$
+^ \* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT$
+^ \* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the$
+^ \* License for the specific language governing permissions and limitations under$
+^ \* the License.$
+^ \*/$

--- a/test/com/linkedin/drelephant/tony/TonyMetricsAggregatorTest.java
+++ b/test/com/linkedin/drelephant/tony/TonyMetricsAggregatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.drelephant.tony;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.analysis.HadoopAggregatedData;
+import com.linkedin.drelephant.math.Statistics;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Event;
+import com.linkedin.tony.events.EventType;
+import com.linkedin.tony.events.Metric;
+import com.linkedin.tony.events.TaskFinished;
+import com.linkedin.tony.events.TaskStarted;
+import com.linkedin.tony.rpc.impl.TaskStatus;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.linkedin.drelephant.tony.TonyMetricsAggregator.MEMORY_BUFFER;
+
+
+public class TonyMetricsAggregatorTest {
+  /**
+   * Low memory utilization but default container size, so pass.
+   */
+  @Test
+  public void testMetricsAggregator() {
+    Configuration conf = new Configuration(false);
+    conf.set(TonyConfigurationKeys.getResourceKey(Constants.WORKER_JOB_NAME, Constants.MEMORY), "4g");
+    conf.setInt(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME), 2);
+    conf.set(TonyConfigurationKeys.getResourceKey(Constants.PS_JOB_NAME, Constants.MEMORY), "4g");
+    conf.setInt(TonyConfigurationKeys.getInstancesKey(Constants.PS_JOB_NAME), 1);
+
+    List<Event> events = new ArrayList<>();
+    events.add(new Event(EventType.TASK_STARTED, new TaskStarted(Constants.WORKER_JOB_NAME, 0, null),0L));
+    events.add(new Event(EventType.TASK_STARTED, new TaskStarted(Constants.WORKER_JOB_NAME, 1, null),0L));
+    events.add(new Event(EventType.TASK_STARTED, new TaskStarted(Constants.PS_JOB_NAME, 0, null),0L));
+    events.add(new Event(EventType.TASK_FINISHED,
+        new TaskFinished(Constants.WORKER_JOB_NAME, 0, TaskStatus.SUCCEEDED.toString(),
+            ImmutableList.of(new Metric(Constants.MAX_MEMORY_BYTES, (double) FileUtils.ONE_GB))),
+        10L * Statistics.SECOND_IN_MS));
+    events.add(new Event(EventType.TASK_FINISHED,
+        new TaskFinished(Constants.WORKER_JOB_NAME, 1, TaskStatus.SUCCEEDED.toString(),
+            ImmutableList.of(new Metric(Constants.MAX_MEMORY_BYTES, (double) 2 * FileUtils.ONE_GB))),
+        20L * Statistics.SECOND_IN_MS));
+    events.add(new Event(EventType.TASK_FINISHED,
+        new TaskFinished(Constants.PS_JOB_NAME, 0, TaskStatus.SUCCEEDED.toString(),
+            ImmutableList.of(new Metric(Constants.MAX_MEMORY_BYTES, (double) FileUtils.ONE_GB))),
+        20L * Statistics.SECOND_IN_MS));
+
+    long expectedResourcesUsed = 10 * 4 * 1024 + 20 * 4 * 1024 + 20 * 4 * 1024;
+    long expectedResourcesWasted = 10 * (long) (4 * 1024 - 2 * 1024 * MEMORY_BUFFER)
+        + 20 * (long) (4 * 1024 - 2 * 1024 * MEMORY_BUFFER)
+        + 20 * (long) (4 * 1024 - 1 * 1024 * MEMORY_BUFFER);
+
+    ApplicationType appType = new ApplicationType(Constants.APP_TYPE);
+    TonyApplicationData data = new TonyApplicationData("application_123_456", appType, conf, events);
+    TonyMetricsAggregator metricsAggregator = new TonyMetricsAggregator(null);
+    metricsAggregator.aggregate(data);
+    HadoopAggregatedData result = metricsAggregator.getResult();
+    Assert.assertEquals(expectedResourcesUsed, result.getResourceUsed());
+    Assert.assertEquals(expectedResourcesWasted, result.getResourceWasted());
+  }
+}

--- a/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
+++ b/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.drelephant.tony.fetchers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import com.linkedin.drelephant.analysis.AnalyticJob;
+import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Event;
+import com.linkedin.tony.events.EventType;
+import com.linkedin.tony.events.Metric;
+import com.linkedin.tony.events.TaskFinished;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+public class TonyFetcherTest {
+  private static final String APPLICATION_ID = "application_123_456";
+  private static File _finishedDir;
+  private static String _tonyConfDir;
+  private static Date _endDate;
+
+  @BeforeClass
+  public static void setup() throws IOException, ParseException {
+    setupFinishedApplicationDir();
+    setupTestTonyConfDir();
+  }
+
+  private static void setupFinishedApplicationDir() throws IOException, ParseException {
+    String yearMonthDay = "2019/05/02";
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+    _endDate = sdf.parse(yearMonthDay);
+
+    File tempDir = Files.createTempDir();
+    _finishedDir = new File(tempDir, "finished");
+    File appDir = new File(_finishedDir, yearMonthDay + Path.SEPARATOR + APPLICATION_ID);
+    appDir.mkdirs();
+
+    Configuration conf = new Configuration(false);
+    conf.set("foo", "bar");
+
+    File configFile = new File(appDir, Constants.TONY_FINAL_XML);
+    conf.writeXml(new FileOutputStream(configFile));
+
+    Event event0 = new Event(EventType.TASK_FINISHED, new TaskFinished("worker", 0, "SUCCEEDED",
+        ImmutableList.of(new Metric("my_metric", 0.0))), System.currentTimeMillis());
+    Event event1 = new Event(EventType.TASK_FINISHED, new TaskFinished("worker", 1, "SUCCEEDED",
+        ImmutableList.of(new Metric("my_metric", 1.0))), System.currentTimeMillis());
+    Event event2 = new Event(EventType.TASK_FINISHED, new TaskFinished("ps", 0, "SUCCEEDED",
+        ImmutableList.of(new Metric("my_metric", 0.0))), System.currentTimeMillis());
+
+    File eventFile = new File(appDir,
+        APPLICATION_ID + "-0-" + _endDate.getTime() + "-user1-SUCCEEDED." + Constants.HISTFILE_SUFFIX);
+    DatumWriter<Event> userDatumWriter = new SpecificDatumWriter<>(Event.class);
+    DataFileWriter<Event> dataFileWriter = new DataFileWriter<>(userDatumWriter);
+    dataFileWriter.create(event0.getSchema(), eventFile);
+    dataFileWriter.append(event0);
+    dataFileWriter.append(event1);
+    dataFileWriter.append(event2);
+    dataFileWriter.close();
+  }
+
+  private static void setupTestTonyConfDir() throws IOException {
+    Configuration testTonyConf = new Configuration(false);
+    testTonyConf.set(TonyConfigurationKeys.TONY_HISTORY_FINISHED, _finishedDir.getPath());
+
+    File confDir = Files.createTempDir();
+    _tonyConfDir = confDir.getPath();
+    File tonySiteFile = new File(confDir, Constants.TONY_SITE_CONF);
+    testTonyConf.writeXml(new FileOutputStream(tonySiteFile));
+  }
+
+  @Test
+  public void testFetchData() throws Exception {
+    FetcherConfigurationData configData = new FetcherConfigurationData(null, null,
+        ImmutableMap.of(Constants.TONY_CONF_DIR, _tonyConfDir));
+    TonyFetcher tonyFetcher = new TonyFetcher(configData);
+
+    AnalyticJob job = new AnalyticJob();
+    ApplicationType tonyAppType = new ApplicationType("TONY");
+    job.setFinishTime(_endDate.getTime());
+    job.setAppId(APPLICATION_ID);
+    job.setAppType(tonyAppType);
+    TonyApplicationData appData = tonyFetcher.fetchData(job);
+
+    Assert.assertEquals(APPLICATION_ID, appData.getAppId());
+    Assert.assertEquals(tonyAppType, appData.getApplicationType());
+    Assert.assertEquals("bar", appData.getConf().get("foo"));
+    Map<String, Map<Integer, List<Metric>>> metricsMap = appData.getMetricsMap();
+    Assert.assertEquals(2, metricsMap.size());
+    Assert.assertEquals(2, metricsMap.get("worker").size());
+    Assert.assertEquals(1, metricsMap.get("ps").size());
+  }
+}

--- a/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
+++ b/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
@@ -109,7 +109,7 @@ public class TonyFetcherTest {
     TonyFetcher tonyFetcher = new TonyFetcher(configData);
 
     AnalyticJob job = new AnalyticJob();
-    ApplicationType tonyAppType = new ApplicationType("TONY");
+    ApplicationType tonyAppType = new ApplicationType(Constants.APP_TYPE);
     job.setFinishTime(_endDate.getTime());
     job.setAppId(APPLICATION_ID);
     job.setAppType(tonyAppType);

--- a/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
+++ b/test/com/linkedin/drelephant/tony/fetchers/TonyFetcherTest.java
@@ -22,6 +22,7 @@ import com.linkedin.drelephant.analysis.AnalyticJob;
 import com.linkedin.drelephant.analysis.ApplicationType;
 import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData;
 import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.drelephant.tony.data.TonyTaskData;
 import com.linkedin.tony.Constants;
 import com.linkedin.tony.TonyConfigurationKeys;
 import com.linkedin.tony.events.Event;
@@ -118,7 +119,7 @@ public class TonyFetcherTest {
     Assert.assertEquals(APPLICATION_ID, appData.getAppId());
     Assert.assertEquals(tonyAppType, appData.getApplicationType());
     Assert.assertEquals("bar", appData.getConf().get("foo"));
-    Map<String, Map<Integer, List<Metric>>> metricsMap = appData.getMetricsMap();
+    Map<String, Map<Integer, TonyTaskData>> metricsMap = appData.getTaskMap();
     Assert.assertEquals(2, metricsMap.size());
     Assert.assertEquals(2, metricsMap.get("worker").size());
     Assert.assertEquals(1, metricsMap.get("ps").size());

--- a/test/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristicTest.java
+++ b/test/com/linkedin/drelephant/tony/heuristics/TaskMemoryHeuristicTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.drelephant.tony.heuristics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.drelephant.analysis.ApplicationType;
+import com.linkedin.drelephant.analysis.HeuristicResult;
+import com.linkedin.drelephant.analysis.Severity;
+import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData;
+import com.linkedin.drelephant.tony.data.TonyApplicationData;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.events.Metric;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TaskMemoryHeuristicTest {
+
+  /**
+   * 3g workers requested, max worker memory < 50%
+   */
+  @Test
+  public void testCritical() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+          1.2e9,
+          1.1e9,
+          1e9,
+          1.3e9
+        }, Constants.PS_JOB_NAME, new double[]{0.5e9}),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g", Constants.PS_JOB_NAME, "2g"),
+        Severity.CRITICAL
+    );
+  }
+
+  /**
+   * 3g ps requested, max ps memory < 60%
+   */
+  @Test
+  public void testSevere() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            1.5e9,
+            1.6e9,
+        }, Constants.PS_JOB_NAME, new double[]{1.84e9}),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "2g", Constants.PS_JOB_NAME, "3g"),
+        Severity.SEVERE
+    );
+  }
+
+  /**
+   * 3g workers requested, max worker memory < 70%
+   */
+  @Test
+  public void testModerate() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            2.14e9,
+            2e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g"),
+        Severity.MODERATE
+    );
+  }
+
+  /**
+   * 3g workers requested, max worker memory < 80%
+   */
+  @Test
+  public void testLow() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            2e9,
+            2.45e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g"),
+        Severity.LOW
+    );
+  }
+
+  /**
+   * 3g workers requested, max worker memory > 80%
+   */
+  @Test
+  public void testNone() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            2.5e9,
+            2.6e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "3g"),
+        Severity.NONE
+    );
+  }
+
+  /**
+   * Low memory utilization but default container size, so pass.
+   */
+  @Test
+  public void testLowUtilizationDefaultContainerSize() {
+    testHelper(
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, new double[]{
+            0.5e9,
+            0.6e9,
+        }),
+        ImmutableMap.of(Constants.WORKER_JOB_NAME, "2g"),
+        Severity.NONE
+    );
+  }
+
+  public void testHelper(Map<String, double[]> memUsed, Map<String, String> memRequested, Severity expectedSeverity) {
+    Configuration conf = new Configuration(false);
+    Map<String, Map<Integer, List<Metric>>> metricsMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : memRequested.entrySet()) {
+      String taskType = entry.getKey();
+      conf.set(TonyConfigurationKeys.getResourceKey(taskType, Constants.MEMORY), entry.getValue());
+      conf.setInt(TonyConfigurationKeys.getInstancesKey(taskType), memUsed.get(taskType).length);
+      metricsMap.put(taskType, new HashMap<>());
+      for (int i = 0; i < memUsed.get(taskType).length; i++) {
+        metricsMap.get(taskType).put(i,
+            ImmutableList.of(new Metric(Constants.MAX_MEMORY_BYTES, memUsed.get(taskType)[i])));
+      }
+    }
+
+    ApplicationType appType = new ApplicationType(Constants.APP_TYPE);
+    TonyApplicationData data = new TonyApplicationData("application_123_456", appType, conf, metricsMap);
+
+    TaskMemoryHeuristic heuristic = new TaskMemoryHeuristic(new HeuristicConfigurationData("ignored",
+        "ignored", "ignored", appType, Collections.EMPTY_MAP));
+    HeuristicResult result = heuristic.apply(data);
+    Assert.assertEquals(expectedSeverity, result.getSeverity());
+  }
+}

--- a/test/resources/JobTypeConf.xml
+++ b/test/resources/JobTypeConf.xml
@@ -78,5 +78,6 @@
     <name>TonY</name>
     <applicationtype>TONY</applicationtype>
     <conf>tony.application.name</conf>
+    <isDefault/>
   </jobType>
 </jobTypes>

--- a/test/resources/JobTypeConf.xml
+++ b/test/resources/JobTypeConf.xml
@@ -74,4 +74,9 @@
     <conf>mapred.child.java.opts</conf>
     <isDefault/>
   </jobType>
+  <jobType>
+    <name>TonY</name>
+    <applicationtype>TONY</applicationtype>
+    <conf>tony.application.name</conf>
+  </jobType>
 </jobTypes>


### PR DESCRIPTION
* Implemented `TonyFetcher`, `TaskMemoryHeuristic`, `TonyMetricsAggregator`.
* Added unit tests for each.
* Disabled `TonyFetcher` by default in the included `FetcherConf.xml`.
* Bumped source and target JDK versions to 1.8 since TonY requires that.

<img width="924" alt="tony-job" src="https://user-images.githubusercontent.com/544734/57483686-3bf54c00-725c-11e9-92e8-1b01f9040cb6.png">

Please ignore the "Unknown" max memory, as that is due to the `ProcfsBasedProcessTree` that TonY uses only working on Linux, not Mac. On a Linux machine, max memory metrics are collected and emitted.