### PR TITLE
Spark environment api

### DIFF
--- a/app/com/linkedin/drelephant/spark/data/SparkApplicationData.scala
+++ b/app/com/linkedin/drelephant/spark/data/SparkApplicationData.scala
@@ -18,8 +18,7 @@ package com.linkedin.drelephant.spark.data
 
 import java.util.Properties
 
-import scala.collection.JavaConverters
-
+import scala.collection.{JavaConverters, mutable}
 import com.linkedin.drelephant.analysis.{ApplicationType, HadoopApplicationData}
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfo, ExecutorSummary, JobData, StageData}
 
@@ -61,10 +60,15 @@ object SparkApplicationData {
     restDerivedData: SparkRestDerivedData,
     logDerivedData: Option[SparkLogDerivedData]
   ): SparkApplicationData = {
-    val appConfigurationProperties: Map[String, String] =
-      logDerivedData
-        .flatMap { _.environmentUpdate.environmentDetails.get("Spark Properties").map(_.toMap) }
-        .getOrElse(Map.empty)
+    var appConfigurationProperties: Map[String, String] = null
+    if(!restDerivedData.appConfigurationProperties.isDefined) {
+      appConfigurationProperties =
+            logDerivedData
+              .flatMap { _.environmentUpdate.environmentDetails.get("Spark Properties").map(_.toMap) }
+              .getOrElse(Map.empty)
+    }else{
+      appConfigurationProperties = getConfigurationPropertiesMap(restDerivedData.appConfigurationProperties.get.sparkProperties)
+    }
     val applicationInfo = restDerivedData.applicationInfo
     val jobDatas = restDerivedData.jobDatas
     val stageDatas = restDerivedData.stageDatas
@@ -72,5 +76,13 @@ object SparkApplicationData {
     val stagesWithFailedTasks = restDerivedData.stagesWithFailedTasks
     val targetRestURIForEF = restDerivedData.targetRestURI
     apply(appId, appConfigurationProperties, applicationInfo, jobDatas, stageDatas, executorSummaries, stagesWithFailedTasks, targetRestURIForEF)
+  }
+  
+  def getConfigurationPropertiesMap(sparkProperties: Seq[Seq[String]]): Map[String, String] ={
+    var appProperties = scala.collection.immutable.Map.empty[String,String]
+    for(sparkProperty <- sparkProperties) {
+      appProperties += (sparkProperty(0) -> sparkProperty(1))
+    }
+    appProperties.toMap
   }
 }

--- a/app/com/linkedin/drelephant/spark/data/SparkApplicationData.scala
+++ b/app/com/linkedin/drelephant/spark/data/SparkApplicationData.scala
@@ -60,7 +60,7 @@ object SparkApplicationData {
     restDerivedData: SparkRestDerivedData,
     logDerivedData: Option[SparkLogDerivedData]
   ): SparkApplicationData = {
-    var appConfigurationProperties: Map[String, String] = null
+    var appConfigurationProperties: Map[String, String] = Map.empty[String, String]
     if(!restDerivedData.appConfigurationProperties.isDefined) {
       appConfigurationProperties =
             logDerivedData

--- a/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
+++ b/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
@@ -16,7 +16,7 @@
 
 package com.linkedin.drelephant.spark.data
 
-import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfo, ExecutorSummary, JobData, StageData}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationConfig, ApplicationInfo, ExecutorSummary, JobData, StageData}
 
 
 case class SparkRestDerivedData(
@@ -26,4 +26,5 @@ case class SparkRestDerivedData(
   executorSummaries: Seq[ExecutorSummary],
   stagesWithFailedTasks: Seq[StageData],
   private[spark] val logDerivedData: Option[SparkLogDerivedData] = None,
-  targetRestURI : String = "")
+  targetRestURI : String = "",
+  appConfigurationProperties : Option[ApplicationConfig] = None)

