### PR TITLE
Using HTTPS enabled sbt repo URL for dependency resolution

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@
 logLevel := Level.Warn
 
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.2.2"))


### PR DESCRIPTION
**DESCRIPTION**

This PR contains changes to address the issue raised in the ticket PWN-17653(internal ticket). The changes are made to use HTTPS enabled sbt dependency resolver so that we only download dependency JARs on a secure connection.