### PR TITLE
Fix exception fingerprinting spark test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
+scala:
+  - 2.10.4
 sudo: true
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - sudo pip install argparse
 
 script:
-  - sbt test jacoco:cover
+  - sbt clean test
 
 # only build PRs and master (not all branch pushes)
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 sudo: true
 jdk:
   - oraclejdk8
-  - oraclejdk7
 python: "2.6"
 install:
   - sudo pip install inspyred

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ branches:
   only:
     - master
     - tuning_20190221
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ install:
   - sudo pip install inspyred
   - sudo pip install argparse
 
+script:
+  - sbt test jacoco:cover
+
 # only build PRs and master (not all branch pushes)
 branches:
   only:
     - master
-
+    - tuning_20190221

--- a/app/com/linkedin/drelephant/mapreduce/fetchers/MapReduceFSFetcherHadoop2.java
+++ b/app/com/linkedin/drelephant/mapreduce/fetchers/MapReduceFSFetcherHadoop2.java
@@ -88,6 +88,7 @@ public class MapReduceFSFetcherHadoop2 extends MapReduceFetcher {
     logger.info("Using timezone: " + _timeZone.getID());
 
     Configuration conf = new Configuration();
+    conf.addDefaultResource("mapred-default.xml");
     this._historyLocation = conf.get("mapreduce.jobhistory.done-dir");
     this._intermediateHistoryLocation = conf.get("mapreduce.jobhistory.intermediate-done-dir");
     try {


### PR DESCRIPTION
The test was previously failing due to a NPE because `mapreduce.jobhistory.done-dir` was null because `new Configuration()` was not loading `mapred-default.xml` by default. Added `conf.addDefaultResource("mapred-default.xml");` to fix this.