### PR TITLE
Changes to alert PIG jobs and an extra rule in alerting

### DIFF
--- a/app/com/linkedin/drelephant/tuning/TuningHelper.java
+++ b/app/com/linkedin/drelephant/tuning/TuningHelper.java
@@ -81,6 +81,24 @@ public class TuningHelper {
     return tuningJobExecutionParamSets;
   }
 
+  public static TuningJobDefinition getTuningJobDefinitionFromExecution(JobExecution jobExecution) {
+    TuningJobDefinition tuningJobDefinition = TuningJobDefinition.find.select("*")
+        .where()
+        .eq(TuningJobDefinition.TABLE.job + '.' + JobDefinition.TABLE.id, jobExecution.job.id)
+        .findUnique();
+    return tuningJobDefinition;
+  }
+
+  public static List<TuningJobExecutionParamSet> getTuningJobExecutionFromParamSet(JobSuggestedParamSet jobSuggestedParamSet) {
+    List<TuningJobExecutionParamSet> tuningJobExecutionParamSets = TuningJobExecutionParamSet.find.select("*")
+        .where()
+        .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + "." + JobSuggestedParamSet.TABLE.id,
+            jobSuggestedParamSet.id)
+        .eq(TuningJobExecutionParamSet.TABLE.isRetried, true)
+        .findList();
+    return tuningJobExecutionParamSets;
+  }
+
   public static int getNumberOfValidSuggestedParamExecution(
       List<TuningJobExecutionParamSet> tuningJobExecutionParamSets) {
     int autoAppliedExecution = 0;

--- a/app/com/linkedin/drelephant/tuning/alerting/NotificationDataGenerator.java
+++ b/app/com/linkedin/drelephant/tuning/alerting/NotificationDataGenerator.java
@@ -17,6 +17,7 @@
 package com.linkedin.drelephant.tuning.alerting;
 
 import com.linkedin.drelephant.tuning.NotificationData;
+import com.linkedin.drelephant.util.Utils;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,11 +40,15 @@ public class NotificationDataGenerator {
   boolean debugEnabled = logger.isDebugEnabled();
   private long windowStartTimeMS;
   private long windowEndTimeMS;
+
+//  Time for which a parameter set is in EXECUTED state before it gets alerted
+  private long paramExecutedStateStaleTime;
   private static String DEVELOPERS_RECIPIENT_ADDRESS = null;
   private List<NotificationData> notificationMessages = null;
   private static String EMAIL_DOMAIN_NAME = null;
   private static long RECENCY_WINDOW_IN_MS = 259200000;
-  private static long TWO_DAYS = 172800000;
+  private static final String PARAM_EXECUTED_STATE_STALE_TIME = "tuning.stale.data.timeout.ms";
+  private static long DEFAULT_PARAM_EXECUTED_STATE_STALE_TIME = 172800000;
 
   public NotificationDataGenerator(long windowStartTimeMS, long windowEndTimeMS, Configuration configuration) {
     this.windowStartTimeMS = windowStartTimeMS;
@@ -51,6 +56,8 @@ public class NotificationDataGenerator {
     DEVELOPERS_RECIPIENT_ADDRESS = configuration.get(ALERTING_DEVELOPERS_RECIPIENT_ADDRESS_PROPERTY);
     EMAIL_DOMAIN_NAME = configuration.get(EMAIL_DOMAIN_NAME_PROPERTY);
     notificationMessages = new ArrayList<NotificationData>();
+    paramExecutedStateStaleTime =
+        Utils.getNonNegativeLong(configuration, PARAM_EXECUTED_STATE_STALE_TIME, DEFAULT_PARAM_EXECUTED_STATE_STALE_TIME);
   }
 
   //todo: Create Rule Interface and then extends specific rule from that interface .
@@ -116,19 +123,20 @@ public class NotificationDataGenerator {
   }
 
   /**
-   *  This rule alerts if param is in EXECUTED state for last 2 days
+   *  This rule alerts if param is in EXECUTED state for last couple of days
    */
 
   private void paramFitnessNotComputedRule() {
     List<JobSuggestedParamSet> jobSuggestedParamSets = JobSuggestedParamSet.find.select("*")
         .where()
         .eq(JobSuggestedParamSet.TABLE.paramSetState, JobSuggestedParamSet.ParamSetStatus.EXECUTED)
-        .between(JobSuggestedParamSet.TABLE.updatedTs, new Timestamp(windowStartTimeMS - TWO_DAYS), new Timestamp(windowEndTimeMS - TWO_DAYS))
+        .between(JobSuggestedParamSet.TABLE.updatedTs,
+            new Timestamp(windowStartTimeMS - paramExecutedStateStaleTime), new Timestamp(windowEndTimeMS - paramExecutedStateStaleTime))
         .findList();
 
     if (jobSuggestedParamSets != null && jobSuggestedParamSets.size() > 0) {
       NotificationData data = new NotificationData(DEVELOPERS_RECIPIENT_ADDRESS);
-      data.setSubject(" Following are the parameter Ids which are in EXECUTED state from at least last 2 days");
+      data.setSubject(" Following are the parameter Ids which are in EXECUTED state from couple of days");
       data.setNotificationType(NotificationType.DEVELOPER);
       for (JobSuggestedParamSet jobSuggestedParamSet : jobSuggestedParamSets) {
         data.addContent(String.valueOf(jobSuggestedParamSet.id));

--- a/app/com/linkedin/drelephant/tuning/alerting/NotificationDataGenerator.java
+++ b/app/com/linkedin/drelephant/tuning/alerting/NotificationDataGenerator.java
@@ -16,8 +16,6 @@
 
 package com.linkedin.drelephant.tuning.alerting;
 
-import com.avaje.ebean.Ebean;
-import com.avaje.ebean.SqlRow;
 import com.linkedin.drelephant.tuning.NotificationData;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -29,7 +27,6 @@ import models.JobSuggestedParamSet;
 import static com.linkedin.drelephant.tuning.alerting.Constant.*;
 
 import models.TuningJobDefinition;
-import models.TuningJobExecutionParamSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
@@ -136,7 +133,6 @@ public class NotificationDataGenerator {
       for (JobSuggestedParamSet jobSuggestedParamSet : jobSuggestedParamSets) {
         data.addContent(String.valueOf(jobSuggestedParamSet.id));
       }
-      logger.info("[paramFitnessNotComputedRule] data : " + data.getContent());
       notificationMessages.add(data);
     }
 

--- a/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
+++ b/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
@@ -30,6 +30,7 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
   private final Logger logger = Logger.getLogger(getClass());
   private boolean isDebugEnabled = logger.isDebugEnabled();
   private final int MINIMUM_HBT_EXECUTION = 3;
+  private final int PARAMETER_RETRY_THRESHOLD = 2;
 
   public FitnessManagerHBT() {
     Configuration configuration = ElephantContext.instance().getAutoTuningConf();
@@ -159,6 +160,30 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
   private void handleJobSucceededAfterRetryScenarios(JobSuggestedParamSet jobSuggestedParamSet,
       JobExecution jobExecution) {
     FailureHandlerContext failureHandlerContext = new FailureHandlerContext();
+
+    /**
+     * Adding logic for identifying auto tuning failure for PIG jobs. Due to unavailability of
+     * exception fingerprinting for PIG, this is the criteria we are opting to
+     * identify auto tuning failure : param set is retried >= 2 times
+     */
+    TuningJobDefinition tuningJobDefinition = TuningJobDefinition.find.select("*")
+        .where()
+        .eq(TuningJobDefinition.TABLE.job + '.' + JobDefinition.TABLE.id, jobExecution.job.id)
+        .findUnique();
+
+    if (tuningJobDefinition.tuningAlgorithm.jobType == TuningAlgorithm.JobType.PIG) {
+      List<TuningJobExecutionParamSet> tuningJobExecutionParamSets = TuningJobExecutionParamSet.find.select("*")
+          .where()
+          .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + "." + JobSuggestedParamSet.TABLE.id,
+              jobSuggestedParamSet.id)
+          .eq(TuningJobExecutionParamSet.TABLE.isRetried, true)
+          .findList();
+
+      if (tuningJobExecutionParamSets.size() >= PARAMETER_RETRY_THRESHOLD) {
+        jobExecution.autoTuningFault = true;
+      }
+    }
+
     if (jobExecution.autoTuningFault) {
       logger.info(" Job execution was failed because of autotuning but retry worked" + jobExecution.id);
       failureHandlerContext.setFailureHandler(new AutoTuningFailureHandler());

--- a/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
+++ b/app/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBT.java
@@ -166,18 +166,11 @@ public class FitnessManagerHBT extends AbstractFitnessManager {
      * exception fingerprinting for PIG, this is the criteria we are opting to
      * identify auto tuning failure : param set is retried >= 2 times
      */
-    TuningJobDefinition tuningJobDefinition = TuningJobDefinition.find.select("*")
-        .where()
-        .eq(TuningJobDefinition.TABLE.job + '.' + JobDefinition.TABLE.id, jobExecution.job.id)
-        .findUnique();
+    TuningJobDefinition tuningJobDefinition = TuningHelper.getTuningJobDefinitionFromExecution(jobExecution);
 
     if (tuningJobDefinition.tuningAlgorithm.jobType == TuningAlgorithm.JobType.PIG) {
-      List<TuningJobExecutionParamSet> tuningJobExecutionParamSets = TuningJobExecutionParamSet.find.select("*")
-          .where()
-          .eq(TuningJobExecutionParamSet.TABLE.jobSuggestedParamSet + "." + JobSuggestedParamSet.TABLE.id,
-              jobSuggestedParamSet.id)
-          .eq(TuningJobExecutionParamSet.TABLE.isRetried, true)
-          .findList();
+      List<TuningJobExecutionParamSet> tuningJobExecutionParamSets =
+          TuningHelper.getTuningJobExecutionFromParamSet(jobSuggestedParamSet);
 
       if (tuningJobExecutionParamSets.size() >= PARAMETER_RETRY_THRESHOLD) {
         jobExecution.autoTuningFault = true;

--- a/test/com/linkedin/drelephant/tuning/AlertingTest.java
+++ b/test/com/linkedin/drelephant/tuning/AlertingTest.java
@@ -30,6 +30,7 @@ public class AlertingTest implements Runnable {
     populateTestData();
     testDeveloperAlerting();
     testSKAlerting();
+    testParamFitnessNotComputedRule();
   }
 
   private void testDeveloperAlerting() {
@@ -49,7 +50,6 @@ public class AlertingTest implements Runnable {
     JobSuggestedParamSet jobSuggestedParamSet = JobSuggestedParamSet.find.select("*").where().findUnique();
     jobSuggestedParamSet.updatedTs = new Timestamp(startTime + 100);
     jobSuggestedParamSet.createdTs = new Timestamp(endTime+1-259200000);
-    jobSuggestedParamSet.paramSetState = JobSuggestedParamSet.ParamSetStatus.EXECUTED;
     jobSuggestedParamSet.update();
 
     JobExecution jobExecution = JobExecution.find.select("*").where().eq(JobExecution.TABLE.id,"1541").findUnique();
@@ -65,13 +65,6 @@ public class AlertingTest implements Runnable {
     NotificationType notificationType = notificationDataAfterUpdate.get(0).getNotificationType();
     assertTrue(" Developers Notification  ",
         notificationType.name().equals(NotificationType.DEVELOPER.name()));
-
-    /**
-     * for testing paramFitnessNotComputedRule
-     */
-    notificationDataAfterUpdate = manager.generateNotificationData(startTime + 172800000, endTime + 172800000 + 1000);
-    assertTrue(" Notification data size "+notificationDataAfterUpdate.size(), notificationDataAfterUpdate.size() == 1);
-
 
     /**
      * If user want to test email functionality
@@ -105,5 +98,36 @@ public class AlertingTest implements Runnable {
      * If user want to test email functionality
      */
     //assertTrue(" Email send successfully ", manager.sendNotification(notificationData));
+  }
+
+  private void testParamFitnessNotComputedRule(){
+    Configuration configuration = ElephantContext.instance().getAutoTuningConf();
+    configuration.setBoolean("alerting.enabled", true);
+
+    long startTime = System.currentTimeMillis();
+    long endTime = System.currentTimeMillis() + 1000;
+
+    List<NotificationData> notificationDataBeforeUpdate =
+        new EmailNotificationManager(configuration).generateNotificationData(startTime, endTime);
+
+    assertTrue("No data within the range provided ", notificationDataBeforeUpdate.size() == 0);
+
+    JobSuggestedParamSet jobSuggestedParamSet = JobSuggestedParamSet.find.select("*")
+        .where()
+        .eq(JobSuggestedParamSet.TABLE.id, "1137")
+        .findUnique();
+    jobSuggestedParamSet.paramSetState = JobSuggestedParamSet.ParamSetStatus.EXECUTED;
+    jobSuggestedParamSet.update();
+
+    NotificationManager manager = new EmailNotificationManager(configuration);
+
+    List<NotificationData> notificationDataAfterUpdate =
+        manager.generateNotificationData(startTime + 172800000, endTime + 172800000 + 1000);
+
+    assertTrue(" Notification data size "+notificationDataAfterUpdate.size(), notificationDataAfterUpdate.size() == 1);
+    NotificationType notificationType = notificationDataAfterUpdate.get(0).getNotificationType();
+    assertTrue(" Developers Notification  ",
+        notificationType.name().equals(NotificationType.DEVELOPER.name()));
+
   }
 }

--- a/test/com/linkedin/drelephant/tuning/TuningManagerTest.java
+++ b/test/com/linkedin/drelephant/tuning/TuningManagerTest.java
@@ -19,6 +19,7 @@ package com.linkedin.drelephant.tuning;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.drelephant.DrElephant;
 import com.linkedin.drelephant.ElephantContext;
+import com.linkedin.drelephant.tuning.hbt.FitnessManagerHBTTest;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -126,5 +127,10 @@ public class TuningManagerTest {
   @Test
   public void testAlerting() throws InterruptedException {
     running(testServer(TEST_SERVER_PORT, fakeApp), new AlertingTest());
+  }
+
+  @Test
+  public void testFitnessManagerHBT() throws InterruptedException {
+    running(testServer(TEST_SERVER_PORT, fakeApp), new FitnessManagerHBTTest());
   }
 }

--- a/test/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBTTest.java
+++ b/test/com/linkedin/drelephant/tuning/hbt/FitnessManagerHBTTest.java
@@ -1,0 +1,86 @@
+package com.linkedin.drelephant.tuning.hbt;
+
+import java.util.List;
+import models.AppResult;
+import models.JobDefinition;
+import models.JobExecution;
+import models.JobSuggestedParamSet;
+import models.TuningJobDefinition;
+import models.TuningJobExecutionParamSet;
+
+import static common.DBTestUtil.*;
+import static org.junit.Assert.*;
+
+
+public class FitnessManagerHBTTest implements Runnable {
+
+  private void populateTestData() {
+    try {
+      initParamGenerater();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void run() {
+    populateTestData();
+    testCalculateAndUpdateFitness();
+  }
+
+  private void testCalculateAndUpdateFitness() {
+    FitnessManagerHBT fitnessManagerHBT = new FitnessManagerHBT();
+
+    JobExecution jobExecution = JobExecution.find.select("*")
+        .where()
+        .eq(JobExecution.TABLE.id,"1541")
+        .findUnique();
+
+    List<AppResult> appResults = AppResult.find.select("*")
+        .where()
+        .eq(JobExecution.TABLE.jobExecId, "https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0")
+        .findList();
+
+    TuningJobDefinition tuningJobDefinition = TuningJobDefinition.find.select("*")
+        .where()
+        .eq(TuningJobDefinition.TABLE.job + '.' + JobDefinition.TABLE.id, "100003")
+        .findUnique();
+
+    JobSuggestedParamSet jobSuggestedParamSet = JobSuggestedParamSet.find.select("*")
+        .where()
+        .eq(JobSuggestedParamSet.TABLE.id, "1137")
+        .findUnique();
+    jobSuggestedParamSet.fitness = 123D;
+    jobSuggestedParamSet.update();
+
+    TuningJobExecutionParamSet tuningJobExecutionParamSet = TuningJobExecutionParamSet.find.select("*")
+        .where()
+        .eq(TuningJobExecutionParamSet.TABLE.jobExecution + '.' + JobExecution.TABLE.id, "1541")
+        .findUnique();
+    tuningJobExecutionParamSet.isRetried = true;
+    tuningJobExecutionParamSet.update();
+
+    fitnessManagerHBT.calculateAndUpdateFitness(jobExecution, appResults, tuningJobDefinition,
+        jobSuggestedParamSet, true);
+
+    assertTrue("Fitness : " + jobSuggestedParamSet.fitness, jobSuggestedParamSet.fitness!=10000);
+    assertTrue("InputSizeInBytes : " + jobExecution.autoTuningFault, !jobExecution.autoTuningFault);
+
+    tuningJobExecutionParamSet = TuningJobExecutionParamSet.find.select("*")
+        .where()
+        .eq(TuningJobExecutionParamSet.TABLE.jobExecution + '.' + JobExecution.TABLE.id, "1542")
+        .findUnique();
+    tuningJobExecutionParamSet.isRetried = true;
+    tuningJobExecutionParamSet.update();
+
+    fitnessManagerHBT.calculateAndUpdateFitness(jobExecution, appResults, tuningJobDefinition,
+        jobSuggestedParamSet, true);
+
+    assertTrue("Fitness : " + jobSuggestedParamSet.fitness, jobSuggestedParamSet.fitness==10000);
+    assertTrue("ExecutionTime : " + jobExecution.executionTime, jobExecution.executionTime==0D);
+    assertTrue("InputSizeInBytes : " + jobExecution.inputSizeInBytes, jobExecution.inputSizeInBytes==1);
+    assertTrue("InputSizeInBytes : " + jobExecution.autoTuningFault, jobExecution.autoTuningFault);
+
+  }
+
+}

--- a/test/resources/AutoTuningConf.xml
+++ b/test/resources/AutoTuningConf.xml
@@ -87,4 +87,10 @@
     <value>corp.com</value>
     <description>company domain email address</description>
 </property>
+
+  <property>
+    <name>tuning.stale.data.timeout.ms</name>
+    <value>172800000</value>
+    <description>Generalized timeout property for data update</description>
+  </property>
 </configuration>

--- a/test/resources/test-param-generate-data.sql
+++ b/test/resources/test-param-generate-data.sql
@@ -1,7 +1,7 @@
 insert into yarn_app_result
     (id,name,username,queue_name,start_time,finish_time,tracking_url,job_type,severity,score,workflow_depth,scheduler,job_name,job_exec_id,flow_exec_id,job_def_id,flow_def_id,job_exec_url,flow_exec_url,job_def_url,flow_def_url,resource_used,resource_wasted,total_delay) values
-    ('application_1458194917883_1453361','Email Overwriter','pkumar2','misc_default',1460980616502,1460980723925,'http://elephant.linkedin.com:19888/jobhistory/job/job_1458194917883_1453361','HadoopJava',0,0,0,'azkaban','overwriter-reminder2','https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293','https://ltx1-holdemaz01.grid.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder','https://elephant.linkedin.com:8443/executor?execid=1654676&job=overwriter-reminder2&attempt=0','https://elephant.linkedin.com:8443/executor?execid=1654676','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder&job=overwriter-reminder2','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder', 100, 30, 20),
-    ('application_1458194917883_1453362','Email Overwriter','pkumar2','misc_default',1460980823925,1460980923925,'http://elephant.linkedin.com:19888/jobhistory/job/job_1458194917883_1453362','HadoopJava',0,0,0,'azkaban','overwriter-reminder2','https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293','https://ltx1-holdemaz01.grid.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder','https://elephant.linkedin.com:8443/executor?execid=1654677&job=overwriter-reminder2&attempt=0','https://elephant.linkedin.com:8443/executor?execid=1654677','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder&job=overwriter-reminder2','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder', 200, 40, 10);
+    ('application_1458194917883_1453361','Email Overwriter','pkumar2','misc_default',1460980616502,1460980723925,'http://elephant.linkedin.com:19888/jobhistory/job/job_1458194917883_1453361','HadoopJava',0,0,0,'azkaban','overwriter-reminder2','https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://elephant.linkedin.com:8443/executor?execid=5416293','https://elephant.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder','https://elephant.linkedin.com:8443/executor?execid=1654676&job=overwriter-reminder2&attempt=0','https://elephant.linkedin.com:8443/executor?execid=1654676','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder&job=overwriter-reminder2','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder', 100, 30, 20),
+    ('application_1458194917883_1453362','Email Overwriter','pkumar2','misc_default',1460980823925,1460980923925,'http://elephant.linkedin.com:19888/jobhistory/job/job_1458194917883_1453362','HadoopJava',0,0,0,'azkaban','overwriter-reminder2','https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://elephant.linkedin.com:8443/executor?execid=5416293','https://elephant.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder','https://elephant.linkedin.com:8443/executor?execid=1654677&job=overwriter-reminder2&attempt=0','https://elephant.linkedin.com:8443/executor?execid=1654677','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder&job=overwriter-reminder2','https://elephant.linkedin.com:8443/manager?project=b2-confirm-email-reminder&flow=reminder', 200, 40, 10);
 
 insert into yarn_app_heuristic_result(id,yarn_app_result_id,heuristic_class,heuristic_name,severity,score) values
 (137594512,'application_1458194917883_1453361','com.linkedin.drelephant.mapreduce.heuristics.MapperSkewHeuristic','Mapper Skew',0,0),
@@ -142,37 +142,32 @@ insert into yarn_app_heuristic_result_details (yarn_app_heuristic_result_id,name
  (137594640,'Number of tasks','20','NULL');
 
 INSERT INTO flow_definition(id, flow_def_id, flow_def_url) VALUES
-(10003,'https://ltx1-holdemaz01.grid.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow','https://ltx1-holdemaz01.grid.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow');
+(10003,'https://elephant.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow','https://elephant.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow');
 
 INSERT INTO job_definition(id, job_def_id, flow_definition_id, job_name, job_def_url, scheduler, username, created_ts, updated_ts) VALUES
-(100003,'https://ltx1-holdemaz01.grid.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry',10003,'countByCountryFlow_countByCountry','https://ltx1-holdemaz01.grid.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry','azkaban','pkumar2','2018-02-12 08:40:42','2018-02-12 08:40:43');
-
+(100003,'https://elephant.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry',10003,'countByCountryFlow_countByCountry','https://elephant.linkedin.com:8443/manager?project=AzkabanHelloPigTest&flow=countByCountryFlow&job=countByCountryFlow_countByCountry','azkaban','pkumar2','2018-02-12 08:40:42','2018-02-12 08:40:43');
 
 INSERT INTO tuning_job_definition(job_definition_id, client, tuning_algorithm_id, tuning_enabled, average_resource_usage, average_execution_time, average_input_size_in_bytes, allowed_max_resource_usage_percent, allowed_max_execution_time_percent, created_ts, updated_ts, tuning_disabled_reason, number_of_iterations, auto_apply)
 VALUES
 (100003,'azkaban',4,1,null,5.178423333333334,324168876088,150,150,'2018-02-12 08:40:42','2018-02-12 08:40:43', NULL, 5, true);
 
-
-
-
 INSERT INTO flow_execution(id, flow_exec_id, flow_exec_url, flow_definition_id) VALUES
-(1541,'https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293','https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293',10003);
+(1541,'https://elephant.linkedin.com:8443/executor?execid=5416293','https://elephant.linkedin.com:8443/executor?execid=5416293',10003),
+(1542,'https://elephant.linkedin.com:8443/executor?execid=5416293','https://elephant.linkedin.com:8443/executor?execid=5416293',10003);
 
 INSERT INTO job_execution(id, job_exec_id, job_exec_url, job_definition_id, flow_execution_id, execution_state, resource_usage, execution_time, input_size_in_bytes, created_ts, updated_ts) VALUES
-(1541,'https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://ltx1-holdemaz01.grid.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0',100003,1541,'SUCCEEDED',21.132545572916666,3.2694833333333335,324713861757,'2018-02-14 05:30:42','2018-02-14 05:30:42');
+(1541,'https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0',100003,1541,'SUCCEEDED',21.132545572916666,3.2694833333333335,324713861757,'2018-02-14 05:30:42','2018-02-14 05:30:42'),
+(1542,'https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0','https://elephant.linkedin.com:8443/executor?execid=5416293&job=countByCountryFlow_countByCountry&attempt=0',100003,1542,'SUCCEEDED',21.132545572916666,3.2694833333333335,324713861757,'2018-02-14 05:30:42','2018-02-14 05:30:42');
 
 INSERT INTO job_suggested_param_set VALUES
 (1137,100003,4,'FITNESS_COMPUTED', 0 ,1 , 0 ,  1 ,   0 ,10000 , 1086,'2018-09-17 23:22:31' ,'2018-09-17 11:09:31');
 
 INSERT INTO tuning_job_execution_param_set (job_suggested_param_set_id,job_execution_id,tuning_enabled,created_ts,updated_ts) VALUES
-(1137,1541,1,'2018-09-17 23:22:31','2018-09-17 10:52:31');
+(1137,1541,1,'2018-09-17 23:22:31','2018-09-17 10:52:31'),
+(1137,1542,1,'2018-09-17 23:22:31','2018-09-17 10:52:31');
 
 INSERT INTO job_suggested_param_value VALUES
 (366044, 1137, 21, 6112.888799667358, '2018-12-21 14:55:36', '2018-12-21 14:55:37'),
 (366045, 1137, 22, 1854.7078742980957, '2018-12-21 14:55:36', '2018-12-21 14:55:37'),
 (366046, 1137, 23, 3, '2018-12-21 14:55:36', '2018-12-21 14:55:37'),
 (366047, 1137, 24, 0.27054230043558763, '2018-12-21 14:55:36', '2018-12-21 14:55:37');
-
-
-
-


### PR DESCRIPTION
This PR contains the following changes:
1. If a PIG job execution is retried & parameter set in this execution is retried >=2 times then set the flag auto tuning fault to true in job execution. This way this job execution gets alerted and the parameter set gets penalized. Due to the unavailability of exception fingerprinting for PIG, this is a very elementary approach to alert PIG jobs.

2. Developers are alerted if a parameter set is in the "EXECUTED" state for the last 2 days.