--- a/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
+++ b/app/com/linkedin/drelephant/spark/data/SparkRestDerivedData.scala
@@ -25,6 +25,5 @@ case class SparkRestDerivedData(
   stageDatas: Seq[StageData],
   executorSummaries: Seq[ExecutorSummary],
   stagesWithFailedTasks: Seq[StageData],
-  private[spark] val logDerivedData: Option[SparkLogDerivedData] = None,
   targetRestURI : String = "",
   appConfigurationProperties : Option[ApplicationConfig] = None)

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -116,7 +116,7 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
 
     val logDerivedData = eventLogSource match {
       case EventLogSource.None => None
-      case EventLogSource.Rest => restDerivedData.logDerivedData
+      case EventLogSource.Rest => None
       case EventLogSource.WebHdfs =>
         val lastAttemptId = restDerivedData.applicationInfo.attempts.maxBy {
           _.startTime

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -107,7 +107,7 @@ class SparkRestClient(sparkConf: SparkConf) {
         applicationInfo,
         jobData,
         Await.result(futureStageDatas, DEFAULT_TIMEOUT),
-        Await.result(futureExecutorSummaries, Duration(500, SECONDS)),
+        Await.result(futureExecutorSummaries, Duration(5, SECONDS)),
         Await.result(futureFailedTasks, DEFAULT_TIMEOUT),
         Await.result(futureLogData, Duration(5, SECONDS)),
         attemptTarget.getUri.toString,

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -94,7 +94,6 @@ class SparkRestClient(sparkConf: SparkConf) {
       val futureExecutorSummaries = Future {
         getExecutorSummaries(attemptTarget)
       }
-      val futureLogData = Future.successful(None)
       val futureFailedTasks = if (fetchFailedTasks) {
         Future {
           getStagesWithFailedTasks(attemptTarget)
@@ -109,7 +108,6 @@ class SparkRestClient(sparkConf: SparkConf) {
         Await.result(futureStageDatas, DEFAULT_TIMEOUT),
         Await.result(futureExecutorSummaries, Duration(5, SECONDS)),
         Await.result(futureFailedTasks, DEFAULT_TIMEOUT),
-        Await.result(futureLogData, Duration(5, SECONDS)),
         attemptTarget.getUri.toString,
         Await.result(appConfigurationProperties, DEFAULT_TIMEOUT)
       )

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -31,8 +31,7 @@ import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
-import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfo, ExecutorSummary, JobData, StageData}
-import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationInfoImpl, ExecutorSummaryImpl, JobDataImpl, StageDataImpl}
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationConfig, ApplicationConfigImpl, ApplicationInfo, ApplicationInfoImpl, ExecutorSummary, ExecutorSummaryImpl, JobData, JobDataImpl, StageData, StageDataImpl}
 import com.linkedin.drelephant.util.SparkUtils
 import javax.ws.rs.client.{Client, ClientBuilder, WebTarget}
 import javax.ws.rs.core.MediaType
@@ -83,17 +82,19 @@ class SparkRestClient(sparkConf: SparkConf) {
     val (applicationInfo, attemptTarget) = getApplicationMetaData(appId)
     val jobData = getJobDatas(attemptTarget)
     Future {
+      val appConfigurationProperties = if (fetchLogs) {
+        Future {
+          Option(getSparkConfigs(attemptTarget))
+        }
+      } else Future.successful(None: Option[ApplicationConfigImpl])
+      
       val futureStageDatas = Future {
         getStageDatas(attemptTarget)
       }
       val futureExecutorSummaries = Future {
         getExecutorSummaries(attemptTarget)
       }
-      val futureLogData = if (fetchLogs) {
-        Future {
-          getLogData(attemptTarget)
-        }
-      } else Future.successful(None)
+      val futureLogData = Future.successful(None)
       val futureFailedTasks = if (fetchFailedTasks) {
         Future {
           getStagesWithFailedTasks(attemptTarget)
@@ -106,10 +107,11 @@ class SparkRestClient(sparkConf: SparkConf) {
         applicationInfo,
         jobData,
         Await.result(futureStageDatas, DEFAULT_TIMEOUT),
-        Await.result(futureExecutorSummaries, Duration(5, SECONDS)),
+        Await.result(futureExecutorSummaries, Duration(500, SECONDS)),
         Await.result(futureFailedTasks, DEFAULT_TIMEOUT),
         Await.result(futureLogData, Duration(5, SECONDS)),
-        attemptTarget.getUri.toString
+        attemptTarget.getUri.toString,
+        Await.result(appConfigurationProperties, DEFAULT_TIMEOUT)
       )
 
     }
@@ -217,6 +219,19 @@ class SparkRestClient(sparkConf: SparkConf) {
     }
   }
 
+  private def getSparkConfigs(attemptTarget: WebTarget): ApplicationConfigImpl = {
+    val target = attemptTarget.path("environment")
+    try {
+      get(target, SparkRestObjectMapper.readValue[ApplicationConfigImpl])
+    } catch {
+      case NonFatal(e) => {
+        logger.error(s"error reading sparkConfigs ${target.getUri}. Exception Message = " + e.getMessage, e)
+        logger.debug(e)
+        throw e
+      }
+    }
+  }
+  
   private def getStageDatas(attemptTarget: WebTarget): Seq[StageDataImpl] = {
     val target = attemptTarget.path("stages/withSummaries")
     try {

--- a/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/statusapiv1/statusapiv1.scala
@@ -59,6 +59,11 @@ trait ApplicationAttemptInfo{
   def completed: Boolean
 }
 
+trait ApplicationConfig{
+  def sparkProperties : Seq[Seq[String]]
+  def systemProperties : Seq[Seq[String]]
+}
+
 trait ExecutorStageSummary{
   def taskTime : Long
   def failedTasks : Int
@@ -311,6 +316,11 @@ class ApplicationAttemptInfoImpl(
   var endTime: Date,
   var sparkUser: String,
   var completed: Boolean = false) extends ApplicationAttemptInfo
+
+class ApplicationConfigImpl(
+  var sparkProperties: Seq[Seq[String]],
+  var systemProperties: Seq[Seq[String]]
+) extends ApplicationConfig
 
 class ExecutorStageSummaryImpl(
   var taskTime : Long,

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -18,9 +18,11 @@ package com.linkedin.drelephant.spark.fetchers
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 import java.text.SimpleDateFormat
-import java.util.zip.{ZipInputStream, ZipEntry, ZipOutputStream}
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
 import java.util.{Calendar, Date, SimpleTimeZone}
+
 import javax.ws.rs.client.WebTarget
+import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationAttemptInfoImpl, ApplicationConfigImpl, ApplicationInfoImpl, ExecutorSummaryImpl, JobDataImpl, StageDataImpl, StageStatus}
 
 import com.linkedin.drelephant.spark.fetchers.statusapiv1.StageStatus
 import scala.concurrent.ExecutionContext
@@ -31,9 +33,11 @@ import com.linkedin.drelephant.spark.fetchers.statusapiv1.{ApplicationAttemptInf
 import javax.ws.rs.{GET, Path, PathParam, Produces}
 import javax.ws.rs.core.{Application, MediaType, Response}
 import javax.ws.rs.ext.ContextResolver
-
 import com.google.common.io.Resources
+import com.linkedin.drelephant.spark.data.SparkApplicationData
+import com.linkedin.drelephant.spark.fetchers.SparkRestClientTest.FetchClientModeDataFixtures.SparkConfig
 import com.ning.compress.lzf.LZFEncoder
+import org.apache.log4j.Logger
 import org.apache.spark.{JobExecutionStatus, SparkConf}
 import org.glassfish.jersey.client.ClientConfig
 import org.glassfish.jersey.server.ResourceConfig
@@ -55,6 +59,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
               .register(classOf[FetchClusterModeDataFixtures.ApplicationResource])
               .register(classOf[FetchClusterModeDataFixtures.JobsResource])
               .register(classOf[FetchClusterModeDataFixtures.StagesResource])
+              .register(classOf[FetchClusterModeDataFixtures.SparkConfig])
               .register(classOf[FetchClusterModeDataFixtures.ExecutorsResource])
               .register(classOf[FetchClusterModeDataFixtures.LogsResource])
           case config => config
@@ -78,7 +83,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
         case assertion: Try[Assertion] => assertion
         case _ =>
           sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID, fetchLogs = true)
-            .map { _.logDerivedData.get.appConfigurationProperties should be(EXPECTED_PROPERTIES_FROM_LOG_1) }
+            .map { restDerivedData => SparkApplicationData.getConfigurationPropertiesMap(restDerivedData.appConfigurationProperties.get.sparkProperties) should be(EXPECTED_PROPERTIES_FROM_LOG_1) }
       } andThen { case assertion: Try[Assertion] =>
         fakeJerseyServer.tearDown()
         assertion
@@ -170,6 +175,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
               .register(classOf[FetchClientModeDataFixtures.ApplicationResource])
               .register(classOf[FetchClientModeDataFixtures.JobsResource])
               .register(classOf[FetchClientModeDataFixtures.StagesResource])
+              .register(classOf[FetchClientModeDataFixtures.SparkConfig])
               .register(classOf[FetchClientModeDataFixtures.ExecutorsResource])
               .register(classOf[FetchClientModeDataFixtures.LogsResource])
               .register(classOf[FetchClientModeDataFixtures.StagesWithFailedTasksResource])
@@ -182,9 +188,10 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
       val sparkConf = new SparkConf().set("spark.yarn.historyServer.address", s"${historyServerUri.getHost}:${historyServerUri.getPort}")
       val sparkRestClient = new SparkRestClient(sparkConf)
 
-      sparkRestClient.fetchData(FetchClusterModeDataFixtures.APP_ID) map { restDerivedData =>
-        restDerivedData.applicationInfo.id should be(FetchClusterModeDataFixtures.APP_ID)
-        restDerivedData.applicationInfo.name should be(FetchClusterModeDataFixtures.APP_NAME)
+      
+      sparkRestClient.fetchData(FetchClientModeDataFixtures.APP_ID) map { restDerivedData =>
+        restDerivedData.applicationInfo.id should be(FetchClientModeDataFixtures.APP_ID)
+        restDerivedData.applicationInfo.name should be(FetchClientModeDataFixtures.APP_NAME)
         restDerivedData.jobDatas should not be(None)
         restDerivedData.stageDatas should not be(None)
         restDerivedData.executorSummaries should not be(None)
@@ -193,7 +200,7 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
         case assertion: Try[Assertion] => assertion
         case _ =>
           sparkRestClient.fetchData(FetchClientModeDataFixtures.APP_ID, fetchLogs = true)
-            .map { _.logDerivedData.get.appConfigurationProperties should be(EXPECTED_PROPERTIES_FROM_LOG_1) }
+            .map { restDerivedData => SparkApplicationData.getConfigurationPropertiesMap(restDerivedData.appConfigurationProperties.get.sparkProperties) should be(EXPECTED_PROPERTIES_FROM_LOG_1) }
       } andThen { case assertion: Try[Assertion] =>
         fakeJerseyServer.tearDown()
         assertion
@@ -309,6 +316,9 @@ object SparkRestClientTest {
       @Path("applications/{appId}/{attemptId}/logs")
       def getLogs(): LogsResource = new LogsResource()
 
+      @Path("applications/{appId}/{attemptId}/environment")
+      def getSparkConfigs(): SparkConfig = new SparkConfig()
+
       @Path("applications/{appId}/{attemptId}/stages/failedTasks")
       def getStagesWithFailedTasks(): StagesWithFailedTasksResource = new StagesWithFailedTasksResource()
     }
@@ -328,6 +338,22 @@ object SparkRestClientTest {
             newFakeApplicationAttemptInfo(Some("1"), startTime = new Date(t1 - duration), endTime = new Date(t1))
           )
         )
+      }
+    }
+    
+    @Produces(Array(MediaType.APPLICATION_JSON))
+    class SparkConfig {
+      val logger: Logger = Logger.getLogger(classOf[SparkConfig])
+
+      @GET
+      def getSparkConfigs(@PathParam("appId") appId: String, @PathParam("attemptId") attemptId: String): ApplicationConfigImpl = {
+        var configArray:Seq[Seq[String]] = Seq()
+        logger.info("Size of the EXPECTED_PROPERTIES_FROM_LOG_1 array " + EXPECTED_PROPERTIES_FROM_LOG_1.size);
+        for ((k,v) <- EXPECTED_PROPERTIES_FROM_LOG_1) {
+          val configVal = Seq(k, v);
+          configArray = configArray :+ configVal
+        }
+        new ApplicationConfigImpl(configArray, Seq.empty)
       }
     }
 
@@ -391,6 +417,9 @@ object SparkRestClientTest {
       @Path("applications/{appId}/logs")
       def getLogs(): LogsResource = new LogsResource()
 
+      @Path("applications/{appId}/environment")
+      def getSparkConfigs(): SparkConfig = new SparkConfig()
+
       @Path("applications/{appId}/stages/failedTasks")
       def getStagesWithFailedTasks(): StagesWithFailedTasksResource = new StagesWithFailedTasksResource()
     }
@@ -413,6 +442,22 @@ object SparkRestClientTest {
       }
     }
 
+    @Produces(Array(MediaType.APPLICATION_JSON))
+    class SparkConfig {
+      val logger: Logger = Logger.getLogger(classOf[SparkConfig])
+
+      @GET
+      def getSparkConfigs(@PathParam("appId") appId: String): ApplicationConfigImpl = {
+        var configArray:Seq[Seq[String]] = Seq()
+        logger.info("Size of the EXPECTED_PROPERTIES_FROM_LOG_1 array " + EXPECTED_PROPERTIES_FROM_LOG_1.size);
+        for ((k,v) <- EXPECTED_PROPERTIES_FROM_LOG_1) {
+          val configVal = Seq(k, v);
+          configArray = configArray :+ configVal
+        }
+        new ApplicationConfigImpl(configArray, Seq.empty)
+      }
+    }
+    
     @Produces(Array(MediaType.APPLICATION_JSON))
     class JobsResource {
       @GET

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkRestClientTest.scala
@@ -78,7 +78,6 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
         restDerivedData.jobDatas should not be (None)
         restDerivedData.stageDatas should not be (None)
         restDerivedData.executorSummaries should not be (None)
-        restDerivedData.logDerivedData should be(None)
       } flatMap {
         case assertion: Try[Assertion] => assertion
         case _ =>
@@ -195,7 +194,6 @@ class SparkRestClientTest extends AsyncFunSpec with Matchers {
         restDerivedData.jobDatas should not be(None)
         restDerivedData.stageDatas should not be(None)
         restDerivedData.executorSummaries should not be(None)
-        restDerivedData.logDerivedData should be(None)
       } flatMap {
         case assertion: Try[Assertion] => assertion
         case _ =>


### PR DESCRIPTION
This change is for using spark environment API for getting Spark job configuration. Currently Dr. Elephant uses logs or rest api for logs and then parses that log. We have encountered following issues in the current implementation:

- It only parses LZO4 log files. Many a times people uses other compression formats. In those cases Dr. Elephant fails to analyse those jobs.  
- If there is any failure on the driver side, Dr. Elephant is not able to fetch the logs because of the state of the job. Because of that it fails to analyse the job. 

Spark history server has an environment API, which returns all the configurations. 

Tests Done: 
Compared configurations for many of the analysed jobs with old and new code. There was no difference. 



