### PR TITLE
Support for Spark 2.2

### DIFF
--- a/app/com/linkedin/drelephant/ElephantContext.java
+++ b/app/com/linkedin/drelephant/ElephantContext.java
@@ -49,7 +49,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 import org.w3c.dom.Document;
-import play.api.templates.Html;
+import play.twirl.api.Html;
 
 
 /**

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -50,7 +50,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 
-import play.api.templates.Html;
+import play.twirl.api.Html;
 import play.data.DynamicForm;
 import play.data.Form;
 import play.libs.Json;

--- a/app/controllers/api/v1/Web.java
+++ b/app/controllers/api/v1/Web.java
@@ -222,7 +222,7 @@ public class Web extends Controller {
   private static AppResult getAppResultFromApplicationId(String applicationId) {
     AppResult result = AppResult.find.select("*").fetch(AppResult.TABLE.APP_HEURISTIC_RESULTS, "*")
         .fetch(AppResult.TABLE.APP_HEURISTIC_RESULTS + "." + AppHeuristicResult.TABLE.APP_HEURISTIC_RESULT_DETAILS, "*")
-        .where().idEq(applicationId).order().desc(AppResult.TABLE.FINISH_TIME).findUnique();
+        .where().idEq(applicationId).setMaxRows(1).order().desc(AppResult.TABLE.FINISH_TIME).findUnique();
     return result;
   }
 

--- a/app/org/apache/spark/deploy/history/SparkDataCollection.scala
+++ b/app/org/apache/spark/deploy/history/SparkDataCollection.scala
@@ -49,8 +49,8 @@ class SparkDataCollection extends SparkApplicationData {
   lazy val applicationEventListener = new ApplicationEventListener()
   lazy val jobProgressListener = new JobProgressListener(new SparkConf())
   lazy val environmentListener = new EnvironmentListener()
-  lazy val storageStatusListener = new StorageStatusListener()
-  lazy val executorsListener = new ExecutorsListener(storageStatusListener)
+  lazy val storageStatusListener = new StorageStatusListener(new SparkConf)
+  lazy val executorsListener = new ExecutorsListener(storageStatusListener, new SparkConf)
   lazy val storageListener = new StorageListener(storageStatusListener)
 
   // This is a customized listener that tracks peak used memory
@@ -164,33 +164,52 @@ class SparkDataCollection extends SparkApplicationData {
     if (_executorData == null) {
       _executorData = new SparkExecutorData()
 
-      for (statusId <- 0 until executorsListener.storageStatusList.size) {
-        val info = new ExecutorInfo()
-
-        val status = executorsListener.storageStatusList(statusId)
-
-        info.execId = status.blockManagerId.executorId
-        info.hostPort = status.blockManagerId.hostPort
-        info.rddBlocks = status.numBlocks
-
-        // Use a customized listener to fetch the peak memory used, the data contained in status are
-        // the current used memory that is not useful in offline settings.
-        info.memUsed = storageStatusTrackingListener.executorIdToMaxUsedMem.getOrElse(info.execId, 0L)
-        info.maxMem = status.maxMem
-        info.diskUsed = status.diskUsed
-        info.activeTasks = executorsListener.executorToTasksActive.getOrElse(info.execId, 0)
-        info.failedTasks = executorsListener.executorToTasksFailed.getOrElse(info.execId, 0)
-        info.completedTasks = executorsListener.executorToTasksComplete.getOrElse(info.execId, 0)
-        info.totalTasks = info.activeTasks + info.failedTasks + info.completedTasks
-        info.duration = executorsListener.executorToDuration.getOrElse(info.execId, 0L)
-        info.inputBytes = executorsListener.executorToInputBytes.getOrElse(info.execId, 0L)
-        info.shuffleRead = executorsListener.executorToShuffleRead.getOrElse(info.execId, 0L)
-        info.shuffleWrite = executorsListener.executorToShuffleWrite.getOrElse(info.execId, 0L)
-
+      for (statusId <- 0 until executorsListener.activeStorageStatusList.size) {
+        val status = executorsListener.activeStorageStatusList(statusId)
+        val info = getExecutorInfo(status)
+        _executorData.setExecutorInfo(info.execId, info)
+      }
+      for (statusId <- 0 until executorsListener.deadStorageStatusList.size) {
+        val status = executorsListener.activeStorageStatusList(statusId)
+        val info = getExecutorInfo(status)
         _executorData.setExecutorInfo(info.execId, info)
       }
     }
     _executorData
+  }
+
+  private def getExecutorInfo(status : StorageStatus): ExecutorInfo = {
+    val info = new ExecutorInfo()
+    info.execId = status.blockManagerId.executorId
+    info.hostPort = status.blockManagerId.hostPort
+    info.rddBlocks = status.numBlocks
+
+    // Use a customized listener to fetch the peak memory used, the data contained in status are
+    // the current used memory that is not useful in offline settings.
+    info.memUsed = storageStatusTrackingListener.executorIdToMaxUsedMem.getOrElse(info.execId, 0L)
+    info.maxMem = status.maxMem
+    info.diskUsed = status.diskUsed
+    val taskSummary = executorsListener.executorToTaskSummary.get(info.execId);
+
+    if (!taskSummary.isEmpty) {
+      info.activeTasks = taskSummary.get.tasksActive
+      info.failedTasks = taskSummary.get.tasksFailed
+      info.completedTasks = taskSummary.get.tasksComplete
+      info.duration = taskSummary.get.duration
+      info.inputBytes = taskSummary.get.inputBytes
+      info.shuffleRead = taskSummary.get.shuffleRead
+      info.shuffleWrite = taskSummary.get.shuffleWrite
+    } else {
+      info.activeTasks = 0
+      info.failedTasks = 0
+      info.completedTasks = 0
+      info.duration = 0
+      info.inputBytes = 0
+      info.shuffleRead = 0
+      info.shuffleWrite = 0
+    }
+    info.totalTasks = info.activeTasks + info.failedTasks + info.completedTasks
+    info
   }
 
   override def getJobProgressData(): SparkJobProgressData = {

--- a/app/org/apache/spark/storage/StorageStatusTrackingListener.scala
+++ b/app/org/apache/spark/storage/StorageStatusTrackingListener.scala
@@ -77,7 +77,7 @@ class StorageStatusTrackingListener extends SparkListener {
       val info = taskEnd.taskInfo
       val metrics = taskEnd.taskMetrics
       if (info != null && metrics != null) {
-        val updatedBlocks = metrics.updatedBlocks.getOrElse(Seq[(BlockId, BlockStatus)]())
+        val updatedBlocks = metrics.updatedBlockStatuses
         if (updatedBlocks.length > 0) {
           updateStorageStatus(info.executorId, updatedBlocks)
         }
@@ -95,8 +95,8 @@ class StorageStatusTrackingListener extends SparkListener {
     synchronized {
       val blockManagerId = blockManagerAdded.blockManagerId
       val executorId = blockManagerId.executorId
-      val maxMem = blockManagerAdded.maxMem
-      val storageStatus = new StorageStatus(blockManagerId, maxMem)
+      val storageStatus = new StorageStatus(blockManagerId, blockManagerAdded.maxMem,
+        blockManagerAdded.maxOnHeapMem, blockManagerAdded.maxOffHeapMem)
       executorIdToStorageStatus(executorId) = storageStatus
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@
 // the License.
 //
 
-import play.Project._
 import Dependencies._
 
 name := "dr-elephant"
@@ -24,9 +23,17 @@ version := "2.1.7"
 organization := "com.linkedin.drelephant"
 
 // Enable CPD SBT plugin
-lazy val root = (project in file(".")).enablePlugins(CopyPasteDetector)
+lazy val root = (project in file("."))
+  .enablePlugins(PlayJava)
+  .enablePlugins(CopyPasteDetector)
 
 javacOptions in Compile ++= Seq("-source", "1.8", "-target", "1.8")
+
+libraryDependencies ++= Seq(
+  javaJdbc,
+  javaEbean,
+  cache,
+  javaWs)
 
 libraryDependencies ++= dependencies map { _.excludeAll(exclusionRules: _*) }
 
@@ -36,8 +43,6 @@ ivyConfigurations += config("compileonly").hide
 // Append all dependencies with 'compileonly' configuration to unmanagedClasspath in Compile.
 unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compileonly"))
 
-playJavaSettings
-
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.1"
 
 envVars in Test := Map("PSO_DIR_PATH" -> (baseDirectory.value / "scripts/pso").getAbsolutePath)

--- a/compile.conf
+++ b/compile.conf
@@ -1,3 +1,3 @@
-hadoop_version=2.7.3
-spark_version=1.6.2
+hadoop_version=2.3.0
+spark_version=2.2.3
 play_opts="-Dsbt.repository.config=app-conf/resolver.conf"

--- a/compile.sh
+++ b/compile.sh
@@ -267,7 +267,7 @@ require_programs zip unzip
 
 # Default configurations
 HADOOP_VERSION="2.3.0"
-SPARK_VERSION="1.4.0"
+SPARK_VERSION="2.2.3"
 
 
 extra_commands=""

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,6 @@
 // the License.
 //
 
-import play.Project._
 import sbt._
 
 object Dependencies {
@@ -40,13 +39,13 @@ object Dependencies {
     hadoopVersion = System.getProperties.getProperty(HADOOP_VERSION)
   }
 
-  var sparkVersion = "1.4.0"
+  var sparkVersion = "2.2.3"
   if (System.getProperties.getProperty(SPARK_VERSION) != null) {
     sparkVersion = System.getProperties.getProperty(SPARK_VERSION)
   }
 
   val sparkExclusion = if (sparkVersion >= "1.5.0") {
-    "org.apache.spark" % "spark-core_2.10" % sparkVersion excludeAll(
+    "org.apache.spark" % "spark-core_2.11" % sparkVersion excludeAll(
       ExclusionRule(organization = "com.typesafe.akka"),
       ExclusionRule(organization = "org.apache.avro"),
       ExclusionRule(organization = "org.apache.hadoop"),
@@ -88,7 +87,6 @@ object Dependencies {
     "org.glassfish.jersey.test-framework" % "jersey-test-framework-core" % jerseyVersion % Test,
     "org.glassfish.jersey.test-framework.providers" % "jersey-test-framework-provider-grizzly2" % jerseyVersion % Test,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
     "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
     "io.dropwizard.metrics" % "metrics-healthchecks" % "3.1.2",
     "org.mockito" % "mockito-core" % "1.10.19" exclude ("org.hamcrest", "hamcrest-core"),
@@ -103,8 +101,7 @@ object Dependencies {
     )
   ) :+ sparkExclusion
 
-  var dependencies = Seq(javaJdbc, javaEbean, cache)
-  dependencies ++= requiredDep
+  var dependencies = requiredDep
 
   val exclusionRules = Seq(
     ExclusionRule(organization = "com.sun.jersey", name = "jersey-core"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.2.2"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.3.0"))
 
 // Jacoco code coverage plugin
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")

--- a/test/controllers/ApplicationTest.java
+++ b/test/controllers/ApplicationTest.java
@@ -21,7 +21,7 @@ import models.AppResult;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import play.api.mvc.Content;
+import play.twirl.api.Content;
 import play.test.FakeApplication;
 import play.test.Helpers;
 import views.html.page.homePage;

--- a/test/controllers/MetricsControllerTest.java
+++ b/test/controllers/MetricsControllerTest.java
@@ -22,15 +22,13 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
-import play.libs.WS;
+import play.libs.ws.WS;
+import play.libs.ws.WSResponse;
 import play.test.FakeApplication;
 
 import static common.TestConstants.*;
-import static play.test.Helpers.fakeApplication;
-import static play.test.Helpers.running;
-import static play.test.Helpers.testServer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
+import static play.test.Helpers.*;
 
 
 /**
@@ -79,7 +77,7 @@ public class MetricsControllerTest {
   }
 
   private static JsonNode getMetricsEndpointResponse() {
-    WS.Response response = WS.url(BASE_URL + METRICS_ENDPOINT).
+    WSResponse response = WS.url(BASE_URL + METRICS_ENDPOINT).
         get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
     return response.asJson();
   }

--- a/test/rest/RestAPITest.java
+++ b/test/rest/RestAPITest.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import play.Application;
 import play.GlobalSettings;
-import play.libs.WS;
+import play.libs.ws.*;
 import play.test.FakeApplication;
 
 import static common.DBTestUtil.*;
@@ -111,7 +111,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_APP_RESULT_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_APP_RESULT_PATH).
             setQueryParameter("id", TEST_JOB_ID1).setQueryParameter("prioritize", "true").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         final JsonNode jsonResponse = response.asJson();
@@ -133,7 +133,7 @@ public class RestAPITest {
         populateAutoTuningTestData1();
 
         JsonNode jsonNode = getTestGetCurrentRunParameterData();
-        final WS.Response response = WS.url(BASE_URL + REST_GET_CURRENT_RUN_PARAMETERS).
+        final WSResponse response = WS.url(BASE_URL + REST_GET_CURRENT_RUN_PARAMETERS).
             post(jsonNode).get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
 
         final JsonNode jsonResponse = response.asJson();
@@ -185,7 +185,7 @@ public class RestAPITest {
         populateAutoTuningTestData1();
 
         JsonNode jsonNode = getTestGetCurrentRunParameterNewData();
-        final WS.Response response = WS.url(BASE_URL + REST_GET_CURRENT_RUN_PARAMETERS).
+        final WSResponse response = WS.url(BASE_URL + REST_GET_CURRENT_RUN_PARAMETERS).
             post(jsonNode).get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
 
         final JsonNode jsonResponse = response.asJson();
@@ -310,7 +310,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_JOB_EXEC_RESULT_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_JOB_EXEC_RESULT_PATH).
             setQueryParameter("id", TEST_JOB_EXEC_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         final JsonNode jsonResponse = response.asJson().get(0);
@@ -337,7 +337,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_FLOW_EXEC_RESULT_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_FLOW_EXEC_RESULT_PATH).
             setQueryParameter("id", TEST_FLOW_EXEC_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         final JsonNode jsonResponse = response.asJson();
@@ -365,7 +365,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_PATH).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         List<String> jobList = response.asJson().findValuesAsText("id");
         assertTrue("Job id1 missing in list", jobList.contains(TEST_JOB_ID1));
@@ -393,7 +393,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_PATH).
             setQueryParameter("username", TEST_USERNAME).
             setQueryParameter("", TEST_JOB_TYPE).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
@@ -421,7 +421,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_COMPARE_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_COMPARE_PATH).
             setQueryParameter("flow-exec-id1", TEST_FLOW_EXEC_ID1).
             setQueryParameter("flow-exec-id2", TEST_FLOW_EXEC_ID2).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
@@ -445,7 +445,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_FLOW_GRAPH_DATA_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_FLOW_GRAPH_DATA_PATH).
             setQueryParameter("id", TEST_FLOW_DEF_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         List<String> jobList = response.asJson().findValuesAsText("jobexecurl");
@@ -470,7 +470,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_JOB_GRAPH_DATA_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_JOB_GRAPH_DATA_PATH).
             setQueryParameter("id", TEST_JOB_DEF_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         List<String> jobList = response.asJson().findValuesAsText("stageid");
@@ -489,7 +489,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_JOB_METRICS_GRAPH_DATA_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_JOB_METRICS_GRAPH_DATA_PATH).
             setQueryParameter("id", TEST_JOB_DEF_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         List<String> jobList = response.asJson().findValuesAsText("stageid");
@@ -509,7 +509,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_FLOW_METRICS_GRAPH_DATA_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_FLOW_METRICS_GRAPH_DATA_PATH).
             setQueryParameter("id", TEST_FLOW_DEF_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         List<String> jobList = response.asJson().findValuesAsText("jobexecurl");
@@ -524,7 +524,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_USER_RESOURCE_USAGE_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_USER_RESOURCE_USAGE_PATH).
             setQueryParameter("startTime", TEST_START_TIME1).
             setQueryParameter("endTime", TEST_END_TIME1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
@@ -554,7 +554,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_USER_RESOURCE_USAGE_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_USER_RESOURCE_USAGE_PATH).
             setQueryParameter("startTime", TEST_START_TIME1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         assertTrue("Invalid input test failed", response.getStatus() == 400);
@@ -567,7 +567,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_WORKFLOW_SUMMARIES_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_WORKFLOW_SUMMARIES_PATH).
             setQueryParameter("username", TEST_USERNAME).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> workflowSummaries = response.asJson().elements();
@@ -602,7 +602,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_JOB_SUMMARIES_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_JOB_SUMMARIES_PATH).
             setQueryParameter("username", TEST_USERNAME).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> jobSummaries = response.asJson().elements();
@@ -639,7 +639,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_APPLICATION_SUMMARIES_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_APPLICATION_SUMMARIES_PATH).
             setQueryParameter("username", TEST_USERNAME).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
 
@@ -691,7 +691,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_WORKFLOWS_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_WORKFLOWS_PATH).
             setQueryParameter("workflowid", TEST_FLOW_EXEC_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> workflows = response.asJson().elements();
@@ -715,7 +715,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_WORKFLOWS_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_WORKFLOWS_PATH).
             setQueryParameter("workflowid", "this_is_a_random_id").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         JsonNode workflows = response.asJson();
@@ -736,7 +736,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_JOBS_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_JOBS_PATH).
             setQueryParameter("jobid", TEST_JOB_EXEC_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> jobs = response.asJson().elements();
@@ -760,7 +760,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_JOBS_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_JOBS_PATH).
             setQueryParameter("jobid", "this_is_a_random_job_id").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         JsonNode jobs = response.asJson();
@@ -781,7 +781,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_APPLICATIONS_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_APPLICATIONS_PATH).
             setQueryParameter("applicationid", TEST_JOB_ID1).
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> applications = response.asJson().elements();
@@ -807,7 +807,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_APPLICATIONS_PATH).
+        final WSResponse response = WS.url(BASE_URL + REST_APPLICATIONS_PATH).
             setQueryParameter("applicationid", "random_id").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         JsonNode applications = response.asJson();
@@ -828,7 +828,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("queue-name", "misc_default").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> searchNode = response.asJson().elements();
@@ -842,7 +842,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("job-type", "HadoopJava").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> searchNode = response.asJson().elements();
@@ -856,7 +856,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS)
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS)
             .
                 setQueryParameter("username", "growth")
             .setQueryParameter("finishTimeBegin", "1460980723925")
@@ -875,7 +875,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("offset", "-1").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> searchNode = response.asJson().elements();
@@ -889,7 +889,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("limit", "-1").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         JsonNode searchNode = response.asJson();
@@ -903,7 +903,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("offset", "0").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> searchNode = response.asJson().elements();
@@ -917,7 +917,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("limit", "0").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         JsonNode searchNode = response.asJson();
@@ -931,7 +931,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("limit", "1000").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> searchNode = response.asJson().elements();
@@ -945,7 +945,7 @@ public class RestAPITest {
     running(testServer(TEST_SERVER_PORT, fakeApp), new Runnable() {
       public void run() {
         populateTestData();
-        final WS.Response response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
+        final WSResponse response = WS.url(BASE_URL + REST_SEARCH_RESULTS).
             setQueryParameter("username", "growth").setQueryParameter("offset", "100").
             get().get(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
         Iterator<JsonNode> searchNode = response.asJson().elements();


### PR DESCRIPTION
**DESCRIPTION**
This PR contains changes done for supporting Spark version 2.2.3 for processing eventLogs, alongside these some changes are done for migrating this product from Play version 2.2 to 2.3 following instructions provided [here](https://www.playframework.com/documentation/2.8.x/Migration23). 

**HOW THESE CHANGES ARE TESTED**
Tested the changes in EI machine.