### PR TITLE
Log Exception object directly

### DIFF
--- a/app/com/linkedin/drelephant/ElephantRunner.java
+++ b/app/com/linkedin/drelephant/ElephantRunner.java
@@ -423,8 +423,7 @@ public class ElephantRunner implements Runnable {
         logger.warn("Timed out while fetching data. Exception message is: " + e.getMessage());
         jobFate(finishTimeInfo, appType, applicableFinishTime, jobFinishTime);
       } catch (Exception e) {
-        logger.error(e.getMessage());
-        logger.error(ExceptionUtils.getStackTrace(e));
+        logger.error(String.format("Failed to analyze %s", analysisName), e);
         jobFate(finishTimeInfo, appType, applicableFinishTime, jobFinishTime);
       }
     }


### PR DESCRIPTION
Instead of logging the Exception type and stack-trace separately, use
`Logger.error(String msg, Throwable t)` to log the message and stack-trace in a
single ERROR entry.

Here's a disposable test whose output illustrates the difference:

```java
import org.apache.commons.lang.exception.ExceptionUtils;
import org.apache.log4j.Logger;
import org.junit.Test;

public class LogTest {

  private static final Logger logger = Logger.getLogger(ElephantRunner.class);
  Object nullObj = null;

  @Test
  public void logExceptionGoodWay() {
    try {
      nullObj.toString();
    } catch (Exception e) {
      logger.error("Failure in .toString()!", e);
    }
  }

  @Test
  public void logExceptionBadWay() {
    try {
      nullObj.toString();
    } catch (Exception e) {
      logger.error(e.getMessage());
      logger.error(ExceptionUtils.getStackTrace(e));
    }
  }
}
```
# Before

Note that the frst log statement is empty:

    03-24-2020 14:40:34 ERROR [main] com.linkedin.drelephant.ElephantRunner :
    03-24-2020 14:40:34 ERROR [main] com.linkedin.drelephant.ElephantRunner : java.lang.NullPointerException
	    at com.linkedin.drelephant.LogTest.logExceptionBadWay(LogTest.java:24)
	    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	    at java.lang.reflect.Method.invoke(Method.java:498)
	    ...

# After

    03-24-2020 14:40:34 ERROR [main] com.linkedin.drelephant.ElephantRunner : Failure in .toString()!
    java.lang.NullPointerException
	    at com.linkedin.drelephant.LogTest.logExceptionGoodWay(LogTest.java:15)
	    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	    at java.lang.reflect.Method.invoke(Method.java:498)
	    ...