### PR TITLE
Bump sbt version to 0.13.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # the License.
 #
 
-sbt.version=0.13.5
+sbt.version=0.13.9


### PR DESCRIPTION
There are several issues that report compilation errors with a message like:

    [error] impossible to get artifacts when data has not been loaded. IvyNode = com.fasterxml.jackson.core#jackson-databind;2.5.4
    java.lang.IllegalStateException: impossible to get artifacts when data has not been loaded. IvyNode = com.fasterxml.jackson.core#jackson-databind;2.5.4

Examples:

- https://github.com/linkedin/dr-elephant/issues/201
- https://github.com/linkedin/dr-elephant/issues/339
- https://github.com/linkedin/dr-elephant/issues/367
- https://github.com/linkedin/dr-elephant/issues/419
- https://github.com/linkedin/dr-elephant/issues/658

It looks like this message stems from a bug in Ivy which has since been fixed
(https://github.com/sbt/sbt/issues/1598). I'm guessing the fix in Ivy is
included in sbt v0.13.9, because upgrading sbt fixed the issue for me, and seems
to have helped others, too (e.g., https://github.com/linkedin/dr-elephant/issues/201#issuecomment-283011092).