### PR TITLE
Relaxing Severity Thresholds for Spark Executor GC

### DIFF
--- a/app/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristic.scala
@@ -82,7 +82,7 @@ object ExecutorGcHeuristic {
   /** The ascending severity thresholds for the ratio of JVM GC Time and executor Run Time (checking whether ratio is above normal)
     * These thresholds are experimental and are likely to change */
   val DEFAULT_GC_SEVERITY_A_THRESHOLDS =
-    SeverityThresholds(low = 0.08D, moderate = 0.09D, severe = 0.1D, critical = 0.15D, ascending = true)
+    SeverityThresholds(low = 0.08D, moderate = 0.1D, severe = 0.15D, critical = 0.2D, ascending = true)
 
   /** The descending severity thresholds for the ratio of JVM GC Time and executor Run Time (checking whether ratio is below normal)
     * These thresholds are experimental and are likely to change */

--- a/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
+++ b/test/com/linkedin/drelephant/spark/heuristics/ExecutorGcHeuristicTest.scala
@@ -90,15 +90,30 @@ class ExecutorGcHeuristicTest extends FunSpec with Matchers {
       )
     )
 
+    val executorSummaries4 = Seq(
+      newFakeExecutorSummary(
+        id = "1",
+        totalGCTime = 17000,
+        totalDuration = Duration("4min").toMillis
+      ),
+      newFakeExecutorSummary(
+        id = "2",
+        totalGCTime = 19000,
+        totalDuration = Duration("1min").toMillis
+      )
+    )
+
     describe(".apply") {
       val data = newFakeSparkApplicationData(executorSummaries)
       val data1 = newFakeSparkApplicationData(executorSummaries1)
       val data2 = newFakeSparkApplicationData(executorSummaries2)
       val data3 = newFakeSparkApplicationData(executorSummaries3)
+      val data4 = newFakeSparkApplicationData(executorSummaries4)
       val heuristicResult = executorGcHeuristic.apply(data)
       val heuristicResult1 = executorGcHeuristic.apply(data1)
       val heuristicResult2 = executorGcHeuristic.apply(data2)
       val heuristicResult3 = executorGcHeuristic.apply(data3)
+      val heuristicResult4 = executorGcHeuristic.apply(data4)
       val heuristicResultDetails = heuristicResult.getHeuristicResultDetails
       val heuristicResultDetails1 = heuristicResult1.getHeuristicResultDetails
       val heuristicResultDetails2 = heuristicResult2.getHeuristicResultDetails
@@ -127,6 +142,10 @@ class ExecutorGcHeuristicTest extends FunSpec with Matchers {
 
       it("return none severity") {
         heuristicResult3.getSeverity should be(Severity.NONE)
+      }
+
+      it("return the moderate severity") {
+        heuristicResult4.getSeverity should be(Severity.MODERATE)
       }
 
       it("returns the JVM GC time to Executor Run time duration") {


### PR DESCRIPTION
Spark Executor Memory heuristic and Executor GC Heuristic are kind of contradicting each other. 
GC ratio is the ratio of JVM GC Time and Executor Run Time. When GC ratio is high, Dr Elephant recommends to increase the executor memory. On increasing the spark.executor.memory, the executor memory threshold becomes severe. 
Hence making severity thresholds for Executor GC Heuristics less restrictive by increasing the boundaries for moderate, severe and critical values.