### PR TITLE
Increasing the timeout for REST call to Spark History Server

### DIFF
--- a/app/com/linkedin/drelephant/analysis/AnalyticJob.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJob.java
@@ -484,4 +484,20 @@ public class AnalyticJob {
     this.jobDiagnostics = jobDiagnostics;
     return this;
   }
+
+  /**
+   * To return the second retries done till now
+   *@return The secondRetries count
+   */
+  public int getSecondRetries() {
+    return this._secondRetries;
+  }
+
+  /**
+   * To return the max Second Retries Allowed limit
+   *@return The SECOND RETRY LIMIT count
+   */
+  public int getSecondRetryLimit() {
+    return this._SECOND_RETRY_LIMIT;
+  }
 }

--- a/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJobGeneratorHadoop2.java
@@ -73,7 +73,7 @@ public class AnalyticJobGeneratorHadoop2 implements AnalyticJobGenerator {
 
   private final Queue<AnalyticJob> _firstRetryQueue = new ConcurrentLinkedQueue<AnalyticJob>();
 
-  private final ArrayList<AnalyticJob> _secondRetryQueue = new ArrayList<AnalyticJob>();
+  private final ArrayList<AnalyticJob> _secondRetryQueue = new ArrayList<>();
 
   public void updateResourceManagerAddresses() {
     if (Boolean.valueOf(configuration.get(IS_RM_HA_ENABLED))) {

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkFetcher.scala
@@ -112,8 +112,9 @@ class SparkFetcher(fetcherConfigurationData: FetcherConfigurationData)
 
   private def doFetchDataUsingRestAndLogClients(analyticJob: AnalyticJob): Future[SparkApplicationData] = Future {
     val appId = analyticJob.getAppId
-    val restDerivedData = Await.result(sparkRestClient.fetchData(appId, eventLogSource == EventLogSource.Rest), DEFAULT_TIMEOUT)
-
+    val retriesRemaining = analyticJob.getSecondRetryLimit - analyticJob.getSecondRetries
+    val restDerivedData = Await.result(sparkRestClient.fetchData(appId, eventLogSource == EventLogSource.Rest,
+      retriesRemaining), DEFAULT_TIMEOUT)
     val logDerivedData = eventLogSource match {
       case EventLogSource.None => None
       case EventLogSource.Rest => None
@@ -145,7 +146,7 @@ object SparkFetcher {
   }
 
   val SPARK_EVENT_LOG_ENABLED_KEY = "spark.eventLog.enabled"
-  val DEFAULT_TIMEOUT = Duration(5, SECONDS)
+  val DEFAULT_TIMEOUT = Duration(20, SECONDS)
   val LOG_LOCATION_URI_XML_FIELD = "event_log_location_uri"
   val FETCH_FAILED_TASKS = "fetch_failed_tasks"
 }

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -56,6 +56,8 @@ class SparkRestClient(sparkConf: SparkConf) {
 
   private val client: Client = ClientBuilder.newClient()
 
+  private val THRESHOLD_REMAINING_RETRIES_FOR_TIMEOUT_CHANGE = 3;
+
   private val historyServerUri: URI = sparkConf.getOption(HISTORY_SERVER_ADDRESS_KEY) match {
     case Some(historyServerAddress) =>
       val baseUri: URI =
@@ -76,17 +78,20 @@ class SparkRestClient(sparkConf: SparkConf) {
     .property(ClientProperties.READ_TIMEOUT, READ_TIMEOUT).target(historyServerUri).path(API_V1_MOUNT_PATH)
 
 
-  def fetchData(appId: String, fetchLogs: Boolean = false, fetchFailedTasks: Boolean = true)(
+  def fetchData(appId: String, fetchLogs: Boolean = false, retriesRemaining: Int = Int.MaxValue, fetchFailedTasks: Boolean = true)(
     implicit ec: ExecutionContext
   ): Future[SparkRestDerivedData] = {
     val (applicationInfo, attemptTarget) = getApplicationMetaData(appId)
-    val jobData = getJobDatas(attemptTarget)
+    val REQUEST_TIMEOUT =
+      if (retriesRemaining > THRESHOLD_REMAINING_RETRIES_FOR_TIMEOUT_CHANGE) DEFAULT_TIMEOUT else TEN_SECONDS_TIMEOUT
+    val jobData = Await.result(Future {getJobDatas(attemptTarget)}, REQUEST_TIMEOUT)
     Future {
       val appConfigurationProperties = if (fetchLogs) {
         Future {
           Option(getSparkConfigs(attemptTarget))
         }
       } else Future.successful(None: Option[ApplicationConfigImpl])
+
       val futureStageDatas = Future {
         getStageDatas(attemptTarget)
       }
@@ -104,13 +109,12 @@ class SparkRestClient(sparkConf: SparkConf) {
       SparkRestDerivedData(
         applicationInfo,
         jobData,
-        Await.result(futureStageDatas, DEFAULT_TIMEOUT),
-        Await.result(futureExecutorSummaries, Duration(5, SECONDS)),
-        Await.result(futureFailedTasks, DEFAULT_TIMEOUT),
+        Await.result(futureStageDatas, REQUEST_TIMEOUT),
+        Await.result(futureExecutorSummaries, REQUEST_TIMEOUT),
+        Await.result(futureFailedTasks, REQUEST_TIMEOUT),
         attemptTarget.getUri.toString,
-        Await.result(appConfigurationProperties, DEFAULT_TIMEOUT)
+        Await.result(appConfigurationProperties, REQUEST_TIMEOUT)
       )
-
     }
   }
 
@@ -275,8 +279,9 @@ object SparkRestClient {
   val API_V1_MOUNT_PATH = "api/v1"
   val IN_PROGRESS = ".inprogress"
   val DEFAULT_TIMEOUT = Duration(5, SECONDS)
-  val CONNECTION_TIMEOUT = 5000
-  val READ_TIMEOUT = 5000
+  val TEN_SECONDS_TIMEOUT = Duration(10, SECONDS)
+  val CONNECTION_TIMEOUT = 10000
+  val READ_TIMEOUT = 10000
 
   val SparkRestObjectMapper = {
     val dateFormat = {

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
@@ -43,7 +43,7 @@ class SparkFetcherTest extends FunSpec with Matchers with MockitoSugar {
 
     val fetcherConfigurationData = newFakeFetcherConfigurationData()
 
-    var appId = "application_1"
+    val appId = "application_1"
 
     val t2 = System.currentTimeMillis
     val t1 = t2 - 1

--- a/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
+++ b/test/com/linkedin/drelephant/spark/fetchers/SparkFetcherTest.scala
@@ -20,7 +20,6 @@ import java.nio.file.Files
 import java.util.Date
 import java.util.concurrent.TimeoutException
 
-import scala.concurrent.{ExecutionContext, Future}
 import com.linkedin.drelephant.analysis.{AnalyticJob, ApplicationType}
 import com.linkedin.drelephant.configurations.fetcher.FetcherConfigurationData
 import com.linkedin.drelephant.spark.data.{SparkApplicationData, SparkLogDerivedData, SparkRestDerivedData}
@@ -31,8 +30,10 @@ import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate
 import org.mockito.Mockito
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class SparkFetcherTest extends FunSpec with Matchers with MockitoSugar {
   import SparkFetcherTest._
@@ -42,7 +43,7 @@ class SparkFetcherTest extends FunSpec with Matchers with MockitoSugar {
 
     val fetcherConfigurationData = newFakeFetcherConfigurationData()
 
-    val appId = "application_1"
+    var appId = "application_1"
 
     val t2 = System.currentTimeMillis
     val t1 = t2 - 1
@@ -67,10 +68,12 @@ class SparkFetcherTest extends FunSpec with Matchers with MockitoSugar {
 
     val analyticJob = new AnalyticJob().setAppId(appId)
 
+    val remainingRetries = analyticJob.getSecondRetryLimit - analyticJob.getSecondRetries
+
     it("returns data") {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkConf = new SparkConf()
-        override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future(restDerivedData))
+        override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future(restDerivedData), remainingRetries)
         override lazy val sparkLogClient = newFakeSparkLogClient(appId, Some("2"), Future(logDerivedData))
       }
       val data = sparkFetcher.fetchData(analyticJob)
@@ -80,7 +83,7 @@ class SparkFetcherTest extends FunSpec with Matchers with MockitoSugar {
     it("throws an exception if the REST client fails") {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkConf = new SparkConf()
-        override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future { throw new Exception() })
+        override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future { throw new Exception() }, remainingRetries)
         override lazy val sparkLogClient = newFakeSparkLogClient(appId, Some("2"), Future(logDerivedData))
       }
 
@@ -91,7 +94,7 @@ class SparkFetcherTest extends FunSpec with Matchers with MockitoSugar {
       val sparkFetcher = new SparkFetcher(fetcherConfigurationData) {
         override lazy val sparkConf = new SparkConf()
           .set(SparkFetcher.SPARK_EVENT_LOG_ENABLED_KEY, "true")
-        override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future(restDerivedData))
+        override lazy val sparkRestClient = newFakeSparkRestClient(appId, Future(restDerivedData), remainingRetries)
         override lazy val sparkLogClient = newFakeSparkLogClient(appId, Some("2"), Future { throw new Exception() })
       }
 
@@ -295,12 +298,13 @@ object SparkFetcherTest {
 
   def newFakeSparkRestClient(
     appId: String,
-    restDerivedData: Future[SparkRestDerivedData]
+    restDerivedData: Future[SparkRestDerivedData],
+    remainingRetries: Int
   )(
     implicit ec: ExecutionContext
   ): SparkRestClient = {
     val sparkRestClient = Mockito.mock(classOf[SparkRestClient])
-    Mockito.when(sparkRestClient.fetchData(appId)).thenReturn(restDerivedData)
+    Mockito.when(sparkRestClient.fetchData(appId, false, remainingRetries)).thenReturn(restDerivedData)
     sparkRestClient
   }
 


### PR DESCRIPTION
**DESCRIPTION**
This PR contains the changes to increase the timeout for REST calls to SHS for fetching application data. The reason for making this change is the spike in the number of jobs drop. This change is for done to handle the condition for a short period of time, as the rollout of Incremental Log Parsing by Spark team will enable the SHS to scale by itself.

**HOW CHANGES ARE TESTED**
The changes are tested on test instance against the jobs on the respective cluster.