### PR TITLE
Changing logger level to warn for error in getting job data from Spark Rest Client

### DIFF
--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -87,7 +87,6 @@ class SparkRestClient(sparkConf: SparkConf) {
           Option(getSparkConfigs(attemptTarget))
         }
       } else Future.successful(None: Option[ApplicationConfigImpl])
-
       val futureStageDatas = Future {
         getStageDatas(attemptTarget)
       }

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -87,7 +87,7 @@ class SparkRestClient(sparkConf: SparkConf) {
           Option(getSparkConfigs(attemptTarget))
         }
       } else Future.successful(None: Option[ApplicationConfigImpl])
-      
+
       val futureStageDatas = Future {
         getStageDatas(attemptTarget)
       }
@@ -210,7 +210,7 @@ class SparkRestClient(sparkConf: SparkConf) {
       get(target, SparkRestObjectMapper.readValue[Seq[JobDataImpl]])
     } catch {
       case NonFatal(e) => {
-        logger.error(s"error reading jobData ${target.getUri}. Exception Message = " + e.getMessage)
+        logger.warn(s"error reading jobData ${target.getUri}. Exception Message = " + e.getMessage)
         logger.debug(e)
         throw e
       }
@@ -229,7 +229,7 @@ class SparkRestClient(sparkConf: SparkConf) {
       }
     }
   }
-  
+
   private def getStageDatas(attemptTarget: WebTarget): Seq[StageDataImpl] = {
     val target = attemptTarget.path("stages/withSummaries")
     try {

--- a/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
+++ b/app/com/linkedin/drelephant/spark/fetchers/SparkRestClient.scala
@@ -223,7 +223,7 @@ class SparkRestClient(sparkConf: SparkConf) {
       get(target, SparkRestObjectMapper.readValue[ApplicationConfigImpl])
     } catch {
       case NonFatal(e) => {
-        logger.error(s"error reading sparkConfigs ${target.getUri}. Exception Message = " + e.getMessage, e)
+        logger.warn(s"error reading sparkConfigs ${target.getUri}. Exception Message = " + e.getMessage, e)
         logger.debug(e)
         throw e
       }
@@ -249,7 +249,7 @@ class SparkRestClient(sparkConf: SparkConf) {
       get(target, SparkRestObjectMapper.readValue[Seq[ExecutorSummaryImpl]])
     } catch {
       case NonFatal(e) => {
-        logger.error(s"error reading executorSummary ${target.getUri}. Exception Message = " + e.getMessage)
+        logger.warn(s"error reading executorSummary ${target.getUri}. Exception Message = " + e.getMessage)
         logger.debug(e)
         throw e
       }
@@ -263,7 +263,7 @@ class SparkRestClient(sparkConf: SparkConf) {
       get(target, SparkRestObjectMapper.readValue[Seq[StageDataImpl]])
     } catch {
       case NonFatal(e) => {
-        logger.error(s"error reading failedTasks ${target.getUri}. Exception Message = " + e.getMessage)
+        logger.warn(s"error reading failedTasks ${target.getUri}. Exception Message = " + e.getMessage)
         logger.debug(e)
         throw e
       }


### PR DESCRIPTION
Changing logger level to warn for error in getting job data from Spark Monitoring REST API.