### PR TITLE
Removing code with usage of NOT_STARTED ExecutionState

### DIFF
--- a/app/com/linkedin/drelephant/tuning/hbt/ParameterGenerateManagerHBT.java
+++ b/app/com/linkedin/drelephant/tuning/hbt/ParameterGenerateManagerHBT.java
@@ -88,8 +88,7 @@ public class ParameterGenerateManagerHBT extends AbstractParameterGenerateManage
         .setMaxRows(1)
         .findUnique();
     logger.debug("Job Status " + jobExecution.executionState.name());
-    if (jobExecution.executionState.name().equals(JobExecution.ExecutionState.IN_PROGRESS.name())
-        || jobExecution.executionState.name().equals(JobExecution.ExecutionState.NOT_STARTED.name())) {
+    if (jobExecution.executionState.name().equals(JobExecution.ExecutionState.IN_PROGRESS.name())) {
       logger.debug(" Job is still running , cannot use for param generation ");
       return "";
     }


### PR DESCRIPTION
**DESCRIPTION**

In this PR changes are made to remove the usage of NOT_STARTED ExecutionState as this is sort of redundant and the main reason for removing this as the team decided to use this ExecutionState type for an upcoming hotfix. For that hotfix to work this ExecutionState type cannot be used anywhere else.