### PR TITLE
Adding provision for Re-Enabling tuning in every two weeks for the jobs which have tuning disabled

### DIFF
--- a/app-conf/AutoTuningConf.xml
+++ b/app-conf/AutoTuningConf.xml
@@ -92,6 +92,23 @@
     <name>pig.hbt.version</name>
     <value>1</value>
   </property>
+
+
+  <property>
+    <name>re_enable_tunein_allowed</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>max_duration_for_tunein.disabled_in_days</name>
+    <value>2</value>
+  </property>
+  <property>
+    <name>max_iteration_after_tunein_re_enable</name>
+    <value>5</value>
+  </property>
+
+
   <!--The below property is optional-->
   <!--<property>-->
   <!--<name>python.path</name>-->

--- a/app/com/linkedin/drelephant/tuning/TuningHelper.java
+++ b/app/com/linkedin/drelephant/tuning/TuningHelper.java
@@ -189,4 +189,27 @@ public class TuningHelper {
     }
     return timeInMinutes;
   }
+
+  static JobSuggestedParamSet getLatestCreatedJobSuggestedParamSet(
+      long jobDefinitionId) {
+    return JobSuggestedParamSet.find.select("*")
+        .where()
+        .eq(JobSuggestedParamSet.TABLE.jobDefinition + "." + JobDefinition.TABLE.id,
+            jobDefinitionId)
+        .order()
+        .desc(JobSuggestedParamSet.TABLE.updatedTs)
+        .setMaxRows(1)
+        .findUnique();
+  }
+
+  static JobSuggestedParamSet getDefaultParamSet(long jobDefinitionId) {
+    return JobSuggestedParamSet.find.select("*")
+        .where()
+        .eq(JobSuggestedParamSet.TABLE.jobDefinition + "." + JobDefinition.TABLE.id,
+            jobDefinitionId)
+        .eq(JobSuggestedParamSet.TABLE.isParamSetDefault, true)
+        .ne(JobSuggestedParamSet.TABLE.paramSetState, JobSuggestedParamSet.ParamSetStatus
+            .DISCARDED)
+        .findUnique();
+  }
 }

--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -59,6 +59,11 @@ public final class Utils {
 
   private static final String TRUNCATE_SUFFIX = "...";
 
+  public static final int HOURS_IN_ONE_DAY = 24;
+  public static final int MINUTES_IN_ONE_HOURS = 60;
+  public static final int SECONDS_IN_ONE_MINUTE = 60;
+  public static final int MILLISECONDS_IN_ONE_SECOND = 1000;
+
   private Utils() {
     // do nothing
   }
@@ -618,5 +623,24 @@ public final class Utils {
       }
     }
     return builder.toString();
+  }
+
+  public static long getTimeInMilliSecondsFromDays(int numberOfDays) {
+    return getTimeInMilliSecondsFromHours(numberOfDays *
+        HOURS_IN_ONE_DAY);
+  }
+
+  public static long getTimeInMilliSecondsFromHours(int numberOfhours) {
+    return getTimeInMilliSecondsFromMinutes(numberOfhours *
+        MINUTES_IN_ONE_HOURS);
+  }
+
+  public static long getTimeInMilliSecondsFromMinutes(int numberOfminutes) {
+    return getTimeInMilliSecondsFromSeconds(numberOfminutes *
+        SECONDS_IN_ONE_MINUTE);
+  }
+
+  public static long getTimeInMilliSecondsFromSeconds(int numberOfseconds) {
+    return numberOfseconds * MILLISECONDS_IN_ONE_SECOND;
   }
 }

