### PR TITLE
LIHADOOP-48670: Fixing Resource Usage Computation for Spark

### DIFF
--- a/app/com/linkedin/drelephant/analysis/AnalyticJob.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJob.java
@@ -69,6 +69,15 @@ public class AnalyticJob {
   private String _amHostHttpAddress;
   // Job final state is finished or failed
   private String _state;
+  private Long memorySeconds;
+
+  public Long getMemorySeconds() {
+    return memorySeconds;
+  }
+
+  public void setMemorySeconds(Long memorySeconds) {
+    this.memorySeconds = memorySeconds;
+  }
 
   /**
    * Returns the application type
@@ -291,7 +300,7 @@ public class AnalyticJob {
     result.finishTime = getFinishTime();
     result.name = Utils.truncateField(getName(), AppResult.APP_NAME_LIMIT, getAppId());
     result.jobType = Utils.truncateField(jobTypeName, AppResult.JOBTYPE_LIMIT, getAppId());
-    result.resourceUsed = hadoopAggregatedData.getResourceUsed();
+    result.resourceUsed = getMemorySeconds();
     result.totalDelay = hadoopAggregatedData.getTotalDelay();
     result.resourceWasted = hadoopAggregatedData.getResourceWasted();
 

--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -270,8 +270,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
 
         if (type != null) {
           AnalyticJob analyticJob = new AnalyticJob();
-          analyticJob
-              .setAppId(appId)
+          analyticJob.setAppId(appId)
               .setAppType(type)
               .setUser(user)
               .setName(name)

--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -258,7 +258,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
         String amContainerLogsURL = app.get("amContainerLogs").getValueAsText();
         String amHostHttpAddress = app.get("amHostHttpAddress").getValueAsText();
         String jobState = app.get("state").getValueAsText();
-
+        long memorySeconds = app.get("memorySeconds").getLongValue();
         if (debugEnabled) {
           logger.debug(" AM Container logs URL " + amContainerLogsURL);
           logger.debug(" AM Host HTTP Address " + amHostHttpAddress);
@@ -268,10 +268,10 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
         ApplicationType type =
             ElephantContext.instance().getApplicationTypeForName(app.get("applicationType").getValueAsText());
 
-
+        if (type != null) {
           AnalyticJob analyticJob = new AnalyticJob();
-          logger.info(" Analysis job " + analyticJob.getTrackingUrl());
-          analyticJob.setAppId(appId)
+          analyticJob
+              .setAppId(appId)
               .setAppType(type)
               .setUser(user)
               .setName(name)
@@ -282,9 +282,10 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
               .setAmContainerLogsURL(amContainerLogsURL)
               .setSucceeded(isSucceeded)
               .setAmHostHttpAddress(amHostHttpAddress)
-              .setState(jobState);
+              .setState(jobState)
+              .setMemorySeconds(memorySeconds);
           appList.add(analyticJob);
-
+        }
       }
     }
     return appList;

--- a/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
+++ b/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
@@ -27,9 +27,11 @@ import org.apache.log4j.Logger
 
 import scala.util.Try
 import java.util.Date
+
 import com.linkedin.drelephant.AutoTuner
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import com.linkedin.drelephant.ElephantContext
+import com.linkedin.drelephant.spark.heuristics.ConfigurationHeuristicsConstants
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.conf.Configuration
 
@@ -85,20 +87,43 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
   //calculates the resource usage by summing up the resources used per executor
   private def calculateResourceUsage(data: SparkApplicationData): (BigInt, BigInt) = {
     val executorSummaries = data.executorSummaries
+
+    val lastAttempt = data.applicationInfo.attempts.maxBy {
+      _.startTime
+    }
+    val attemptStartTime = lastAttempt.startTime
+    val attemptEndTime = lastAttempt.endTime
+
     var sumResourceUsage: BigInt = 0
     var sumResourcesAllocatedForUse: BigInt = 0
+    val driverContainerBytes = getRoundedContainerBytes(data, true).get
+    val executorContainerBytes = getRoundedContainerBytes(data, false).get
+    val driverMemoryOverhead = overheadMemoryBytesOf(data, true).get
+    val executorMemoryOverhead = overheadMemoryBytesOf(data, false).get
+
     executorSummaries.foreach(
       executorSummary => {
-        val memoryOverhead = overheadMemoryBytesOf(data).get
-        val roundedContainerBytes = getRoundedContainerBytes(data).get
-        val memUsedBytes: Long = executorSummary.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY, 0).asInstanceOf[Number].longValue + MemoryFormatUtils.stringToBytes(SPARK_RESERVED_MEMORY) + memoryOverhead
-        val timeSpent: Long = executorSummary.totalDuration
-        var totalCores: Int = executorSummary.totalCores
-        if (totalCores == 0) {
-          totalCores = 1
+        val executorStartTime = executorSummary.addTime
+        var executorEndTime = executorSummary.removeTime
+        if (executorEndTime == null) {
+          executorEndTime = attemptEndTime;
         }
-        val bytesMillisUsed = BigInt(memUsedBytes) * timeSpent / totalCores
-        val bytesMillisAllocated = BigInt(roundedContainerBytes) * timeSpent / totalCores
+        var memoryOverhead: Long = 0L
+        var roundedContainerBytes: Long = 0L
+        if (executorSummary.id.equals("driver")) {
+          roundedContainerBytes = driverContainerBytes
+          memoryOverhead = driverMemoryOverhead
+        } else {
+          roundedContainerBytes = executorContainerBytes
+          memoryOverhead = executorMemoryOverhead
+        }
+
+        val memUsedBytes: Long = executorSummary.peakJvmUsedMemory.getOrElse(JVM_USED_MEMORY,
+          0).asInstanceOf[Number].longValue + MemoryFormatUtils.stringToBytes(SPARK_RESERVED_MEMORY) + memoryOverhead
+        val timeSpent: BigInt = executorEndTime.getTime - executorStartTime.getTime
+        val bytesMillisUsed = BigInt(memUsedBytes) * timeSpent
+        val bytesMillisAllocated = BigInt(roundedContainerBytes) * timeSpent
+
         sumResourcesAllocatedForUse += (bytesMillisAllocated / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
         sumResourceUsage += (bytesMillisUsed / (BigInt(FileUtils.ONE_MB) * BigInt(Statistics.SECOND_IN_MS)))
       })
@@ -123,6 +148,11 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
     appConfigurationProperties.get(SPARK_EXECUTOR_MEMORY_KEY).map(MemoryFormatUtils.stringToBytes)
   }
 
+  private def driverMemoryBytesOf(data: SparkApplicationData): Option[Long] = {
+    val appConfigurationProperties = data.appConfigurationProperties
+    appConfigurationProperties.get(ConfigurationHeuristicsConstants.SPARK_DRIVER_MEMORY).map(MemoryFormatUtils.stringToBytes)
+  }
+
   private def applicationDurationMillisOf(data: SparkApplicationData): Long = {
     require(data.applicationInfo.attempts.nonEmpty)
     val lastApplicationAttemptInfo = data.applicationInfo.attempts.last
@@ -132,21 +162,23 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
   private def totalExecutorTaskTimeMillisOf(data: SparkApplicationData): BigInt = {
     data.executorSummaries.map { executorSummary => BigInt(executorSummary.totalDuration) }.sum
   }
-  private def overheadMemoryBytesOf(data: SparkApplicationData): Option[Long] = {
-    val executorMemory = executorMemoryBytesOf(data)
+
+  private def overheadMemoryBytesOf(data: SparkApplicationData, isDriver: Boolean): Option[Long] = {
+    val executorMemory = if (isDriver) driverMemoryBytesOf(data) else executorMemoryBytesOf(data)
+    val memoryOverHeadConfigKey = if (isDriver) ConfigurationHeuristicsConstants.SPARK_DRIVER_MEMORY_OVERHEAD else SPARK_YARN_EXECUTOR_MEMORY_OVERHEAD
     val appConfigurationProperties = data.appConfigurationProperties
-    if (appConfigurationProperties.get(SPARK_YARN_EXECUTOR_MEMORY_OVERHEAD).isEmpty) {
+    if (appConfigurationProperties.get(memoryOverHeadConfigKey).isEmpty) {
       val overheadMemory = executorMemory.get * (appConfigurationProperties.get(SPARK_MEMORY_OVERHEAD_MULTIPLIER_PERCENT).getOrElse(DEFAULT_SPARK_MEMORY_OVERHEAD_MULTIPLIER_PERCENT)).toInt / 100
       Option(overheadMemory)
     } else {
-      appConfigurationProperties.get(SPARK_YARN_EXECUTOR_MEMORY_OVERHEAD).map(MemoryFormatUtils.stringToBytes)
+      appConfigurationProperties.get(memoryOverHeadConfigKey).map(MemoryFormatUtils.stringToBytes)
     }
   }
 
-  private def getRoundedContainerBytes(data: SparkApplicationData): Option[Long] = {
+  private def getRoundedContainerBytes(data: SparkApplicationData, isDriver: Boolean): Option[Long] = {
     val increment = getIncrementBytes()
-    val executorMemory = executorMemoryBytesOf(data)
-    val memoryOverHead = overheadMemoryBytesOf(data)
+    val executorMemory = if (isDriver) driverMemoryBytesOf(data) else executorMemoryBytesOf(data)
+    val memoryOverHead = overheadMemoryBytesOf(data, isDriver)
     val totalMemoryRequired = executorMemory.get + memoryOverHead.get
     val roundedContainerBytes = Math.ceil((totalMemoryRequired * 1.0) / increment.get) * increment.get
     Option(roundedContainerBytes.longValue())

--- a/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
+++ b/app/com/linkedin/drelephant/spark/SparkMetricsAggregator.scala
@@ -62,6 +62,8 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
     if (applicationDurationMillis < 0) {
       logger.warn(s"applicationDurationMillis is negative. Skipping Metrics Aggregation:${applicationDurationMillis}")
     } else {
+      //From now on we will be using resource allocated from RM API. Not cleaning up the code now, will do 
+      //it in a separate PR. 
       var (resourcesActuallyUsed, resourcesAllocatedForUse) = calculateResourceUsage(data)
       val resourcesActuallyUsedWithBuffer = resourcesActuallyUsed.doubleValue() * (1.0 + allocatedMemoryWasteBufferPercentage)
       val resourcesWastedMBSeconds = (resourcesActuallyUsedWithBuffer < resourcesAllocatedForUse.doubleValue()) match {
@@ -105,7 +107,7 @@ class SparkMetricsAggregator(private val aggregatorConfigurationData: Aggregator
       executorSummary => {
         val executorStartTime = executorSummary.addTime
         var executorEndTime = executorSummary.removeTime
-        if (executorEndTime == null) {
+        if (Option(executorEndTime).isEmpty) {
           executorEndTime = attemptEndTime;
         }
         var memoryOverhead: Long = 0L

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
@@ -88,6 +88,8 @@ trait ExecutorSummary{
   def totalShuffleRead: Long
   def totalShuffleWrite: Long
   def maxMemory: Long
+  def addTime: Date
+  def removeTime: Date
   def totalGCTime: Long
   def totalMemoryBytesSpilled: Long
   def executorLogs: Map[String, String]
@@ -338,6 +340,8 @@ class ExecutorSummaryImpl(
   var totalShuffleRead: Long,
   var totalShuffleWrite: Long,
   var maxMemory: Long,
+  var addTime: Date,
+  var removeTime: Date,
   var totalGCTime: Long,
   var totalMemoryBytesSpilled: Long,
   var executorLogs: Map[String, String],

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -234,7 +234,7 @@ object LegacyDataConverters {
         executorInfo.shuffleWrite,
         executorInfo.maxMem,
         new Date(executorInfo.addTime),
-        if(executorInfo.removeTime!=null) new Date(executorInfo.removeTime) else null,
+        if (Option(executorInfo.removeTime).isDefined) new Date(executorInfo.removeTime) else null,
         executorInfo.totalGCTime,
         executorInfo.totalMemoryBytesSpilled,
         executorLogs = Map.empty,

--- a/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
+++ b/app/com/linkedin/drelephant/spark/legacydata/LegacyDataConverters.scala
@@ -233,6 +233,8 @@ object LegacyDataConverters {
         executorInfo.shuffleRead,
         executorInfo.shuffleWrite,
         executorInfo.maxMem,
+        new Date(executorInfo.addTime),
+        if(executorInfo.removeTime!=null) new Date(executorInfo.removeTime) else null,
         executorInfo.totalGCTime,
         executorInfo.totalMemoryBytesSpilled,
         executorLogs = Map.empty,

--- a/app/com/linkedin/drelephant/spark/legacydata/SparkExecutorData.java
+++ b/app/com/linkedin/drelephant/spark/legacydata/SparkExecutorData.java
@@ -45,6 +45,8 @@ public class SparkExecutorData {
     public long outputBytes = 0L;
     public long shuffleRead = 0L;
     public long totalGCTime = 0L;
+    public long addTime = 0L;
+    public Long removeTime = 0L;
     public long totalMemoryBytesSpilled = 0L;
     public long shuffleWrite = 0L;
 

--- a/app/org/apache/spark/deploy/history/SparkDataCollection.scala
+++ b/app/org/apache/spark/deploy/history/SparkDataCollection.scala
@@ -186,7 +186,13 @@ class SparkDataCollection extends SparkApplicationData {
         info.inputBytes = executorsListener.executorToInputBytes.getOrElse(info.execId, 0L)
         info.shuffleRead = executorsListener.executorToShuffleRead.getOrElse(info.execId, 0L)
         info.shuffleWrite = executorsListener.executorToShuffleWrite.getOrElse(info.execId, 0L)
-
+        if (!info.execId.equals("driver")) {
+          info.addTime = executorsListener.executorIdToData(info.execId).startTime
+          info.removeTime = if (executorsListener.executorIdToData(info.execId).finishTime.isEmpty) null else executorsListener.executorIdToData(info.execId).finishTime.get
+        } else {
+          info.addTime = _applicationData.getStartTime
+          info.removeTime =_applicationData.getEndTime
+        }
         _executorData.setExecutorInfo(info.execId, info)
       }
     }

--- a/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
+++ b/test/com/linkedin/drelephant/spark/SparkMetricsAggregatorTest.scala
@@ -95,12 +95,12 @@ class SparkMetricsAggregatorTest extends FunSpec with Matchers {
       val result = aggregator.getResult
 
       it("calculates resources used (allocated)") {
-        result.getResourceUsed should be(6826666)
+        result.getResourceUsed should be(20480000)
       }
 
       it("calculates resources wasted") {
-        val resourceAllocated = 6826666
-        val resourceUsed = 1366999
+        val resourceAllocated = 20480000
+        val resourceUsed = 4100998
         val resourceWasted: Long = (resourceAllocated.toDouble - resourceUsed.toDouble * 1.5).longValue()
         result.getResourceWasted should be(resourceWasted)
       }
@@ -203,6 +203,8 @@ object SparkMetricsAggregatorTest {
     totalShuffleRead = 0,
     totalShuffleWrite = 0,
     maxMemory = 0,
+    addTime = new Date(1567159291000L-totalDuration),
+    removeTime = new Date(1567159291000L),
     totalGCTime = 0,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/DriverHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/DriverHeuristicTest.scala
@@ -1,5 +1,7 @@
 package com.linkedin.drelephant.spark.heuristics
 
+import java.util.Date
+
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkRestDerivedData}
@@ -86,6 +88,8 @@ object DriverHeuristicTest {
     totalShuffleRead = 0,
     totalShuffleWrite = 0,
     maxMemory,
+    new Date(),
+    new Date(),
     totalGCTime,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
@@ -16,6 +16,8 @@
 
 package com.linkedin.drelephant.spark.heuristics
 
+import java.util.Date
+
 import scala.collection.JavaConverters
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity, SeverityThresholds}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
@@ -187,6 +189,8 @@ object ExecutorGcHeuristicTest {
     totalShuffleRead=0,
     totalShuffleWrite= 0,
     maxMemory = 0,
+    new Date(),
+    new Date(),
     totalGCTime,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorStorageSpillHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorStorageSpillHeuristicTest.scala
@@ -16,6 +16,8 @@
 
 package com.linkedin.drelephant.spark.heuristics
 
+import java.util.Date
+
 import scala.collection.JavaConverters
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity, SeverityThresholds}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
@@ -123,6 +125,8 @@ object ExecutorStorageSpillHeuristicTest {
     totalShuffleRead=0,
     totalShuffleWrite= 0,
     maxMemory= 2000,
+    addTime = new Date(),
+    removeTime = new Date(),
     totalGCTime = 0,
     totalMemoryBytesSpilled,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorsHeuristicTest.scala
@@ -16,8 +16,9 @@
 
 package com.linkedin.drelephant.spark.heuristics
 
-import scala.collection.JavaConverters
+import java.util.Date
 
+import scala.collection.JavaConverters
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity, SeverityThresholds}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
@@ -253,6 +254,8 @@ object ExecutorsHeuristicTest {
     totalShuffleRead,
     totalShuffleWrite,
     maxMemory,
+    addTime = new Date(),
+    removeTime = new Date(),
     totalGCTime = 0,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/JvmUsedMemoryHeuristicTest.scala
@@ -1,5 +1,7 @@
 package com.linkedin.drelephant.spark.heuristics
 
+import java.util.Date
+
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
@@ -99,6 +101,8 @@ object JvmUsedMemoryHeuristicTest {
     totalShuffleRead = 0,
     totalShuffleWrite = 0,
     maxMemory = 0,
+    addTime = new Date(),
+    removeTime = new Date(),
     totalGCTime = 0,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/SparkTestUtilities.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/SparkTestUtilities.scala
@@ -520,6 +520,8 @@ private [spark] object SparkTestUtilities {
     totalShuffleRead=0,
     totalShuffleWrite= 0,
     maxMemory = 0,
+    addTime = new Date(),
+    removeTime = new Date(),
     totalGCTimeSec * 1000,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,

--- a/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/UnifiedMemoryHeuristicTest.scala
@@ -1,5 +1,7 @@
 package com.linkedin.drelephant.spark.heuristics
 
+import java.util.Date
+
 import com.linkedin.drelephant.analysis.{ApplicationType, Severity}
 import com.linkedin.drelephant.configurations.heuristic.HeuristicConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
@@ -149,6 +151,8 @@ object UnifiedMemoryHeuristicTest {
     totalShuffleRead = 0,
     totalShuffleWrite = 0,
     maxMemory,
+    addTime = new Date(),
+    removeTime = new Date(),
     totalGCTime = 0,
     totalMemoryBytesSpilled = 0,
     executorLogs = Map.empty,


### PR DESCRIPTION
### Problem
Resource usage for Spark jobs in Dr. Elephant is understated. Goal is to fix this, so it represent actual resource usage for a job. 

We found that Dr. Elephant is using total_duration from containers SHS API (Spark History Server), but value, it is getting is total task time instead of duration. Total task time is time, a container spent in working on the tasks. So if a container is live for 10 minutes but it was working on task only for 2 minutes, then spark SHS API returns 2 minutes for total duration. Because of this Dr. Elephant RU numbers for Spark jobs is always less than RMAppSummary data.

### Solution
To fix this we are making following changes: 
- For resource allocated value, we will use memoryseconds from RM API 
- Start using addTime and removeTime to compute the duration rather than using total_duration field in executor API. 
- Currently for driver container SHS API always returns 0 for total_duration. So driver container usage are not counted. Using removeTime and addTime will result in driver usage being included as well. 

### Testing Done
- Verified for many Spark jobs whether we are getting right resource usage or not 
- Verified cases where both addTime and removeTime available for containers 
- Verified cases where for many containers removeTime field is not available

### Issues identified in SHS 
- Currently Spark history server (SHS) allexecutors API is not returning all the executors spawned throughout the life of the application. We are looking into this issue to fix from SHS side. 
- addTime is container launch time, not container allocation time. 
