### PR TITLE
Fix the case where showRecommendation is NULL due to MySql settings

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -1851,10 +1851,13 @@ public class Application extends Controller {
         .where()
         .eq(TuningJobDefinition.TABLE.job + '.' + JobDefinition.TABLE.id, jobDefinitionId)
         .findUnique();
+    if (tuningJobDefinition.showRecommendationCount == null) {
+      tuningJobDefinition.showRecommendationCount = 0;
+    }
     tuningJobDefinition.showRecommendationCount += 1;
     tuningJobDefinition.save();
     JsonObject parent = new JsonObject();
-    parent.addProperty("showRecommendationCount", tuningJobDefinition.showRecommendationCount);
+    parent.addProperty(SHOW_RECOMMENDATION_COUNT, tuningJobDefinition.showRecommendationCount);
     return ok(new Gson().toJson(parent));
   }
 
@@ -2170,7 +2173,7 @@ public class Application extends Controller {
   }
 
   private static String reasonForDisablingTuning(TuningJobDefinition tuningJobDefinition) {
-    if (tuningJobDefinition.tuningEnabled) {
+    if (!tuningJobDefinition.tuningEnabled) {
       logger.debug("Tuning is disabled for this application");
       if (tuningJobDefinition.tuningDisabledReason != null) {
         return tuningJobDefinition.tuningDisabledReason;

--- a/app/controllers/api/v1/JsonKeys.java
+++ b/app/controllers/api/v1/JsonKeys.java
@@ -112,6 +112,7 @@ public class JsonKeys {
   public static final String TUNING_PARAMETERS = "tuningParameters";
   public static final String TUNING_ALGORITHM_LIST = "tuningAlgorithmList";
   public static final String UPDATED_PARAM_DETAILS = "updatedParamDetails";
+  public static final String SHOW_RECOMMENDATION_COUNT = "showRecommendationCount";
 
   // Authentication and Authorizaton
   public static final String SESSION_ID_KEY = "session_id";


### PR DESCRIPTION
**DESCRIPTION**

In this PR the changes are made to handle the case where show_recommendation_count is NULL and TuneIn API needs to increment on every view. MySql DB is not accepting the DEFAULT value of zero which was mentioned while creating the respective column in TuningJobDefinition table.