--- a/test/com/linkedin/drelephant/tuning/TestAutoTuningAPIHelper.java
+++ b/test/com/linkedin/drelephant/tuning/TestAutoTuningAPIHelper.java
@@ -1,0 +1,118 @@
+package com.linkedin.drelephant.tuning;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import models.JobDefinition;
+import models.JobSuggestedParamSet;
+import models.TuningJobDefinition;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import play.Application;
+import play.GlobalSettings;
+import play.test.FakeApplication;
+
+import static common.DBTestUtil.*;
+import static common.TestConstants.*;
+import static play.test.Helpers.*;
+
+
+public class TestAutoTuningAPIHelper {
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private static FakeApplication fakeApp;
+
+  private final static long testJobDefintionId_1 = 100149;
+  private final static long testJobDefintionId_2 = 100150;
+  private final static String ALL_HEURISTICS_PASSED = "All Heuristics Passed";
+
+  private final double delta = 0.000001;
+
+  private void populateTestData() {
+    try {
+      initTuneInReEnableMockDB();
+    } catch (IOException ioEx) {
+      logger.error("IOException encountered while populating test data", ioEx);
+    } catch (SQLException sqlEx) {
+      logger.error("SqlException encountered while populating test data", sqlEx);
+    }
+  }
+
+  @Before
+  public void setup() {
+    Map<String, String> dbConn = new HashMap<>();
+    dbConn.put(DB_DEFAULT_DRIVER_KEY, DB_DEFAULT_DRIVER_VALUE);
+    dbConn.put(DB_DEFAULT_URL_KEY, DB_DEFAULT_URL_VALUE);
+    dbConn.put(EVOLUTION_PLUGIN_KEY, EVOLUTION_PLUGIN_VALUE);
+    dbConn.put(APPLY_EVOLUTIONS_DEFAULT_KEY, APPLY_EVOLUTIONS_DEFAULT_VALUE);
+
+    GlobalSettings gs = new GlobalSettings() {
+      @Override
+      public void onStart(Application app) {
+        logger.info("Starting FakeApplication");
+      }
+    };
+
+    fakeApp = fakeApplication(dbConn, gs);
+  }
+
+  private TuningJobDefinition getTuningJobDefinition(long jobDefinitionId) {
+    return TuningJobDefinition.find.select("*")
+        .where()
+        .eq(TuningJobDefinition.TABLE.job + "." + JobDefinition.TABLE.id, jobDefinitionId)
+        .findUnique();
+  }
+
+  @Test
+  public void testReEnableWhenAutoApplyDisabled() {
+    running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
+      public void run() {
+        populateTestData();
+        logger.info("testing the re-enablement ooooo");
+        TuningJobDefinition tjd = getTuningJobDefinition(testJobDefintionId_1);
+        Assert.assertFalse(tjd.tuningEnabled);
+        Assert.assertFalse(tjd.autoApply);
+        Assert.assertNotNull(tjd.tuningDisabledReason);
+        Assert.assertNotEquals(tjd.tuningDisabledReason, "");
+        AutoTuningAPIHelper autoTuningAPIHelper = new AutoTuningAPIHelper();
+        autoTuningAPIHelper.reEnableAutoTuning(tjd, null);
+        Assert.assertFalse(tjd.tuningEnabled);
+      }
+    });
+  }
+
+  @Test
+  public void testReEnableTuning() {
+    running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
+      public void run() {
+        populateTestData();
+        TuningJobDefinition tjd = getTuningJobDefinition(testJobDefintionId_2);
+        Assert.assertFalse(tjd.tuningEnabled);
+        Assert.assertTrue(tjd.autoApply);
+        Assert.assertNotNull(tjd.tuningDisabledReason);
+        Assert.assertEquals(tjd.tuningDisabledReason, ALL_HEURISTICS_PASSED);
+
+        AutoTuningAPIHelper autoTuningAPIHelper = new AutoTuningAPIHelper();
+        autoTuningAPIHelper.reEnableAutoTuning(tjd, null);
+
+        Assert.assertTrue(tjd.tuningEnabled);
+        Assert.assertNotNull(tjd.tuningDisabledReason);
+        Assert.assertEquals(tjd.tuningDisabledReason, StringUtils.EMPTY);
+
+        JobSuggestedParamSet bestJobSuggestedParamSet = JobSuggestedParamSet.find.select("*")
+            .where()
+            .eq(JobSuggestedParamSet.TABLE.jobDefinition + "." + JobDefinition.TABLE.id, tjd.job.id)
+            .eq(JobSuggestedParamSet.TABLE.isParamSetBest, true)
+            .findUnique();
+        Assert.assertNull(bestJobSuggestedParamSet);
+      }
+    });
+  }
+}

