### PR TITLE
Fixing NPE caused due to unchecked call to get method of Map

### DIFF
--- a/app/com/linkedin/drelephant/tony/heuristics/TaskGPUHeuristic.java
+++ b/app/com/linkedin/drelephant/tony/heuristics/TaskGPUHeuristic.java
@@ -73,7 +73,7 @@ public class TaskGPUHeuristic implements Heuristic<TonyApplicationData> {
 
     for (String taskType : taskTypes) {
       details.add(new HeuristicResultDetails("Number of " + taskType + " tasks",
-          Integer.toString(taskMap.get(taskType).size())));
+          taskMap.containsKey(taskType) ? Integer.toString(taskMap.get(taskType).size()) : "0"));
 
       // get number of GPU resource requested, if any
       int numGPUsRequested = conf.getInt(TonyConfigurationKeys.getResourceKey(taskType, Constants.GPUS), 0);


### PR DESCRIPTION
**DESCRIPTION**
This PR contains changes to fix the drop of TonY application due to NPE caused by unchecked call **get** method of a Map for respective taskType's size.