### PR TITLE
Adding ExceptionName with ExceptionStackTrace for Spark Jobs

### DIFF
--- a/app/com/linkedin/drelephant/exceptions/core/ExceptionFingerprintingSpark.java
+++ b/app/com/linkedin/drelephant/exceptions/core/ExceptionFingerprintingSpark.java
@@ -135,7 +135,7 @@ public class ExceptionFingerprintingSpark implements ExceptionFingerprinting {
            */
           //TODO : ID should be same for simillar exceptions
           addExceptions((stageData.failureReason().toString() + "" + stageData.details()).hashCode(),
-              stageData.failureReason().toString(), stageData.details(), ExceptionSource.EXECUTOR, exceptions,
+              stageData.failureReason().toString(), stageData.failureReason().toString()+"\n"+stageData.details(), ExceptionSource.EXECUTOR, exceptions,
               processExceptionTrackingURL(stageData.stageId()));
         }
       } else {


### PR DESCRIPTION
Dr Elephant UI only shows the value of column exceptionStackTrace and does not show the Exception Name. 
Hence appending the ExceptionName with ExceptionStackTrace for exception fingerprinting in spark.