### PR TITLE
Parsing Azkaban job logs for Exception Fingerprinting

### DIFF
--- a/app/com/linkedin/drelephant/clients/WorkflowClient.java
+++ b/app/com/linkedin/drelephant/clients/WorkflowClient.java
@@ -85,4 +85,13 @@ public interface WorkflowClient {
    * @return The exeception encountered
    */
   public LoggingEvent getJobException(String jobId);
+
+  /**
+   * Get the logs for a job, given a job id, start offset and max length
+   * @param jobId The id of the job
+   * @param offset Start offset for the job logs
+   * @param maxLength Max length of log needed
+   * @return The job logs
+   */
+  public String getAzkabanJobLog(String jobId, String offset, String maxLength);
 }

--- a/app/com/linkedin/drelephant/clients/azkaban/AzkabanWorkflowClient.java
+++ b/app/com/linkedin/drelephant/clients/azkaban/AzkabanWorkflowClient.java
@@ -521,7 +521,7 @@ public class AzkabanWorkflowClient implements WorkflowClient {
    * @param length Maximum limit on length of log
    * @return Azkaban job log in the form of string
    */
-   private String getAzkabanJobLog(String jobId, String offset, String length) {
+   public String getAzkabanJobLog(String jobId, String offset, String length) {
     List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
     urlParameters.add(new BasicNameValuePair("session.id", _sessionId));
     urlParameters.add(new BasicNameValuePair("ajax", "fetchExecJobLogs"));

--- a/app/com/linkedin/drelephant/exceptions/azkaban/AzkabanExceptionLogAnalyzer.java
+++ b/app/com/linkedin/drelephant/exceptions/azkaban/AzkabanExceptionLogAnalyzer.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.exceptions.azkaban;
+
+import com.linkedin.drelephant.clients.WorkflowClient;
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+import com.linkedin.drelephant.exceptions.util.ExceptionInfo;
+import com.linkedin.drelephant.util.InfoExtractor;
+import com.linkedin.drelephant.util.Utils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
+
+import static com.linkedin.drelephant.exceptions.util.ExceptionUtils.ConfigurationBuilder.*;
+import static com.linkedin.drelephant.exceptions.util.ExceptionUtils.*;
+import static controllers.api.v1.JsonKeys.*;
+
+
+/**
+ * This class servers the purpose of analyzing Azkaban Logs for a job
+ * and filter out exception stacktraces based on some pre-defined exception patterns
+ */
+public class AzkabanExceptionLogAnalyzer {
+
+  private final String flowExecUrl;
+  private final String jobExecUrl;
+  private WorkflowClient _workflowClient;
+  private List<ExceptionInfo> azkabanExceptionInfoList = new ArrayList<>();
+  private final String SCHEDULER_NAME = "azkaban";
+  private final String PRIVATE_KEY = "private_key";
+
+  private HashSet<String> exceptionIdSet = new HashSet<>();
+
+  private static final Logger logger = Logger.getLogger(AzkabanExceptionLogAnalyzer.class);
+
+  //For controlling the way instance is created
+  private AzkabanExceptionLogAnalyzer() {
+    flowExecUrl = null;
+    jobExecUrl = null;
+  }
+
+  public AzkabanExceptionLogAnalyzer(String flowExecUrl, String jobExecUrl) {
+    this.flowExecUrl = flowExecUrl;
+    this.jobExecUrl = jobExecUrl;
+  }
+
+  private void init() {
+    String jobId = getJobName(jobExecUrl);
+    _workflowClient = getWorkflowClient(flowExecUrl);
+    logger.info("Fetching job logs from Azkaban for " + jobExecUrl);
+    String jobLog = _workflowClient.getAzkabanJobLog(jobId, AZKABAN_JOB_LOG_START_OFFSET.getValue()
+        .toString(), AZKABAN_JOB_LOG_MAX_LENGTH.getValue().toString());
+    analyzeJobLog(processJobLog(jobLog));
+  }
+
+  /**
+   * @return Exceptions Info list containing logs relevant to failure cause
+   */
+  public List<ExceptionInfo> getExceptionInfoList() {
+    if (azkabanExceptionInfoList.isEmpty()) {
+      init();
+    }
+    return azkabanExceptionInfoList;
+  }
+
+  /**
+   * @param jobLogs Log for the job provided by Azkaban
+   * @return Filtered out exceptions relevant to failure cause
+   */
+  private void analyzeJobLog(String jobLogs) {
+    logger.info("Analyzing job logs from Azkaban of length " + jobLogs.length());
+    List<Pattern> exceptionRegexList = new ArrayList<>();
+    for (String exceptionRegex : REGEX_FOR_EXCEPTION_PATTERN_IN_AZKABAN_LOGS.getValue()) {
+      exceptionRegexList.add(Pattern.compile(exceptionRegex));
+    }
+    for (Pattern exceptionPattern : exceptionRegexList) {
+      Matcher exceptionPatternMatcher = exceptionPattern.matcher(jobLogs);
+      while (exceptionPatternMatcher.find()) {
+        if (!isExceptionLogDuplicate(exceptionPatternMatcher.group(0))) {
+          ExceptionInfo exceptionInfo = new ExceptionInfo();
+          exceptionInfo.setExceptionID(exceptionPatternMatcher.group(0).hashCode());
+          exceptionInfo.setExceptionName(exceptionPatternMatcher.group(1));
+          exceptionInfo.setExceptionSource(ExceptionInfo.ExceptionSource.SCHEDULER);
+          exceptionInfo.setWeightOfException(exceptionIdSet.size());
+          exceptionInfo.setExceptionStackTrace(Utils.truncateStackTrace(exceptionPatternMatcher.group(0),
+              MAX_LINE_LENGTH_OF_EXCEPTION.getValue()));
+          azkabanExceptionInfoList.add(exceptionInfo);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param flowExecUrl Azkaban flowExection Url for creating the workflow client
+   * @return Workflow client for connecting to Azkaban and getting flow specific information
+   */
+  protected WorkflowClient getWorkflowClient(String flowExecUrl) {
+    WorkflowClient workflowClient = InfoExtractor.getWorkflowClientInstance(SCHEDULER_NAME, flowExecUrl);
+    SchedulerConfigurationData schedulerData = InfoExtractor.getSchedulerData(SCHEDULER_NAME);
+    if (schedulerData == null) {
+      throw new RuntimeException(String.format("No scheduler data found for scheduler %s", SCHEDULER_NAME));
+    }
+
+    if (!schedulerData.getParamMap().containsKey(USERNAME)) {
+      throw new RuntimeException("Username Not Found for login");
+    }
+
+    String username = schedulerData.getParamMap().get(USERNAME);
+    if (schedulerData.getParamMap().containsKey(PRIVATE_KEY)) {
+      workflowClient.login(username, new File(schedulerData.getParamMap().get(PRIVATE_KEY)));
+    } else if (schedulerData.getParamMap().containsKey(PASSWORD)) {
+      workflowClient.login(username, schedulerData.getParamMap().get(PASSWORD));
+    } else {
+      throw new RuntimeException("Neither private key nor password was specified for scheduler " + SCHEDULER_NAME);
+    }
+    return workflowClient;
+  }
+
+  /**
+   * @param exceptionStackTrace HashCode for filterOut duplicate exception stackTrace
+   * @return whether this exception stackTrace is parsed and saved before
+   */
+  private boolean isExceptionLogDuplicate(String exceptionStackTrace) {
+    if (exceptionIdSet.contains(exceptionStackTrace)) {
+      for (String uniqueExceptions : exceptionIdSet) {
+        if (uniqueExceptions.equals(exceptionStackTrace)) {
+          return true;
+        }
+      }
+    }
+    exceptionIdSet.add(exceptionStackTrace);
+    return false;
+  }
+
+  /**
+   * @param logs Azkaban logs obtained from workflowClient
+   * @return Logs after removing all the redundant log for exception fingerprinting
+   */
+  private String processJobLog(String logs) {
+    for (String logPattern : REGEX_FOR_REDUNDANT_LOG_PATTERN_IN_AZKABAN_LOGS.getValue()) {
+      logs = logs.replaceAll(logPattern, "");
+    }
+    return logs;
+  }
+}

--- a/app/com/linkedin/drelephant/exceptions/core/ExceptionFingerprintingSpark.java
+++ b/app/com/linkedin/drelephant/exceptions/core/ExceptionFingerprintingSpark.java
@@ -125,6 +125,7 @@ public class ExceptionFingerprintingSpark implements ExceptionFingerprinting {
     String NOT_AVAILABLE = "Not Available";
     ExceptionInfo jobDiagnosticsInfo = new ExceptionInfo();
     jobDiagnosticsInfo.setExceptionName(exceptionName);
+    jobDiagnosticsInfo.setExceptionSource(ExceptionSource.DRIVER);
     if (Strings.isNullOrEmpty(jobDiagnostics)) {
       jobDiagnosticsInfo.setExceptionStackTrace(NOT_AVAILABLE);
       //Since No job diagnostic message is present so show this at bottom of results

--- a/app/com/linkedin/drelephant/exceptions/util/Constant.java
+++ b/app/com/linkedin/drelephant/exceptions/util/Constant.java
@@ -59,6 +59,10 @@ public final class Constant {
       "ef.tony.exact.regex.for.exception";
   public static final String REGEX_FOR_PARTIAL_EXCEPTION_PATTERN_IN_TONY_LOGS_KEY =
       "ef.tony.partial.pattern.regex.for.exception";
+  public static final String REGEX_FOR_EXCEPTION_PATTERN_IN_AZKABAN_LOGS_KEY =
+      "ef.azkaban.regex.for.exception.pattern";
+  public static final String REGEX_FOR_REDUNDANT_LOG_PATTERN_IN_AZKABAN_LOGS_CONFIG_NAME =
+      "ef.azkaban.regex.redundant.log.pattern";
   public static final String REGEX_AUTO_TUNING_FAULT_NAME = "ef.regex.for.autotuning.fault";
   public static final String FIRST_THRESHOLD_LOG_LENGTH_NAME = "ef.first.threshold.loglength";
   public static final String LAST_THRESHOLD_LOG_LENGTH_NAME = "ef.last.threshold.loglength";
@@ -76,4 +80,7 @@ public final class Constant {
   static final String NUMBER_OF_RETRIES_FOR_FETCHING_DRIVER_LOGS_NAME = "ef.number.retries.fetching.driver.logs";
   static final String DURATION_FOR_THREAD_SLEEP_FOR_FETCHING_DRIVER_LOGS_NAME = "ef.duration.thread.sleep.ms";
   static final String TOTAL_LENGTH_OF_LOG_SAVED_IN_DB_NAME = "ef.loglength.saved.db" ;
+  static final String AZKABAN_JOB_LOG_START_OFFSET_CONFIG_KEY = "ef.azkaban.job.log.start.offset" ;
+  static final String AZKABAN_JOB_LOG_MAX_LENGTH_CONFIG_KEY = "ef.azkaban.job.log.max.length" ;
+  static final String SHOULD_PROCESS_AZKABAN_LOG_CONFIG_NAME = "ef.azkaban.log.processing.enable" ;
 }

--- a/app/com/linkedin/drelephant/util/Utils.java
+++ b/app/com/linkedin/drelephant/util/Utils.java
@@ -257,6 +257,16 @@ public final class Utils {
   }
 
   /**
+   * @param stackTrace String containing stackTrace of exception seperated by new line
+   * @param limit maximum number of lines required in stackTrace
+   * @return stackTrace with given number of lines or less
+   */
+  public static String truncateStackTrace(String stackTrace, int limit) {
+    List<String> stackTraceSplitList = Arrays.asList(stackTrace.split("\n"));
+    return String.join("\n", stackTraceSplitList.subList(0, Math.min(limit, stackTraceSplitList.size())));
+  }
+
+  /**
    * Convert a millisecond duration to a string format
    *
    * @param millis A duration to convert to a string form

--- a/test/com/linkedin/drelephant/exceptions/azkaban/AzkabanExceptionLogAnalyzerTest.java
+++ b/test/com/linkedin/drelephant/exceptions/azkaban/AzkabanExceptionLogAnalyzerTest.java
@@ -1,0 +1,93 @@
+package com.linkedin.drelephant.exceptions.azkaban;
+
+import com.linkedin.drelephant.ElephantContext;
+import com.linkedin.drelephant.clients.WorkflowClient;
+import com.linkedin.drelephant.clients.azkaban.AzkabanWorkflowClient;
+import com.linkedin.drelephant.exceptions.util.ExceptionInfo;
+import com.linkedin.drelephant.exceptions.util.ExceptionUtils;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.drelephant.exceptions.util.ExceptionUtils.ConfigurationBuilder.*;
+import static com.linkedin.drelephant.exceptions.util.ExceptionUtils.*;
+import static common.TestConstants.*;
+import static org.mockito.Mockito.*;
+
+
+public class AzkabanExceptionLogAnalyzerTest {
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  WorkflowClient mockWorkflowClient = mock(AzkabanWorkflowClient.class);
+
+  private final String MOCK_LOG_PATH_1 = "test/resources/exception/azkaban/azkabanExceptionLog_1.log.txt";
+
+  @Before
+  public void setUp() {
+    ExceptionUtils.ConfigurationBuilder.buildConfigurations(ElephantContext.instance().getAutoTuningConf());
+  }
+
+  @Test
+  public void testAzkabanExceptionLogAnalyzer() {
+    AzkabanExceptionLogAnalyzer azkabanExceptionLogAnalyzerSpy = spy(new AzkabanExceptionLogAnalyzer(
+        TEST_FLOW_EXEC_ID1, TEST_JOB_EXEC_ID1));
+    String jobName = getJobName(TEST_JOB_EXEC_ID1);
+    String jobLog = getLog(MOCK_LOG_PATH_1);
+    when(mockWorkflowClient.getAzkabanJobLog(jobName, AZKABAN_JOB_LOG_START_OFFSET.getValue()
+        .toString(), AZKABAN_JOB_LOG_MAX_LENGTH.getValue().toString())).thenReturn(jobLog);
+    doReturn(mockWorkflowClient).when(azkabanExceptionLogAnalyzerSpy).getWorkflowClient(Mockito.any(String.class));
+    azkabanExceptionLogAnalyzerSpy.getExceptionInfoList();
+
+    List<ExceptionInfo> result = azkabanExceptionLogAnalyzerSpy.getExceptionInfoList();
+    Assert.assertTrue(SHOULD_PROCESS_AZKABAN_LOG.getValue());
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals(1, result.get(0).getWeightOfException().intValue());
+    Assert.assertEquals(ExceptionInfo.ExceptionSource.SCHEDULER, result.get(0).getExceptionSource());
+    Assert.assertEquals("Exception in thread \"main\" java.lang.reflect.UndeclaredThrowableException\n",
+        result.get(0).getExceptionName());
+    Assert.assertEquals(2, result.get(1).getWeightOfException().intValue());
+    Assert.assertEquals(ExceptionInfo.ExceptionSource.SCHEDULER, result.get(1).getExceptionSource());
+    Assert.assertEquals("java.lang.RuntimeException: azkaban.jobExecutor.utils.process.ProcessFailureException:"
+            + " Process exited with code 1\n", result.get(1).getExceptionName());
+  }
+
+  @Test
+  public void testAzkabanExceptionLogAnalyzerWhenNoLogFound() {
+    AzkabanExceptionLogAnalyzer azkabanExceptionLogAnalyzerSpy = spy(new AzkabanExceptionLogAnalyzer(
+        TEST_FLOW_EXEC_ID1, TEST_JOB_EXEC_ID1));
+    String jobName = getJobName(TEST_JOB_EXEC_ID1);
+    when(mockWorkflowClient.getAzkabanJobLog(jobName, AZKABAN_JOB_LOG_START_OFFSET.getValue()
+        .toString(), AZKABAN_JOB_LOG_MAX_LENGTH.getValue().toString())).thenReturn("");
+    doReturn(mockWorkflowClient).when(azkabanExceptionLogAnalyzerSpy).getWorkflowClient(Mockito.any(String.class));
+    azkabanExceptionLogAnalyzerSpy.getExceptionInfoList();
+    List<ExceptionInfo> result = azkabanExceptionLogAnalyzerSpy.getExceptionInfoList();
+    Assert.assertEquals(0, result.size());
+  }
+
+  private void write(String path, String data) {
+    try {
+      FileOutputStream inputStream = new FileOutputStream(path);
+      inputStream.write(data.getBytes(), 0 , data.length());
+    } catch (IOException ex) {
+      logger.error("Exception while reading mock logs from path " + path);
+    }
+  }
+
+  private String getLog(String path) {
+    try {
+      FileInputStream inputStream = new FileInputStream(path);
+      return IOUtils.toString(inputStream);
+    } catch (IOException ex) {
+      logger.error("Exception while reading mock logs from path " + path);
+      return "";
+    }
+  }
+}

--- a/test/resources/exception/azkaban/azkabanExceptionLog_1.log.txt
+++ b/test/resources/exception/azkaban/azkabanExceptionLog_1.log.txt
@@ -1,0 +1,59 @@
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 20/04/01 21:51:15 INFO yarn.Client: Deleted staging directory hdfs://default.linkedin.com:9000
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - Exception in thread "main" java.lang.reflect.UndeclaredThrowableException
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1769)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at com.linkedin.spark.wrapper.HadoopSecureSparkWrapper.main(HadoopSecureSparkWrapper.java:114)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - Caused by: org.apache.spark.SparkException: Application application_1584565458783_12345678 finished with failed status
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.spark.deploy.yarn.Client.run(Client.scala:1160)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.spark.deploy.yarn.YarnClusterApplication.start(Client.scala:1519)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:943)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:199)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:229)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:138)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at com.linkedin.spark.wrapper.HadoopSecureSparkWrapper.runSpark(HadoopSecureSparkWrapper.java:165)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at com.linkedin.spark.wrapper.HadoopSecureSparkWrapper.access$000(HadoopSecureSparkWrapper.java:70)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at com.linkedin.spark.wrapper.HadoopSecureSparkWrapper$1.run(HadoopSecureSparkWrapper.java:118)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at com.linkedin.spark.wrapper.HadoopSecureSparkWrapper$1.run(HadoopSecureSparkWrapper.java:114)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at java.security.AccessController.doPrivileged(Native Method)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at javax.security.auth.Subject.doAs(Subject.java:422)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1754)
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 	... 1 more
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - 20/04/06 21:51:15 INFO util.ShutdownHookManager: Shutdown hook called
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - Process with id 19328 completed unsuccessfully in 76 seconds.
+01-04-2020 14:51:15 PDT overwriter-reminder2 ERROR - caught error running the job
+java.lang.RuntimeException: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
+	at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:312)
+	at azkaban.jobtype.AbstractHadoopJavaProcessJob.run(AbstractHadoopJavaProcessJob.java:50)
+	at com.linkedin.spark.HadoopSparkJob.runSparkJob(HadoopSparkJob.java:321)
+	at com.linkedin.spark.HadoopSparkJob.run(HadoopSparkJob.java:297)
+	at azkaban.execapp.JobRunner.runJob(JobRunner.java:817)
+	at azkaban.execapp.JobRunner.doRun(JobRunner.java:602)
+	at azkaban.execapp.JobRunner.run(JobRunner.java:563)
+	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+Caused by: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
+	at azkaban.jobExecutor.utils.process.AzkabanProcess.run(AzkabanProcess.java:125)
+	at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:304)
+	... 11 more
+01-04-2020 14:51:15 PDT overwriter-reminder2 ERROR - Job run failed!
+java.lang.RuntimeException: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
+	at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:312)
+	at azkaban.jobtype.AbstractHadoopJavaProcessJob.run(AbstractHadoopJavaProcessJob.java:50)
+	at com.linkedin.spark.HadoopSparkJob.runSparkJob(HadoopSparkJob.java:321)
+	at com.linkedin.spark.HadoopSparkJob.run(HadoopSparkJob.java:297)
+	at azkaban.execapp.JobRunner.runJob(JobRunner.java:817)
+	at azkaban.execapp.JobRunner.doRun(JobRunner.java:602)
+	at azkaban.execapp.JobRunner.run(JobRunner.java:563)
+	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+Caused by: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
+	at azkaban.jobExecutor.utils.process.AzkabanProcess.run(AzkabanProcess.java:125)
+	at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:304)
+	... 11 more
+01-04-2020 14:51:15 PDT overwriter-reminder2 ERROR - azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1 cause: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
+01-04-2020 14:51:15 PDT overwriter-reminder2 INFO - Finishing job overwriter-reminder2 at 1586209875715 with status FAILED


### PR DESCRIPTION
**DESCRIPTION**
This PR contains changes needed to use and analyze Azkaban logs for a failed job to get the exceptions from Scheduler. This analysis of Azkaban logs is done when none or not much information is available on the Application level. In those cases, Scheduler captures exceptions which can we of value for the users in finding out the Root Cause of job failure.

**HOW THESE CHANGES ARE TESTED**
Respective unit tests are added for the Analyzer class. Also, tested the changes on the EI machine.