--- a/test/com/linkedin/drelephant/util/UtilsTest.java
+++ b/test/com/linkedin/drelephant/util/UtilsTest.java
@@ -16,21 +16,18 @@
 
 package com.linkedin.drelephant.util;
 
-
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 
 /**
  * This class tests the Utils class
  */
 public class UtilsTest {
-
   @Test
   public void testParseJavaOptions() {
     Map<String, String> options1 = Utils.parseJavaOptions("-Dfoo=bar");
@@ -186,8 +183,8 @@ public class UtilsTest {
     assertEquals("Hello world!", Utils.formatStringOrNull("%s %s!", "Hello", "world"));
     assertEquals(null, Utils.formatStringOrNull("%s %s!", "Hello", null));
   }
- 
-  @Test 
+
+  @Test
   public void testGetDurationBreakdown() {
     long []durations = {13423,432344,23423562,23,324252,1132141414141L};
     assertEquals("0:00:13", Utils.getDurationBreakdown(durations[0]));
@@ -232,6 +229,34 @@ public class UtilsTest {
     assertEquals("0.172 GB Hours", Utils.getResourceInGBHours(durations[3]));
     assertEquals("0 GB Hours", Utils.getResourceInGBHours(durations[4]));
 
+  }
+
+  @Test
+  public void testGetTimeInMilliSecondsFromDays() {
+    assertEquals(Utils.getTimeInMilliSecondsFromDays(1), 86400000);
+    assertEquals(Utils.getTimeInMilliSecondsFromDays(0), 0);
+  }
+
+  @Test
+  public void testGetTimeInMilliSecondsFromHours() {
+    assertEquals(Utils.getTimeInMilliSecondsFromHours(1), 3600000);
+    assertEquals(Utils.getTimeInMilliSecondsFromHours(24), 86400000);
+    assertEquals(Utils.getTimeInMilliSecondsFromHours(0), 0);
+  }
+
+  @Test
+  public void testGetTimeInMilliSecondsFromMinutes() {
+    assertEquals(Utils.getTimeInMilliSecondsFromMinutes(1), 60000);
+    assertEquals(Utils.getTimeInMilliSecondsFromMinutes(60), 3600000);
+    assertEquals(Utils.getTimeInMilliSecondsFromMinutes(3600), 216000000);
+    assertEquals(Utils.getTimeInMilliSecondsFromMinutes(0), 0);
+  }
+
+  @Test
+  public void testGetTimeInMilliSecondsFromSeconds() {
+    assertEquals(Utils.getTimeInMilliSecondsFromSeconds(1), 1000);
+    assertEquals(Utils.getTimeInMilliSecondsFromSeconds(60), 60000);
+    assertEquals(Utils.getTimeInMilliSecondsFromMinutes(0), 0);
   }
 
 }

--- a/test/common/DBTestUtil.java
+++ b/test/common/DBTestUtil.java
@@ -66,6 +66,10 @@ public class DBTestUtil {
     initDBUtil(TEST_MR_PIG_HBT_PARAMETER_RECOMMENDER);
   }
 
+  public static void initTuneInReEnableMockDB() throws IOException, SQLException {
+    initDBUtil(TEST_TUNEIN_RE_ENABLE_DATA_FILE);
+  }
+
   public static void initDBForExceptionFingerPrinting() throws IOException, SQLException {
     initDBUtil(TEST_EXCEPTION_FINGERPRINTING);
   }

--- a/test/common/TestConstants.java
+++ b/test/common/TestConstants.java
@@ -31,6 +31,7 @@ public class TestConstants {
   public static final String TEST_SPARK_HBT_PARAM_RECOMMENDER = "test/resources/test-SparkHBTParamRecommender.sql";
   public static final String TEST_AUTO_TUNING_MR_HBT="test/resources/test-init-MRHBT.sql";
   public static final String TEST_MR_PIG_HBT_PARAMETER_RECOMMENDER = "test/resources/test-pig-hbt.sql";
+  public static final String TEST_TUNEIN_RE_ENABLE_DATA_FILE = "test/resources/test-tunein-re-enable.sql";
   public static final String TEST_EXCEPTION_FINGERPRINTING = "test/resources/test-exception-fingerprinting.sql";
   public static final int RESPONSE_TIMEOUT = 3000; // milliseconds
 

--- a/test/resources/AutoTuningConf.xml
+++ b/test/resources/AutoTuningConf.xml
@@ -87,4 +87,20 @@
     <value>corp.com</value>
     <description>company domain email address</description>
 </property>
+
+
+  <property>
+    <name>re_enable_tunein_allowed</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>max_duration_for_tunein.disabled_in_days</name>
+    <value>2</value>
+  </property>
+  <property>
+    <name>max_iteration_after_tunein_re_enable</name>
+    <value>5</value>
+  </property>
+
 </configuration>

--- a/test/resources/test-tunein-re-enable.sql
+++ b/test/resources/test-tunein-re-enable.sql
@@ -1,0 +1,62 @@
+INSERT INTO `flow_definition` (`id`, `flow_def_id`, `flow_def_url`, `created_ts`, `updated_ts`) VALUES
+(1,'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_1',
+'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_1','2019-05-28 22:07:43','2019-05-28 22:07:43'),
+(2,'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_2',
+'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_2','2019-05-28 23:07:54','2019-05-28 23:07:54');
+
+INSERT INTO `job_definition` (`id`, `job_def_id`, `job_def_url`, `flow_definition_id`, `job_name`, `scheduler`, `username`, `created_ts`, `updated_ts`)
+VALUES (100149,'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_1&job=job_1',
+'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_1&job=job_1',
+1,'job_1','azkaban','metrics','2019-05-28 22:07:43','2019-05-28 22:07:43'),
+
+(100150,'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_2&job=job_2',
+'https://elephant.linkedin.com:8443/manager?project=testProject&flow=flow_2&job=job_2',
+2,'job_2','azkaban','metrics','2019-05-28 23:07:54','2019-05-28 23:07:54');
+
+INSERT INTO `tuning_algorithm` (`job_type`, `optimization_algo`, `optimization_algo_version`, `optimization_metric`, `created_ts`,
+ `updated_ts`) VALUES
+ ('PIG','PSO',1,'RESOURCE','2018-08-23 08:53:51','2018-08-23 08:53:51'),
+ ('PIG','PSO_IPSO',3,'RESOURCE','2018-08-23 08:53:53','2018-08-23 08:53:53'),
+ ('PIG','HBT',4,'RESOURCE','2018-08-29 13:16:25','2018-08-29 13:16:25'),
+ ('SPARK','HBT',1,'RESOURCE','2018-09-04 07:26:29','2018-09-04 07:26:29');
+
+INSERT INTO `tuning_job_definition` (`job_definition_id`, `client`, `tuning_algorithm_id`, `tuning_enabled`, `auto_apply`,
+ `average_resource_usage`, `average_execution_time`, `average_input_size_in_bytes`, `allowed_max_resource_usage_percent`,
+ `allowed_max_execution_time_percent`, `tuning_disabled_reason`, `number_of_iterations`, `created_ts`, `updated_ts`,
+ `show_recommendation_count`) VALUES
+ (100149,'azkaban',4,0,0,14.48426667,42.86533333,52739178496,150,150,'All Heuristics Passed',10,'2019-05-29 04:03:38',
+ '2019-09-12 18:38:46',9),
+ (100150,'azkaban',4,0,1,3920.58746667,43.52463333,8200657043456,150,150,'All Heuristics Passed',10,
+'2019-05-29 03:06:47','2019-09-13 19:50:03',31);
+
+INSERT INTO `flow_execution` (`id`, `flow_exec_id`, `flow_exec_url`, `flow_definition_id`, `created_ts`, `updated_ts`) VALUES
+(1573,'https://elephant.linkedin.com:8443/executor?execid=5252291','https://elephant.linkedin.com:8443/executor?execid=5252291'
+,2,'2019-05-29 03:06:48','2019-05-29 03:06:48'),
+(1574,'https://elephant.linkedin.com:8443/executor?execid=5252449','https://elephant.linkedin.com:8443/executor?execid=5252449',
+1,'2019-05-29 04:03:38','2019-05-29 04:03:39'),
+(1575,'https://elephant.linkedin.com:8443/executor?execid=5252941',
+'https://elephant.linkedin.com:8443/executor?execid=5252941',1,'2019-05-29 07:00:43','2019-05-29 07:00:44'),
+(1576,'https://elephant.linkedin.com:8443/executor?execid=5253039','https://elephant.linkedin.com:8443/executor?execid=5253039',
+2,'2019-05-29 07:32:46','2019-05-29 07:32:47');
+
+INSERT INTO `job_execution`
+(`id`, `job_exec_id`, `job_exec_url`, `job_definition_id`, `flow_execution_id`, `execution_state`, `resource_usage`,
+ `execution_time`, `input_size_in_bytes`, `auto_tuning_fault`, `created_ts`, `updated_ts`) VALUES
+ (1573,'https://elephant.linkedin.com:8443/executor?execid=5252291&job=job_2&attempt=0',
+ 'https://elephant.linkedin.com:8443/executor?execid=5252291&job=job_2&attempt=0',100150,1573,'SUCCEEDED',6712.747777777778,35.98485,0,0,'2019-05-29 03:06:48','2019-05-29 05:13:22'),
+ (1574,'https://elephant.linkedin.com:8443/executor?execid=5252449&job=job_1&attempt=0',
+ 'https://elephant.linkedin.com:8443/executor?execid=5252449&job=job_1&attempt=0',100149,1574,'SUCCEEDED',16.90162326388889,44.608583333333335,0,0,'2019-05-29 04:03:38','2019-05-29 06:16:26'),
+ (1575,'https://elephant.linkedin.com:8443/executor?execid=5252941&job=job_1&attempt=0',
+ 'https://elephant.linkedin.com:8443/executor?execid=5252941&job=job_1&attempt=0',100149,1575,
+ 'SUCCEEDED',16.791666666666668,49.040533333333336,0,0,'2019-05-29 07:00:43','2019-05-29 09:11:44'),
+ (1576,'https://elephant.linkedin.com:8443/executor?execid=5253039&job=job_2&attempt=0',
+ 'https://elephant.linkedin.com:8443/executor?execid=5253039&job=job_2&attempt=0',100150,
+ 1576,'SUCCEEDED',5378.952222222222,74.86451666666666,0,0,'2019-05-29 07:32:46','2019-05-29 10:07:47');
+
+INSERT INTO `job_suggested_param_set` (`id`, `job_definition_id`, `tuning_algorithm_id`, `param_set_state`, `are_constraints_violated`,
+ `is_param_set_default`, `is_param_set_best`, `is_manually_overriden_parameter`, `is_param_set_suggested`, `fitness`,
+  `fitness_job_execution_id`, `created_ts`, `updated_ts`) VALUES
+  (1579,100149,4,'FITNESS_COMPUTED',0,1,0,0,0,0,1574,'2019-05-29 04:03:38','2019-09-15 11:20:17'),
+  (1581,100149,4,'FITNESS_COMPUTED',0,0,1,0,1,112,1575,'2019-05-29 06:16:25','2019-05-29 09:11:44'),
+  (1578,100150,4,'FITNESS_COMPUTED',0,1,0,0,0,149702,1573,'2019-05-29 03:06:48','2019-05-29 11:48:04'),
+  (1580,100150,4,'FITNESS_COMPUTED',0,0,1,0,1,52588,1576,'2019-05-29 05:13:21','2019-05-29 17:08:44');


### PR DESCRIPTION
**DESCRIPTION**
In many cases, after TuneIn is disabled for a job, that job's resource usage spikes and there is a need for Re-Enabling TuneIn. For now the changes made in this PR are for Re-Enabling TuneIn every two weeks after TuneIn was disabled for the job.

**HOW CHANGES ARE TESTED**
Respective unit tests are implemented. One round of End to End testing is done on the EI machine.